### PR TITLE
#90: volunteer contact details container

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-icons": "^5.5.0",
     "react-toastify": "^11.0.5",
     "styled-components": "^6.1.19",
+    "ts-type-safe": "^1.5.0",
     "zod": "^4.1.13"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "classnames": "^2.5.1",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "^0.0.19",
+    "need4deed-sdk": "^0.0.23",
     "next": "15.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@phosphor-icons/react": "^2.1.10",
     "@tanstack/react-form": "^0.26.4",
     "@tanstack/react-query": "^5.80.7",
@@ -22,10 +23,12 @@
     "next": "15.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.68.0",
     "react-i18next": "^15.6.1",
     "react-icons": "^5.5.0",
     "react-toastify": "^11.0.5",
-    "styled-components": "^6.1.19"
+    "styled-components": "^6.1.19",
+    "zod": "^4.1.13"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "classnames": "^2.5.1",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "^0.0.23",
+    "need4deed-sdk": "^0.0.24",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -495,7 +495,15 @@
         "notProvided": "Nicht angegeben",
         "cancel": "Abbrechen",
         "saveChanges": "Änderungen speichern",
-        "saveSuccess": "Kontaktdaten erfolgreich aktualisiert"
+        "saveSuccess": "Kontaktdaten erfolgreich aktualisiert",
+        "validation": {
+          "phoneRequired": "Telefonnummer ist erforderlich",
+          "phoneInvalid": "Bitte geben Sie eine gültige Telefonnummer ein",
+          "emailRequired": "E-Mail ist erforderlich",
+          "emailInvalid": "Bitte geben Sie eine gültige E-Mail-Adresse ein",
+          "addressRequired": "Adresse ist erforderlich",
+          "waysToContactRequired": "Bitte wählen Sie mindestens eine Kontaktmöglichkeit aus"
+        }
       }
     },
     "message": {

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -491,7 +491,14 @@
         "phoneNumber": "Telefonnummer",
         "email": "E-Mail",
         "address": "Adresse",
-        "waysToContact": "Kontaktmöglichkeiten",
+        "waysToContact": {
+          "label": "Kontaktmöglichkeiten",
+          "whatsapp": "WhatsApp",
+          "telegram": "Telegram",
+          "mobilePhone": "Mobiltelefon",
+          "email": "E-Mail",
+          "sms": "SMS"
+        },
         "notProvided": "Nicht angegeben",
         "cancel": "Abbrechen",
         "saveChanges": "Änderungen speichern",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -492,7 +492,10 @@
         "email": "E-Mail",
         "address": "Adresse",
         "waysToContact": "Kontaktmöglichkeiten",
-        "notProvided": "Nicht angegeben"
+        "notProvided": "Nicht angegeben",
+        "cancel": "Abbrechen",
+        "saveChanges": "Änderungen speichern",
+        "saveSuccess": "Kontaktdaten erfolgreich aktualisiert"
       }
     },
     "message": {

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -488,7 +488,7 @@
       "contactDetails": {
         "title": "Kontaktdaten",
         "edit": "Bearbeiten",
-        "phoneNumber": "Telefonnummer",
+        "phone": "Telefonnummer",
         "email": "E-Mail",
         "address": "Adresse",
         "preferredCommunicationType": {

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -496,8 +496,7 @@
           "whatsapp": "WhatsApp",
           "telegram": "Telegram",
           "mobilePhone": "Mobiltelefon",
-          "email": "E-Mail",
-          "sms": "SMS"
+          "email": "E-Mail"
         },
         "notProvided": "Nicht angegeben",
         "cancel": "Abbrechen",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -498,7 +498,7 @@
         "saveSuccess": "Kontaktdaten erfolgreich aktualisiert",
         "validation": {
           "phoneRequired": "Telefonnummer ist erforderlich",
-          "phoneInvalid": "Bitte geben Sie eine gültige Telefonnummer ein",
+          "phoneInvalid": "Telefonnummer muss mit + beginnen und nur Ziffern enthalten (keine Leerzeichen)",
           "emailRequired": "E-Mail ist erforderlich",
           "emailInvalid": "Bitte geben Sie eine gültige E-Mail-Adresse ein",
           "addressRequired": "Adresse ist erforderlich",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -484,6 +484,15 @@
           "uploaded": "Hochgeladen",
           "missing": "Fehlend"
         }
+      },
+      "contactDetails": {
+        "title": "Kontaktdaten",
+        "edit": "Bearbeiten",
+        "phoneNumber": "Telefonnummer",
+        "email": "E-Mail",
+        "address": "Adresse",
+        "waysToContact": "Kontaktmöglichkeiten",
+        "notProvided": "Nicht angegeben"
       }
     },
     "message": {

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -491,7 +491,7 @@
         "phoneNumber": "Telefonnummer",
         "email": "E-Mail",
         "address": "Adresse",
-        "waysToContact": {
+        "preferredCommunicationType": {
           "label": "Kontaktmöglichkeiten",
           "whatsapp": "WhatsApp",
           "telegram": "Telegram",
@@ -508,7 +508,7 @@
           "emailRequired": "E-Mail ist erforderlich",
           "emailInvalid": "Bitte geben Sie eine gültige E-Mail-Adresse ein",
           "addressRequired": "Adresse ist erforderlich",
-          "waysToContactRequired": "Bitte wählen Sie mindestens eine Kontaktmöglichkeit aus"
+          "preferredCommunicationTypeRequired": "Bitte wählen Sie mindestens eine Kontaktmöglichkeit aus"
         }
       }
     },

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -491,7 +491,7 @@
         "phoneNumber": "Phone number",
         "email": "Email",
         "address": "Address",
-        "waysToContact": {
+        "preferredCommunicationType": {
           "label": "Ways to contact",
           "whatsapp": "WhatsApp",
           "telegram": "Telegram",
@@ -508,7 +508,7 @@
           "emailRequired": "Email is required",
           "emailInvalid": "Please enter a valid email address",
           "addressRequired": "Address is required",
-          "waysToContactRequired": "Please select at least one way to contact"
+          "preferredCommunicationTypeRequired": "Please select at least one way to contact"
         }
       }
     }

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -496,8 +496,7 @@
           "whatsapp": "WhatsApp",
           "telegram": "Telegram",
           "mobilePhone": "Mobile Phone",
-          "email": "Email",
-          "sms": "SMS"
+          "email": "Email"
         },
         "notProvided": "Not provided",
         "cancel": "Cancel",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -498,7 +498,7 @@
         "saveSuccess": "Contact details updated successfully",
         "validation": {
           "phoneRequired": "Phone number is required",
-          "phoneInvalid": "Please enter a valid phone number",
+          "phoneInvalid": "Phone number must start with + and contain only digits (no spaces)",
           "emailRequired": "Email is required",
           "emailInvalid": "Please enter a valid email address",
           "addressRequired": "Address is required",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -492,7 +492,10 @@
         "email": "Email",
         "address": "Address",
         "waysToContact": "Ways to contact",
-        "notProvided": "Not provided"
+        "notProvided": "Not provided",
+        "cancel": "Cancel",
+        "saveChanges": "Save changes",
+        "saveSuccess": "Contact details updated successfully"
       }
     }
   },

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -488,7 +488,7 @@
       "contactDetails": {
         "title": "Contact details",
         "edit": "Edit",
-        "phoneNumber": "Phone number",
+        "phone": "Phone number",
         "email": "Email",
         "address": "Address",
         "preferredCommunicationType": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -495,7 +495,15 @@
         "notProvided": "Not provided",
         "cancel": "Cancel",
         "saveChanges": "Save changes",
-        "saveSuccess": "Contact details updated successfully"
+        "saveSuccess": "Contact details updated successfully",
+        "validation": {
+          "phoneRequired": "Phone number is required",
+          "phoneInvalid": "Please enter a valid phone number",
+          "emailRequired": "Email is required",
+          "emailInvalid": "Please enter a valid email address",
+          "addressRequired": "Address is required",
+          "waysToContactRequired": "Please select at least one way to contact"
+        }
       }
     }
   },

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -491,7 +491,14 @@
         "phoneNumber": "Phone number",
         "email": "Email",
         "address": "Address",
-        "waysToContact": "Ways to contact",
+        "waysToContact": {
+          "label": "Ways to contact",
+          "whatsapp": "WhatsApp",
+          "telegram": "Telegram",
+          "mobilePhone": "Mobile Phone",
+          "email": "Email",
+          "sms": "SMS"
+        },
         "notProvided": "Not provided",
         "cancel": "Cancel",
         "saveChanges": "Save changes",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -484,6 +484,15 @@
           "uploaded": "Uploaded",
           "missing": "Missing"
         }
+      },
+      "contactDetails": {
+        "title": "Contact details",
+        "edit": "Edit",
+        "phoneNumber": "Phone number",
+        "email": "Email",
+        "address": "Address",
+        "waysToContact": "Ways to contact",
+        "notProvided": "Not provided"
       }
     }
   },

--- a/src/app/[lang]/globals.css
+++ b/src/app/[lang]/globals.css
@@ -1108,14 +1108,16 @@ html {
 
 :root {
   --editableField-fieldWrapper-display: flex;
-  --editableField-fieldWrapper-borderBottom: 1px solid var(--color-blue-50);
-  --editableField-fieldWrapper-padding: 1rem;
+  --editableField-fieldWrapper-borderBottom: none;
+  --editableField-fieldWrapper-padding: 1rem 0;
   --editableField-fieldWrapper-fontSize: 20px;
   --editableField-fieldWrapper-width: 100%;
   --editableField-fieldWrapper-alignItems: center;
+  --editableField-fieldWrapper-gap: 32px;
   --editableField-fieldWrapper-label-fontWeight: bold;
-  --editableField-fieldWrapper-label-fontSize: 24px;
-  --editableField-fieldWrapper-label-width: 10rem;
+  --editableField-fieldWrapper-label-fontSize: 20px;
+  --editableField-fieldWrapper-label-width: 220px;
+  --editableField-fieldWrapper-label-flexShrink: 0;
   --editableField-fieldWrapper-input-borderRadius: 8px;
   --editableField-fieldWrapper-input-width: 100%;
   --editableField-fieldWrapper-input-padding: 16px;
@@ -1155,6 +1157,6 @@ html {
   --editableField-text-whiteSpace: normal;
   --editableField-text-overflow: break-word;
   --editableField-text-wordBreak: break-word;
-  
+
 
 }

--- a/src/components/Dashboard/Profile/ProfileController.tsx
+++ b/src/components/Dashboard/Profile/ProfileController.tsx
@@ -5,7 +5,7 @@ import ProfilePage from "./ProfilePage";
 
 export function ProfileController({ volunteerId }: { volunteerId: string }) {
   const { data } = useGetQuery<ApiVolunteerGet>({
-    queryKey: ["volunteers", volunteerId],
+    queryKey: ["volunteer", volunteerId],
     apiPath: `${apiPathVolunteer}${volunteerId}`,
     staleTime: cacheTTL,
   });

--- a/src/components/Dashboard/Profile/ProfilePage.tsx
+++ b/src/components/Dashboard/Profile/ProfilePage.tsx
@@ -7,6 +7,7 @@ import { ApiVolunteerGet } from "need4deed-sdk";
 // import { PROFILE_CARD_CONFIG } from "./config/ProfileSectionConfig";
 import { useTranslation } from "react-i18next";
 import { VolunteerHeader } from "./sections/VolunteerHeader";
+import { ContactDetails } from "./sections/ContactDetails";
 
 const PageContainer = styled.div`
   max-width: 1200px;
@@ -78,6 +79,8 @@ const ProfilePage = ({ volunteer }: ProfilePageProps) => {
       <Card>
         <VolunteerHeader volunteer={volunteer} />
       </Card>
+
+      <ContactDetails volunteer={volunteer} />
     </PageContainer>
   );
 };

--- a/src/components/Dashboard/Profile/common/statusMaps.ts
+++ b/src/components/Dashboard/Profile/common/statusMaps.ts
@@ -1,3 +1,4 @@
+import type React from "react";
 import {
   CalendarBlank,
   CalendarX,
@@ -46,10 +47,8 @@ export const statusColorMap = {
   [VolunteerStateMatchType.MATCHED]: "var(--color-green-100)",
   [VolunteerStateMatchType.NEEDS_REMATCH]: "var(--color-yellow-500)",
   [VolunteerStateTypeType.ACCOMPANYING]: "var(--color-grey-50)",
-  [VolunteerStateTypeType.EVENT]: "var(--color-pink-50)",
+  [VolunteerStateTypeType.EVENTS]: "var(--color-pink-50)",
   [VolunteerStateTypeType.REGULAR]: "var(--color-grey-50)",
-  [VolunteerStateTypeType.FESTIVAL]: "var(--color-grey-50)",
-  [VolunteerStateTypeType.WEEKEND_ONLY]: "var(--color-grey-50)",
 } as const satisfies Record<string, string>;
 
 export const statusIconMap = {
@@ -66,15 +65,13 @@ export const statusIconMap = {
   [VolunteerStateEngagementType.AVAILABLE]: CalendarBlank,
   [VolunteerStateEngagementType.TEMP_UNAVAILABLE]: CalendarX,
   [VolunteerStateEngagementType.UNRESPONSIVE]: PhoneX,
-  [VolunteerStateTypeType.ACCOMPANYING]: Users,
   [VolunteerStateEngagementType.INACTIVE]: StopCircle,
   [VolunteerStateEngagementType.NEW]: StopCircle,
   [VolunteerStateMatchType.NO_MATCHES]: StopCircle,
   [VolunteerStateMatchType.PENDING_MATCH]: StopCircle,
   [VolunteerStateMatchType.MATCHED]: StopCircle,
   [VolunteerStateMatchType.NEEDS_REMATCH]: StopCircle,
+  [VolunteerStateTypeType.ACCOMPANYING]: Users,
   [VolunteerStateTypeType.REGULAR]: Users,
-  [VolunteerStateTypeType.EVENT]: Users,
-  [VolunteerStateTypeType.FESTIVAL]: Users,
-  [VolunteerStateTypeType.WEEKEND_ONLY]: Users,
+  [VolunteerStateTypeType.EVENTS]: Users,
 } as const satisfies Record<string, React.ComponentType<{ size?: number; color?: string }>>;

--- a/src/components/Dashboard/Profile/sections/ContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails.tsx
@@ -71,6 +71,16 @@ const formatAddress = (address: ApiVolunteerGet["person"]["address"]) => {
   return parts.join(", ");
 };
 
+const parseAddress = (addressString: string) => {
+  // Address format: "street, city, postcode"
+  const parts = addressString.split(",").map((part) => part.trim());
+  return {
+    street: parts[0] || "",
+    city: parts[1] || "",
+    postcode: parts[2] || "",
+  };
+};
+
 interface Props {
   volunteer: ApiVolunteerGet;
 }
@@ -116,16 +126,6 @@ export function ContactDetails({ volunteer }: Props) {
   const handleCancel = () => {
     reset();
     setIsEditing(false);
-  };
-
-  const parseAddress = (addressString: string) => {
-    // Address format: "street, city, postcode"
-    const parts = addressString.split(",").map((part) => part.trim());
-    return {
-      street: parts[0] || "",
-      city: parts[1] || "",
-      postcode: parts[2] || "",
-    };
   };
 
   const onSubmit = (data: ContactDetailsFormData) => {

--- a/src/components/Dashboard/Profile/sections/ContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails.tsx
@@ -2,13 +2,12 @@
 import Button from "@/components/core/button/Button/Button";
 import { EditableField } from "@/components/EditableField/EditableField";
 import { Heading2 } from "@/components/styled/text";
+import { useUpdateVolunteerContact } from "@/hooks/useUpdateVolunteerContact";
 import { ChatsCircle } from "@phosphor-icons/react";
 import { ApiVolunteerGet } from "need4deed-sdk";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
-import { useMutationQuery } from "@/hooks";
-import { apiPathVolunteer } from "@/config/constants";
 
 const Container = styled.div<{ $isEditing: boolean }>`
   display: flex;
@@ -60,29 +59,13 @@ const ButtonRow = styled.div`
   width: 100%;
 `;
 
-type UpdateVolunteerContactData = {
-  person: {
-    id: number;
-    phone?: string;
-    email?: string;
-    address?: {
-      id: string | number;
-      street?: string;
-      city?: string;
-      postcode?: {
-        code?: string;
-      };
-    };
-  };
-};
-
-const useUpdateVolunteerContact = (volunteerId: number) => {
-  return useMutationQuery<UpdateVolunteerContactData, ApiVolunteerGet>({
-    apiPath: `${apiPathVolunteer}${volunteerId}`,
-    method: "patch",
-    successMessage: "dashboard.volunteerProfile.contactDetails.saveSuccess",
-    queryKeyToInvalidate: ["volunteer", volunteerId],
-  });
+const formatAddress = (address: ApiVolunteerGet["person"]["address"]) => {
+  if (!address || typeof address !== "object") {
+    return "";
+  }
+  const postcode = address.postcode && typeof address.postcode === "object" ? address.postcode.code : address.postcode;
+  const parts = [address.street, address.city, postcode].filter(Boolean);
+  return parts.join(", ");
 };
 
 interface Props {
@@ -94,26 +77,16 @@ export function ContactDetails({ volunteer }: Props) {
   const [isEditing, setIsEditing] = useState(false);
   const { mutate: updateContact, isPending } = useUpdateVolunteerContact(volunteer.id);
 
-  const formatAddress = () => {
-    const addr = volunteer.person.address;
-    if (!addr || typeof addr !== "object") {
-      return "";
-    }
-    const postcode = addr.postcode && typeof addr.postcode === "object" ? addr.postcode.code : addr.postcode;
-    const parts = [addr.street, addr.city, postcode].filter(Boolean);
-    return parts.join(", ");
-  };
-
   const [phoneNumber, setPhoneNumber] = useState(volunteer.person.phone || "");
   const [email, setEmail] = useState(volunteer.person.email || "");
-  const [address, setAddress] = useState(formatAddress());
+  const [address, setAddress] = useState(formatAddress(volunteer.person.address));
   const [waysToContact, setWaysToContact] = useState<string[]>(["Whatsapp", "Telegram", "Mobile phone"]);
 
   // Sync local state when volunteer data changes (after refetch)
   useEffect(() => {
     setPhoneNumber(volunteer.person.phone || "");
     setEmail(volunteer.person.email || "");
-    setAddress(formatAddress());
+    setAddress(formatAddress(volunteer.person.address));
   }, [volunteer]);
 
   const handleEditClick = () => {
@@ -123,7 +96,7 @@ export function ContactDetails({ volunteer }: Props) {
   const handleCancel = () => {
     setPhoneNumber(volunteer.person.phone || "");
     setEmail(volunteer.person.email || "");
-    setAddress(formatAddress());
+    setAddress(formatAddress(volunteer.person.address));
     setWaysToContact(["Whatsapp", "Telegram", "Mobile phone"]);
     setIsEditing(false);
   };
@@ -161,7 +134,7 @@ export function ContactDetails({ volunteer }: Props) {
         onSuccess: () => {
           setIsEditing(false);
         },
-      }
+      },
     );
   };
 

--- a/src/components/Dashboard/Profile/sections/ContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails.tsx
@@ -1,0 +1,182 @@
+"use client";
+import Button from "@/components/core/button/Button/Button";
+import { Heading2, Heading4, Paragraph } from "@/components/styled/text";
+import { ChatsCircle } from "@phosphor-icons/react";
+import { ApiVolunteerGet } from "need4deed-sdk";
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  gap: 8px;
+  background: var(--color-white);
+  border-radius: 24px;
+`;
+
+const Header = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 24px;
+`;
+
+const HeaderRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 24px;
+  width: 100%;
+`;
+
+const HeaderContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 24px;
+  flex: 1;
+`;
+
+const TitleRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 16px;
+`;
+
+const IconContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 40px;
+  height: 40px;
+  color: var(--color-papaya);
+`;
+
+const Details = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+`;
+
+const DetailRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  padding: 24px 0;
+  gap: 32px;
+  width: 100%;
+  border-bottom: 1px solid #ebedf7;
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const Label = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  width: 276px;
+`;
+
+const Value = styled.div`
+  display: flex;
+  align-items: center;
+  flex: 1;
+`;
+
+interface Props {
+  volunteer: ApiVolunteerGet;
+}
+
+export function ContactDetails({ volunteer }: Props) {
+  const { t } = useTranslation();
+
+  const handleEditClick = () => {
+    // TODO: Implement edit functionality
+  };
+
+  const phoneNumber = volunteer.person.phone || t("dashboard.volunteerProfile.contactDetails.notProvided");
+  const email = volunteer.person.email || t("dashboard.volunteerProfile.contactDetails.notProvided");
+
+  const formatAddress = () => {
+    const addr = volunteer.person.address;
+    if (!addr || typeof addr !== "object") {
+      return t("dashboard.volunteerProfile.contactDetails.notProvided");
+    }
+    const postcode = addr.postcode && typeof addr.postcode === "object" ? addr.postcode.code : addr.postcode;
+    const parts = [addr.street, addr.city, postcode].filter(Boolean);
+    return parts.length > 0 ? parts.join(", ") : t("dashboard.volunteerProfile.contactDetails.notProvided");
+  };
+
+  const address = formatAddress();
+
+  // TODO: Get this from volunteer data when available
+  const waysToContact = "Whatsapp, Telegram, mobile phone";
+
+  return (
+    <Container data-testid="contact-details-container">
+      <Header>
+        <HeaderRow>
+          <HeaderContent>
+            <TitleRow>
+              <IconContainer>
+                <ChatsCircle size={40} weight="fill" />
+              </IconContainer>
+              <Heading2>{t("dashboard.volunteerProfile.contactDetails.title")}</Heading2>
+            </TitleRow>
+          </HeaderContent>
+          <Button
+            text={t("dashboard.volunteerProfile.contactDetails.edit")}
+            onClick={handleEditClick}
+            width="auto"
+            padding="16px 24px"
+          />
+        </HeaderRow>
+      </Header>
+
+      <Details>
+        <DetailRow>
+          <Label>
+            <Heading4>{t("dashboard.volunteerProfile.contactDetails.phoneNumber")}</Heading4>
+          </Label>
+          <Value>
+            <Paragraph>{phoneNumber}</Paragraph>
+          </Value>
+        </DetailRow>
+
+        <DetailRow>
+          <Label>
+            <Heading4>{t("dashboard.volunteerProfile.contactDetails.email")}</Heading4>
+          </Label>
+          <Value>
+            <Paragraph>{email}</Paragraph>
+          </Value>
+        </DetailRow>
+
+        <DetailRow>
+          <Label>
+            <Heading4>{t("dashboard.volunteerProfile.contactDetails.address")}</Heading4>
+          </Label>
+          <Value>
+            <Paragraph>{address}</Paragraph>
+          </Value>
+        </DetailRow>
+
+        <DetailRow>
+          <Label>
+            <Heading4>{t("dashboard.volunteerProfile.contactDetails.waysToContact")}</Heading4>
+          </Label>
+          <Value>
+            <Paragraph>{waysToContact}</Paragraph>
+          </Value>
+        </DetailRow>
+      </Details>
+    </Container>
+  );
+}

--- a/src/components/Dashboard/Profile/sections/ContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails.tsx
@@ -5,8 +5,8 @@ import { Heading2 } from "@/components/styled/text";
 import { useUpdateVolunteerContact } from "@/hooks/useUpdateVolunteerContact";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ChatsCircle } from "@phosphor-icons/react";
-import { ApiVolunteerGet } from "need4deed-sdk";
-import { useEffect, useState } from "react";
+import { ApiVolunteerGet, VolunteerCommunicationType } from "need4deed-sdk";
+import { useMemo, useState } from "react";
 import { Controller, ControllerRenderProps, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
@@ -85,8 +85,7 @@ interface Props {
   volunteer: ApiVolunteerGet;
 }
 
-// TODO: use enum-values from backend / sdk when available
-const waysToContactKeys = ["whatsapp", "telegram", "mobilePhone", "email", "sms"];
+const waysToContactKeys = Object.values(VolunteerCommunicationType);
 
 export function ContactDetails({ volunteer }: Props) {
   const { t } = useTranslation();
@@ -115,25 +114,17 @@ export function ContactDetails({ volunteer }: Props) {
   } = useForm<ContactDetailsFormData>({
     resolver: zodResolver(schema),
     mode: "onChange",
-    defaultValues: {
-      phoneNumber: volunteer.person.phone || "",
-      email: volunteer.person.email || "",
-      address: formatAddress(volunteer.person.address),
-      waysToContact: ["whatsapp"],
-    },
+    defaultValues: useMemo(
+      () => ({
+        phoneNumber: volunteer.person.phone || "",
+        email: volunteer.person.email || "",
+        address: formatAddress(volunteer.person.address),
+        // TODO: Load actual waysToContact from volunteer data when available
+        waysToContact: [],
+      }),
+      [volunteer],
+    ),
   });
-
-  // Sync form when volunteer data changes (after refetch)
-  useEffect(() => {
-    reset({
-      phoneNumber: volunteer.person.phone || "",
-      email: volunteer.person.email || "",
-      address: formatAddress(volunteer.person.address),
-      // TODO: Load actual waysToContact from volunteer data when available
-      waysToContact: ["whatsapp"],
-    });
-    setIsEditing(false);
-  }, [volunteer, reset]);
 
   const handleEditClick = () => {
     setIsEditing(true);
@@ -144,15 +135,15 @@ export function ContactDetails({ volunteer }: Props) {
     setIsEditing(false);
   };
 
-  const onSubmit = (data: ContactDetailsFormData) => {
-    const addressData = parseAddress(data.address);
+  const onSubmit = (values: ContactDetailsFormData) => {
+    const addressData = parseAddress(values.address);
 
     updateContact(
       {
         person: {
           id: volunteer.person.id,
-          phone: data.phoneNumber,
-          email: data.email,
+          phone: values.phoneNumber,
+          email: values.email,
           address: {
             id: volunteer.person.address?.id,
             street: addressData.street,
@@ -162,11 +153,11 @@ export function ContactDetails({ volunteer }: Props) {
             },
           },
         },
-        waysToContact: data.waysToContact,
+        waysToContact: values.waysToContact,
       },
       {
         onSuccess: () => {
-          reset(data);
+          reset(values);
           setIsEditing(false);
         },
       },

--- a/src/components/Dashboard/Profile/sections/ContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails.tsx
@@ -6,7 +6,7 @@ import { useUpdateVolunteerContact } from "@/hooks/useUpdateVolunteerContact";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ChatsCircle } from "@phosphor-icons/react";
 import { ApiVolunteerGet, VolunteerCommunicationType } from "need4deed-sdk";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Controller, ControllerRenderProps, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
@@ -89,7 +89,7 @@ const waysToContactKeys = Object.values(VolunteerCommunicationType);
 
 export function ContactDetails({ volunteer }: Props) {
   const { t } = useTranslation();
-  const { mutate: updateContact, isPending } = useUpdateVolunteerContact(volunteer.id);
+  const { mutate: updateContact, isPending } = useUpdateVolunteerContact(String(volunteer.id));
   const [isEditing, setIsEditing] = useState(false);
 
   const waysToContactOptions = waysToContactKeys.map((key) =>
@@ -106,6 +106,17 @@ export function ContactDetails({ volunteer }: Props) {
 
   const schema = createContactDetailsSchema(t);
 
+  const initialFormValues = useMemo(
+    () => ({
+      phoneNumber: volunteer.person.phone || "",
+      email: volunteer.person.email || "",
+      address: formatAddress(volunteer.person.address),
+      // TODO: Load actual waysToContact from volunteer data when available
+      waysToContact: [],
+    }),
+    [volunteer],
+  );
+
   const {
     control,
     handleSubmit,
@@ -114,16 +125,7 @@ export function ContactDetails({ volunteer }: Props) {
   } = useForm<ContactDetailsFormData>({
     resolver: zodResolver(schema),
     mode: "onChange",
-    defaultValues: useMemo(
-      () => ({
-        phoneNumber: volunteer.person.phone || "",
-        email: volunteer.person.email || "",
-        address: formatAddress(volunteer.person.address),
-        // TODO: Load actual waysToContact from volunteer data when available
-        waysToContact: [],
-      }),
-      [volunteer],
-    ),
+    defaultValues: initialFormValues,
   });
 
   const handleEditClick = () => {
@@ -157,12 +159,18 @@ export function ContactDetails({ volunteer }: Props) {
       },
       {
         onSuccess: () => {
-          reset(values);
           setIsEditing(false);
         },
       },
     );
   };
+
+  // Reset form when volunteer data changes (after successful mutation & refetch)
+  useEffect(() => {
+    if (!isEditing) {
+      reset(initialFormValues);
+    }
+  }, [initialFormValues, isEditing, reset]);
 
   return (
     <Container data-testid="contact-details-container" $isEditing={isEditing}>

--- a/src/components/Dashboard/Profile/sections/ContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails.tsx
@@ -62,18 +62,6 @@ const ButtonRow = styled.div`
   width: 100%;
 `;
 
-const ErrorMessage = styled.p`
-  color: var(--color-red-600);
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 20px;
-  margin-top: 8px;
-  margin-left: 252px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-`;
-
 const formatAddress = (address: ApiVolunteerGet["person"]["address"]) => {
   if (!address || typeof address !== "object") {
     return "";
@@ -192,17 +180,15 @@ export function ContactDetails({ volunteer }: Props) {
           name="phoneNumber"
           control={control}
           render={({ field }: { field: ControllerRenderProps<ContactDetailsFormData, "phoneNumber"> }) => (
-            <>
-              <EditableField
-                mode={isEditing ? "edit" : "display"}
-                type="text"
-                label={t("dashboard.volunteerProfile.contactDetails.phoneNumber")}
-                value={field.value}
-                setValue={field.onChange}
-                hasError={!!errors.phoneNumber}
-              />
-              {errors.phoneNumber && <ErrorMessage>{errors.phoneNumber.message}</ErrorMessage>}
-            </>
+            <EditableField
+              mode={isEditing ? "edit" : "display"}
+              type="text"
+              label={t("dashboard.volunteerProfile.contactDetails.phoneNumber")}
+              value={field.value}
+              setValue={field.onChange}
+              hasError={!!errors.phoneNumber}
+              errorMessage={errors.phoneNumber?.message}
+            />
           )}
         />
 
@@ -210,17 +196,15 @@ export function ContactDetails({ volunteer }: Props) {
           name="email"
           control={control}
           render={({ field }: { field: ControllerRenderProps<ContactDetailsFormData, "email"> }) => (
-            <>
-              <EditableField
-                mode={isEditing ? "edit" : "display"}
-                type="text"
-                label={t("dashboard.volunteerProfile.contactDetails.email")}
-                value={field.value}
-                setValue={field.onChange}
-                hasError={!!errors.email}
-              />
-              {errors.email && <ErrorMessage>{errors.email.message}</ErrorMessage>}
-            </>
+            <EditableField
+              mode={isEditing ? "edit" : "display"}
+              type="text"
+              label={t("dashboard.volunteerProfile.contactDetails.email")}
+              value={field.value}
+              setValue={field.onChange}
+              hasError={!!errors.email}
+              errorMessage={errors.email?.message}
+            />
           )}
         />
 
@@ -228,17 +212,15 @@ export function ContactDetails({ volunteer }: Props) {
           name="address"
           control={control}
           render={({ field }: { field: ControllerRenderProps<ContactDetailsFormData, "address"> }) => (
-            <>
-              <EditableField
-                mode={isEditing ? "edit" : "display"}
-                type="text"
-                label={t("dashboard.volunteerProfile.contactDetails.address")}
-                value={field.value}
-                setValue={field.onChange}
-                hasError={!!errors.address}
-              />
-              {errors.address && <ErrorMessage>{errors.address.message}</ErrorMessage>}
-            </>
+            <EditableField
+              mode={isEditing ? "edit" : "display"}
+              type="text"
+              label={t("dashboard.volunteerProfile.contactDetails.address")}
+              value={field.value}
+              setValue={field.onChange}
+              hasError={!!errors.address}
+              errorMessage={errors.address?.message}
+            />
           )}
         />
 
@@ -246,17 +228,16 @@ export function ContactDetails({ volunteer }: Props) {
           name="waysToContact"
           control={control}
           render={({ field }: { field: ControllerRenderProps<ContactDetailsFormData, "waysToContact"> }) => (
-            <>
-              <EditableField
-                mode={isEditing ? "edit" : "display"}
-                type="checkbox-list"
-                label={t("dashboard.volunteerProfile.contactDetails.waysToContact")}
-                value={field.value}
-                setValue={field.onChange}
-                options={["Whatsapp", "Telegram", "Mobile phone", "Email", "SMS"]}
-              />
-              {errors.waysToContact && <ErrorMessage>{errors.waysToContact.message}</ErrorMessage>}
-            </>
+            <EditableField
+              mode={isEditing ? "edit" : "display"}
+              type="checkbox-list"
+              label={t("dashboard.volunteerProfile.contactDetails.waysToContact")}
+              value={field.value}
+              setValue={field.onChange}
+              options={["Whatsapp", "Telegram", "Mobile phone", "Email", "SMS"]}
+              hasError={!!errors.waysToContact}
+              errorMessage={errors.waysToContact?.message}
+            />
           )}
         />
       </Details>

--- a/src/components/Dashboard/Profile/sections/ContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails.tsx
@@ -186,7 +186,6 @@ export function ContactDetails({ volunteer }: Props) {
               label={t("dashboard.volunteerProfile.contactDetails.phoneNumber")}
               value={field.value}
               setValue={field.onChange}
-              hasError={!!errors.phoneNumber}
               errorMessage={errors.phoneNumber?.message}
             />
           )}
@@ -202,7 +201,6 @@ export function ContactDetails({ volunteer }: Props) {
               label={t("dashboard.volunteerProfile.contactDetails.email")}
               value={field.value}
               setValue={field.onChange}
-              hasError={!!errors.email}
               errorMessage={errors.email?.message}
             />
           )}
@@ -218,7 +216,6 @@ export function ContactDetails({ volunteer }: Props) {
               label={t("dashboard.volunteerProfile.contactDetails.address")}
               value={field.value}
               setValue={field.onChange}
-              hasError={!!errors.address}
               errorMessage={errors.address?.message}
             />
           )}
@@ -235,7 +232,6 @@ export function ContactDetails({ volunteer }: Props) {
               value={field.value}
               setValue={field.onChange}
               options={["Whatsapp", "Telegram", "Mobile phone", "Email", "SMS"]}
-              hasError={!!errors.waysToContact}
               errorMessage={errors.waysToContact?.message}
             />
           )}

--- a/src/components/Dashboard/Profile/sections/ContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails.tsx
@@ -3,14 +3,14 @@ import Button from "@/components/core/button/Button/Button";
 import { EditableField } from "@/components/EditableField/EditableField";
 import { Heading2 } from "@/components/styled/text";
 import { useUpdateVolunteerContact } from "@/hooks/useUpdateVolunteerContact";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { ChatsCircle } from "@phosphor-icons/react";
 import { ApiVolunteerGet } from "need4deed-sdk";
 import { useEffect, useState } from "react";
+import { Controller, ControllerRenderProps, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
-import { useForm, Controller, ControllerRenderProps } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { createContactDetailsSchema, ContactDetailsFormData } from "./ContactDetails/contactDetailsSchema";
+import { ContactDetailsFormData, createContactDetailsSchema } from "./ContactDetails/contactDetailsSchema";
 
 const Container = styled.div<{ $isEditing: boolean }>`
   display: flex;
@@ -104,7 +104,7 @@ export function ContactDetails({ volunteer }: Props) {
       phoneNumber: volunteer.person.phone || "",
       email: volunteer.person.email || "",
       address: formatAddress(volunteer.person.address),
-      waysToContact: ["Whatsapp", "Telegram", "Mobile phone"],
+      waysToContact: ["WhatsApp"],
     },
   });
 
@@ -114,7 +114,8 @@ export function ContactDetails({ volunteer }: Props) {
       phoneNumber: volunteer.person.phone || "",
       email: volunteer.person.email || "",
       address: formatAddress(volunteer.person.address),
-      waysToContact: ["Whatsapp", "Telegram", "Mobile phone"],
+      // TODO: Load actual waysToContact from volunteer data when available
+      waysToContact: ["WhatsApp"],
     });
     setIsEditing(false);
   }, [volunteer, reset]);
@@ -146,6 +147,7 @@ export function ContactDetails({ volunteer }: Props) {
             },
           },
         },
+        waysToContact: data.waysToContact,
       },
       {
         onSuccess: () => {
@@ -231,7 +233,7 @@ export function ContactDetails({ volunteer }: Props) {
               label={t("dashboard.volunteerProfile.contactDetails.waysToContact")}
               value={field.value}
               setValue={field.onChange}
-              options={["Whatsapp", "Telegram", "Mobile phone", "Email", "SMS"]}
+              options={["WhatsApp", "Telegram", "Mobile phone", "Email", "SMS"]}
               errorMessage={errors.waysToContact?.message}
             />
           )}

--- a/src/components/Dashboard/Profile/sections/ContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails.tsx
@@ -138,7 +138,7 @@ export function ContactDetails({ volunteer }: Props) {
           phone: data.phoneNumber,
           email: data.email,
           address: {
-            id: volunteer.person.address?.id || "",
+            id: volunteer.person.address?.id,
             street: addressData.street,
             city: addressData.city,
             postcode: {

--- a/src/components/Dashboard/Profile/sections/ContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails.tsx
@@ -245,7 +245,7 @@ export function ContactDetails({ volunteer }: Props) {
             <EditableField
               mode={isEditing ? "edit" : "display"}
               type="checkbox-list"
-              label={t("dashboard.volunteerProfile.contactDetails.waysToContact")}
+              label={t("dashboard.volunteerProfile.contactDetails.waysToContact.label")}
               value={field.value.map((key) => keyToLabel[key])}
               setValue={(value) => {
                 const labels = Array.isArray(value) ? value : [value];

--- a/src/components/Dashboard/Profile/sections/ContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails.tsx
@@ -1,42 +1,30 @@
 "use client";
 import Button from "@/components/core/button/Button/Button";
-import { Heading2, Heading4, Paragraph } from "@/components/styled/text";
+import { EditableField } from "@/components/EditableField/EditableField";
+import { Heading2 } from "@/components/styled/text";
 import { ChatsCircle } from "@phosphor-icons/react";
 import { ApiVolunteerGet } from "need4deed-sdk";
+import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
+import { useMutationQuery } from "@/hooks";
+import { apiPathVolunteer } from "@/config/constants";
 
-const Container = styled.div`
+const Container = styled.div<{ $isEditing: boolean }>`
   display: flex;
   flex-direction: column;
   padding: 24px;
-  gap: 8px;
+  gap: ${(props) => (props.$isEditing ? "16px" : "8px")};
   background: var(--color-white);
   border-radius: 24px;
 `;
 
 const Header = styled.div`
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 24px;
-`;
-
-const HeaderRow = styled.div`
-  display: flex;
   flex-direction: row;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
-  gap: 24px;
   width: 100%;
-`;
-
-const HeaderContent = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 24px;
-  flex: 1;
 `;
 
 const TitleRow = styled.div`
@@ -60,35 +48,42 @@ const Details = styled.div`
   flex-direction: column;
   align-items: flex-start;
   width: 100%;
+  gap: 8px;
 `;
 
-const DetailRow = styled.div`
+const ButtonRow = styled.div`
   display: flex;
   flex-direction: row;
-  align-items: flex-start;
-  padding: 24px 0;
-  gap: 32px;
-  width: 100%;
-  border-bottom: 1px solid #ebedf7;
-
-  &:last-child {
-    border-bottom: none;
-  }
-`;
-
-const Label = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: flex-start;
-  width: 276px;
-`;
-
-const Value = styled.div`
-  display: flex;
+  justify-content: flex-end;
   align-items: center;
-  flex: 1;
+  gap: 24px;
+  width: 100%;
 `;
+
+type UpdateVolunteerContactData = {
+  person: {
+    id: number;
+    phone?: string;
+    email?: string;
+    address?: {
+      id: string | number;
+      street?: string;
+      city?: string;
+      postcode?: {
+        code?: string;
+      };
+    };
+  };
+};
+
+const useUpdateVolunteerContact = (volunteerId: number) => {
+  return useMutationQuery<UpdateVolunteerContactData, ApiVolunteerGet>({
+    apiPath: `${apiPathVolunteer}${volunteerId}`,
+    method: "patch",
+    successMessage: "dashboard.volunteerProfile.contactDetails.saveSuccess",
+    queryKeyToInvalidate: ["volunteer", volunteerId],
+  });
+};
 
 interface Props {
   volunteer: ApiVolunteerGet;
@@ -96,87 +91,154 @@ interface Props {
 
 export function ContactDetails({ volunteer }: Props) {
   const { t } = useTranslation();
-
-  const handleEditClick = () => {
-    // TODO: Implement edit functionality
-  };
-
-  const phoneNumber = volunteer.person.phone || t("dashboard.volunteerProfile.contactDetails.notProvided");
-  const email = volunteer.person.email || t("dashboard.volunteerProfile.contactDetails.notProvided");
+  const [isEditing, setIsEditing] = useState(false);
+  const { mutate: updateContact, isPending } = useUpdateVolunteerContact(volunteer.id);
 
   const formatAddress = () => {
     const addr = volunteer.person.address;
     if (!addr || typeof addr !== "object") {
-      return t("dashboard.volunteerProfile.contactDetails.notProvided");
+      return "";
     }
     const postcode = addr.postcode && typeof addr.postcode === "object" ? addr.postcode.code : addr.postcode;
     const parts = [addr.street, addr.city, postcode].filter(Boolean);
-    return parts.length > 0 ? parts.join(", ") : t("dashboard.volunteerProfile.contactDetails.notProvided");
+    return parts.join(", ");
   };
 
-  const address = formatAddress();
+  const [phoneNumber, setPhoneNumber] = useState(volunteer.person.phone || "");
+  const [email, setEmail] = useState(volunteer.person.email || "");
+  const [address, setAddress] = useState(formatAddress());
+  const [waysToContact, setWaysToContact] = useState<string[]>(["Whatsapp", "Telegram", "Mobile phone"]);
 
-  // TODO: Get this from volunteer data when available
-  const waysToContact = "Whatsapp, Telegram, mobile phone";
+  // Sync local state when volunteer data changes (after refetch)
+  useEffect(() => {
+    setPhoneNumber(volunteer.person.phone || "");
+    setEmail(volunteer.person.email || "");
+    setAddress(formatAddress());
+  }, [volunteer]);
+
+  const handleEditClick = () => {
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    setPhoneNumber(volunteer.person.phone || "");
+    setEmail(volunteer.person.email || "");
+    setAddress(formatAddress());
+    setWaysToContact(["Whatsapp", "Telegram", "Mobile phone"]);
+    setIsEditing(false);
+  };
+
+  const parseAddress = (addressString: string) => {
+    // Address format: "street, city, postcode"
+    const parts = addressString.split(",").map((part) => part.trim());
+    return {
+      street: parts[0] || "",
+      city: parts[1] || "",
+      postcode: parts[2] || "",
+    };
+  };
+
+  const handleSave = () => {
+    const addressData = parseAddress(address);
+
+    updateContact(
+      {
+        person: {
+          id: volunteer.person.id,
+          phone: phoneNumber,
+          email: email,
+          address: {
+            id: volunteer.person.address?.id || "",
+            street: addressData.street,
+            city: addressData.city,
+            postcode: {
+              code: addressData.postcode,
+            },
+          },
+        },
+      },
+      {
+        onSuccess: () => {
+          setIsEditing(false);
+        },
+      }
+    );
+  };
 
   return (
-    <Container data-testid="contact-details-container">
+    <Container data-testid="contact-details-container" $isEditing={isEditing}>
       <Header>
-        <HeaderRow>
-          <HeaderContent>
-            <TitleRow>
-              <IconContainer>
-                <ChatsCircle size={40} weight="fill" />
-              </IconContainer>
-              <Heading2>{t("dashboard.volunteerProfile.contactDetails.title")}</Heading2>
-            </TitleRow>
-          </HeaderContent>
+        <TitleRow>
+          <IconContainer>
+            <ChatsCircle size={40} weight="fill" />
+          </IconContainer>
+          <Heading2>{t("dashboard.volunteerProfile.contactDetails.title")}</Heading2>
+        </TitleRow>
+        {!isEditing && (
           <Button
             text={t("dashboard.volunteerProfile.contactDetails.edit")}
             onClick={handleEditClick}
             width="auto"
             padding="16px 24px"
           />
-        </HeaderRow>
+        )}
       </Header>
 
       <Details>
-        <DetailRow>
-          <Label>
-            <Heading4>{t("dashboard.volunteerProfile.contactDetails.phoneNumber")}</Heading4>
-          </Label>
-          <Value>
-            <Paragraph>{phoneNumber}</Paragraph>
-          </Value>
-        </DetailRow>
+        <EditableField
+          mode={isEditing ? "edit" : "display"}
+          type="text"
+          label={t("dashboard.volunteerProfile.contactDetails.phoneNumber")}
+          value={phoneNumber}
+          setValue={(v) => setPhoneNumber(v as string)}
+        />
 
-        <DetailRow>
-          <Label>
-            <Heading4>{t("dashboard.volunteerProfile.contactDetails.email")}</Heading4>
-          </Label>
-          <Value>
-            <Paragraph>{email}</Paragraph>
-          </Value>
-        </DetailRow>
+        <EditableField
+          mode={isEditing ? "edit" : "display"}
+          type="text"
+          label={t("dashboard.volunteerProfile.contactDetails.email")}
+          value={email}
+          setValue={(v) => setEmail(v as string)}
+        />
 
-        <DetailRow>
-          <Label>
-            <Heading4>{t("dashboard.volunteerProfile.contactDetails.address")}</Heading4>
-          </Label>
-          <Value>
-            <Paragraph>{address}</Paragraph>
-          </Value>
-        </DetailRow>
+        <EditableField
+          mode={isEditing ? "edit" : "display"}
+          type="text"
+          label={t("dashboard.volunteerProfile.contactDetails.address")}
+          value={address}
+          setValue={(v) => setAddress(v as string)}
+        />
 
-        <DetailRow>
-          <Label>
-            <Heading4>{t("dashboard.volunteerProfile.contactDetails.waysToContact")}</Heading4>
-          </Label>
-          <Value>
-            <Paragraph>{waysToContact}</Paragraph>
-          </Value>
-        </DetailRow>
+        <EditableField
+          mode={isEditing ? "edit" : "display"}
+          type="checkbox-list"
+          label={t("dashboard.volunteerProfile.contactDetails.waysToContact")}
+          value={waysToContact}
+          setValue={(v) => setWaysToContact(v as string[])}
+          options={["Whatsapp", "Telegram", "Mobile phone", "Email", "SMS"]}
+        />
       </Details>
+
+      {isEditing && (
+        <ButtonRow>
+          <Button
+            text={t("dashboard.volunteerProfile.contactDetails.cancel")}
+            onClick={handleCancel}
+            width="auto"
+            padding="16px 24px"
+            backgroundcolor="var(--color-white)"
+            textColor="var(--color-aubergine)"
+            border="2px solid var(--color-aubergine)"
+          />
+          <Button
+            text={t("dashboard.volunteerProfile.contactDetails.saveChanges")}
+            onClick={handleSave}
+            width="auto"
+            padding="16px 24px"
+            disabled={isPending}
+          />
+        </ButtonRow>
+      )}
     </Container>
   );
 }

--- a/src/components/Dashboard/Profile/sections/ContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails.tsx
@@ -111,8 +111,7 @@ export function ContactDetails({ volunteer }: Props) {
       phoneNumber: volunteer.person.phone || "",
       email: volunteer.person.email || "",
       address: formatAddress(volunteer.person.address),
-      // TODO: Load actual waysToContact from volunteer data when available
-      waysToContact: [],
+      waysToContact: volunteer.waysToContact || [],
     }),
     [volunteer],
   );

--- a/src/components/Dashboard/Profile/sections/ContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails.tsx
@@ -85,21 +85,21 @@ interface Props {
   volunteer: ApiVolunteerGet;
 }
 
-const waysToContactKeys = Object.values(VolunteerCommunicationType);
+const preferredCommunicationTypeKeys = Object.values(VolunteerCommunicationType);
 
 export function ContactDetails({ volunteer }: Props) {
   const { t } = useTranslation();
   const { mutate: updateContact, isPending } = useUpdateVolunteerContact(String(volunteer.id));
   const [isEditing, setIsEditing] = useState(false);
 
-  const waysToContactOptions = waysToContactKeys.map((key) =>
-    t(`dashboard.volunteerProfile.contactDetails.waysToContact.${key}`),
+  const preferredCommunicationTypeOptions = preferredCommunicationTypeKeys.map((key) =>
+    t(`dashboard.volunteerProfile.contactDetails.preferredCommunicationType.${key}`),
   );
 
   const keyToLabel: Record<string, string> = {};
   const labelToKey: Record<string, string> = {};
-  waysToContactKeys.forEach((key, index) => {
-    const label = waysToContactOptions[index];
+  preferredCommunicationTypeKeys.forEach((key, index) => {
+    const label = preferredCommunicationTypeOptions[index];
     keyToLabel[key] = label;
     labelToKey[label] = key;
   });
@@ -108,10 +108,10 @@ export function ContactDetails({ volunteer }: Props) {
 
   const initialFormValues = useMemo(
     () => ({
-      phoneNumber: volunteer.person.phone || "",
+      phone: volunteer.person.phone || "",
       email: volunteer.person.email || "",
       address: formatAddress(volunteer.person.address),
-      waysToContact: volunteer.waysToContact || [],
+      preferredCommunicationType: volunteer.preferredCommunicationType || [],
     }),
     [volunteer],
   );
@@ -143,7 +143,7 @@ export function ContactDetails({ volunteer }: Props) {
       {
         person: {
           id: volunteer.person.id,
-          phone: values.phoneNumber,
+          phone: values.phone,
           email: values.email,
           address: {
             id: volunteer.person.address?.id,
@@ -154,7 +154,7 @@ export function ContactDetails({ volunteer }: Props) {
             },
           },
         },
-        waysToContact: values.waysToContact,
+        preferredCommunicationType: values.preferredCommunicationType,
       },
       {
         onSuccess: () => {
@@ -192,16 +192,16 @@ export function ContactDetails({ volunteer }: Props) {
 
       <Details>
         <Controller
-          name="phoneNumber"
+          name="phone"
           control={control}
-          render={({ field }: { field: ControllerRenderProps<ContactDetailsFormData, "phoneNumber"> }) => (
+          render={({ field }: { field: ControllerRenderProps<ContactDetailsFormData, "phone"> }) => (
             <EditableField
               mode={isEditing ? "edit" : "display"}
               type="text"
-              label={t("dashboard.volunteerProfile.contactDetails.phoneNumber")}
+              label={t("dashboard.volunteerProfile.contactDetails.phone")}
               value={field.value}
               setValue={field.onChange}
-              errorMessage={errors.phoneNumber?.message}
+              errorMessage={errors.phone?.message}
             />
           )}
         />
@@ -237,20 +237,24 @@ export function ContactDetails({ volunteer }: Props) {
         />
 
         <Controller
-          name="waysToContact"
+          name="preferredCommunicationType"
           control={control}
-          render={({ field }: { field: ControllerRenderProps<ContactDetailsFormData, "waysToContact"> }) => (
+          render={({
+            field,
+          }: {
+            field: ControllerRenderProps<ContactDetailsFormData, "preferredCommunicationType">;
+          }) => (
             <EditableField
               mode={isEditing ? "edit" : "display"}
               type="checkbox-list"
-              label={t("dashboard.volunteerProfile.contactDetails.waysToContact.label")}
+              label={t("dashboard.volunteerProfile.contactDetails.preferredCommunicationType.label")}
               value={field.value.map((key) => keyToLabel[key])}
               setValue={(value) => {
                 const labels = Array.isArray(value) ? value : [value];
                 field.onChange(labels.map((label) => labelToKey[label]));
               }}
-              options={waysToContactOptions}
-              errorMessage={errors.waysToContact?.message}
+              options={preferredCommunicationTypeOptions}
+              errorMessage={errors.preferredCommunicationType?.message}
             />
           )}
         />

--- a/src/components/Dashboard/Profile/sections/ContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails.tsx
@@ -85,10 +85,25 @@ interface Props {
   volunteer: ApiVolunteerGet;
 }
 
+// TODO: use enum-values from backend / sdk when available
+const waysToContactKeys = ["whatsapp", "telegram", "mobilePhone", "email", "sms"];
+
 export function ContactDetails({ volunteer }: Props) {
   const { t } = useTranslation();
   const { mutate: updateContact, isPending } = useUpdateVolunteerContact(volunteer.id);
   const [isEditing, setIsEditing] = useState(false);
+
+  const waysToContactOptions = waysToContactKeys.map((key) =>
+    t(`dashboard.volunteerProfile.contactDetails.waysToContact.${key}`),
+  );
+
+  const keyToLabel: Record<string, string> = {};
+  const labelToKey: Record<string, string> = {};
+  waysToContactKeys.forEach((key, index) => {
+    const label = waysToContactOptions[index];
+    keyToLabel[key] = label;
+    labelToKey[label] = key;
+  });
 
   const schema = createContactDetailsSchema(t);
 
@@ -104,7 +119,7 @@ export function ContactDetails({ volunteer }: Props) {
       phoneNumber: volunteer.person.phone || "",
       email: volunteer.person.email || "",
       address: formatAddress(volunteer.person.address),
-      waysToContact: ["WhatsApp"],
+      waysToContact: ["whatsapp"],
     },
   });
 
@@ -115,7 +130,7 @@ export function ContactDetails({ volunteer }: Props) {
       email: volunteer.person.email || "",
       address: formatAddress(volunteer.person.address),
       // TODO: Load actual waysToContact from volunteer data when available
-      waysToContact: ["WhatsApp"],
+      waysToContact: ["whatsapp"],
     });
     setIsEditing(false);
   }, [volunteer, reset]);
@@ -231,9 +246,12 @@ export function ContactDetails({ volunteer }: Props) {
               mode={isEditing ? "edit" : "display"}
               type="checkbox-list"
               label={t("dashboard.volunteerProfile.contactDetails.waysToContact")}
-              value={field.value}
-              setValue={field.onChange}
-              options={["WhatsApp", "Telegram", "Mobile phone", "Email", "SMS"]}
+              value={field.value.map((key) => keyToLabel[key])}
+              setValue={(value) => {
+                const labels = Array.isArray(value) ? value : [value];
+                field.onChange(labels.map((label) => labelToKey[label]));
+              }}
+              options={waysToContactOptions}
               errorMessage={errors.waysToContact?.message}
             />
           )}

--- a/src/components/Dashboard/Profile/sections/ContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails.tsx
@@ -8,6 +8,9 @@ import { ApiVolunteerGet } from "need4deed-sdk";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
+import { useForm, Controller, ControllerRenderProps } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { createContactDetailsSchema, ContactDetailsFormData } from "./ContactDetails/contactDetailsSchema";
 
 const Container = styled.div<{ $isEditing: boolean }>`
   display: flex;
@@ -59,6 +62,18 @@ const ButtonRow = styled.div`
   width: 100%;
 `;
 
+const ErrorMessage = styled.p`
+  color: var(--color-red-600);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 20px;
+  margin-top: 8px;
+  margin-left: 252px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
 const formatAddress = (address: ApiVolunteerGet["person"]["address"]) => {
   if (!address || typeof address !== "object") {
     return "";
@@ -74,30 +89,44 @@ interface Props {
 
 export function ContactDetails({ volunteer }: Props) {
   const { t } = useTranslation();
-  const [isEditing, setIsEditing] = useState(false);
   const { mutate: updateContact, isPending } = useUpdateVolunteerContact(volunteer.id);
+  const [isEditing, setIsEditing] = useState(false);
 
-  const [phoneNumber, setPhoneNumber] = useState(volunteer.person.phone || "");
-  const [email, setEmail] = useState(volunteer.person.email || "");
-  const [address, setAddress] = useState(formatAddress(volunteer.person.address));
-  const [waysToContact, setWaysToContact] = useState<string[]>(["Whatsapp", "Telegram", "Mobile phone"]);
+  const schema = createContactDetailsSchema(t);
 
-  // Sync local state when volunteer data changes (after refetch)
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors, isValid },
+  } = useForm<ContactDetailsFormData>({
+    resolver: zodResolver(schema),
+    mode: "onChange",
+    defaultValues: {
+      phoneNumber: volunteer.person.phone || "",
+      email: volunteer.person.email || "",
+      address: formatAddress(volunteer.person.address),
+      waysToContact: ["Whatsapp", "Telegram", "Mobile phone"],
+    },
+  });
+
+  // Sync form when volunteer data changes (after refetch)
   useEffect(() => {
-    setPhoneNumber(volunteer.person.phone || "");
-    setEmail(volunteer.person.email || "");
-    setAddress(formatAddress(volunteer.person.address));
-  }, [volunteer]);
+    reset({
+      phoneNumber: volunteer.person.phone || "",
+      email: volunteer.person.email || "",
+      address: formatAddress(volunteer.person.address),
+      waysToContact: ["Whatsapp", "Telegram", "Mobile phone"],
+    });
+    setIsEditing(false);
+  }, [volunteer, reset]);
 
   const handleEditClick = () => {
     setIsEditing(true);
   };
 
   const handleCancel = () => {
-    setPhoneNumber(volunteer.person.phone || "");
-    setEmail(volunteer.person.email || "");
-    setAddress(formatAddress(volunteer.person.address));
-    setWaysToContact(["Whatsapp", "Telegram", "Mobile phone"]);
+    reset();
     setIsEditing(false);
   };
 
@@ -111,15 +140,15 @@ export function ContactDetails({ volunteer }: Props) {
     };
   };
 
-  const handleSave = () => {
-    const addressData = parseAddress(address);
+  const onSubmit = (data: ContactDetailsFormData) => {
+    const addressData = parseAddress(data.address);
 
     updateContact(
       {
         person: {
           id: volunteer.person.id,
-          phone: phoneNumber,
-          email: email,
+          phone: data.phoneNumber,
+          email: data.email,
           address: {
             id: volunteer.person.address?.id || "",
             street: addressData.street,
@@ -132,6 +161,7 @@ export function ContactDetails({ volunteer }: Props) {
       },
       {
         onSuccess: () => {
+          reset(data);
           setIsEditing(false);
         },
       },
@@ -158,37 +188,76 @@ export function ContactDetails({ volunteer }: Props) {
       </Header>
 
       <Details>
-        <EditableField
-          mode={isEditing ? "edit" : "display"}
-          type="text"
-          label={t("dashboard.volunteerProfile.contactDetails.phoneNumber")}
-          value={phoneNumber}
-          setValue={(v) => setPhoneNumber(v as string)}
+        <Controller
+          name="phoneNumber"
+          control={control}
+          render={({ field }: { field: ControllerRenderProps<ContactDetailsFormData, "phoneNumber"> }) => (
+            <>
+              <EditableField
+                mode={isEditing ? "edit" : "display"}
+                type="text"
+                label={t("dashboard.volunteerProfile.contactDetails.phoneNumber")}
+                value={field.value}
+                setValue={field.onChange}
+                hasError={!!errors.phoneNumber}
+              />
+              {errors.phoneNumber && <ErrorMessage>{errors.phoneNumber.message}</ErrorMessage>}
+            </>
+          )}
         />
 
-        <EditableField
-          mode={isEditing ? "edit" : "display"}
-          type="text"
-          label={t("dashboard.volunteerProfile.contactDetails.email")}
-          value={email}
-          setValue={(v) => setEmail(v as string)}
+        <Controller
+          name="email"
+          control={control}
+          render={({ field }: { field: ControllerRenderProps<ContactDetailsFormData, "email"> }) => (
+            <>
+              <EditableField
+                mode={isEditing ? "edit" : "display"}
+                type="text"
+                label={t("dashboard.volunteerProfile.contactDetails.email")}
+                value={field.value}
+                setValue={field.onChange}
+                hasError={!!errors.email}
+              />
+              {errors.email && <ErrorMessage>{errors.email.message}</ErrorMessage>}
+            </>
+          )}
         />
 
-        <EditableField
-          mode={isEditing ? "edit" : "display"}
-          type="text"
-          label={t("dashboard.volunteerProfile.contactDetails.address")}
-          value={address}
-          setValue={(v) => setAddress(v as string)}
+        <Controller
+          name="address"
+          control={control}
+          render={({ field }: { field: ControllerRenderProps<ContactDetailsFormData, "address"> }) => (
+            <>
+              <EditableField
+                mode={isEditing ? "edit" : "display"}
+                type="text"
+                label={t("dashboard.volunteerProfile.contactDetails.address")}
+                value={field.value}
+                setValue={field.onChange}
+                hasError={!!errors.address}
+              />
+              {errors.address && <ErrorMessage>{errors.address.message}</ErrorMessage>}
+            </>
+          )}
         />
 
-        <EditableField
-          mode={isEditing ? "edit" : "display"}
-          type="checkbox-list"
-          label={t("dashboard.volunteerProfile.contactDetails.waysToContact")}
-          value={waysToContact}
-          setValue={(v) => setWaysToContact(v as string[])}
-          options={["Whatsapp", "Telegram", "Mobile phone", "Email", "SMS"]}
+        <Controller
+          name="waysToContact"
+          control={control}
+          render={({ field }: { field: ControllerRenderProps<ContactDetailsFormData, "waysToContact"> }) => (
+            <>
+              <EditableField
+                mode={isEditing ? "edit" : "display"}
+                type="checkbox-list"
+                label={t("dashboard.volunteerProfile.contactDetails.waysToContact")}
+                value={field.value}
+                setValue={field.onChange}
+                options={["Whatsapp", "Telegram", "Mobile phone", "Email", "SMS"]}
+              />
+              {errors.waysToContact && <ErrorMessage>{errors.waysToContact.message}</ErrorMessage>}
+            </>
+          )}
         />
       </Details>
 
@@ -205,10 +274,10 @@ export function ContactDetails({ volunteer }: Props) {
           />
           <Button
             text={t("dashboard.volunteerProfile.contactDetails.saveChanges")}
-            onClick={handleSave}
+            onClick={handleSubmit(onSubmit)}
             width="auto"
             padding="16px 24px"
-            disabled={isPending}
+            disabled={!isValid || isPending}
           />
         </ButtonRow>
       )}

--- a/src/components/Dashboard/Profile/sections/ContactDetails/contactDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/contactDetailsSchema.ts
@@ -6,7 +6,7 @@ export const createContactDetailsSchema = (t: (key: string) => string) => {
       .string()
       .min(1, t("dashboard.volunteerProfile.contactDetails.validation.phoneRequired"))
       .regex(
-        /^\+?[0-9\s\-()]+$/,
+        /^\+[0-9]+$/,
         t("dashboard.volunteerProfile.contactDetails.validation.phoneInvalid")
       ),
     email: z

--- a/src/components/Dashboard/Profile/sections/ContactDetails/contactDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/contactDetailsSchema.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const createContactDetailsSchema = (t: (key: string) => string) => {
+  return z.object({
+    phoneNumber: z
+      .string()
+      .min(1, t("dashboard.volunteerProfile.contactDetails.validation.phoneRequired"))
+      .regex(
+        /^\+?[0-9\s\-()]+$/,
+        t("dashboard.volunteerProfile.contactDetails.validation.phoneInvalid")
+      ),
+    email: z
+      .string()
+      .min(1, t("dashboard.volunteerProfile.contactDetails.validation.emailRequired"))
+      .email(t("dashboard.volunteerProfile.contactDetails.validation.emailInvalid")),
+    address: z
+      .string()
+      .min(1, t("dashboard.volunteerProfile.contactDetails.validation.addressRequired")),
+    waysToContact: z
+      .array(z.string())
+      .min(1, t("dashboard.volunteerProfile.contactDetails.validation.waysToContactRequired")),
+  });
+};
+
+export type ContactDetailsFormData = z.infer<ReturnType<typeof createContactDetailsSchema>>;

--- a/src/components/Dashboard/Profile/sections/ContactDetails/contactDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/contactDetailsSchema.ts
@@ -16,9 +16,7 @@ export const createContactDetailsSchema = (t: (key: string) => string) => {
     address: z
       .string()
       .min(1, t("dashboard.volunteerProfile.contactDetails.validation.addressRequired")),
-    waysToContact: z
-      .array(z.string())
-      .min(1, t("dashboard.volunteerProfile.contactDetails.validation.waysToContactRequired")),
+    waysToContact: z.array(z.string()).min(1, t("dashboard.volunteerProfile.contactDetails.validation.waysToContactRequired")),
   });
 };
 

--- a/src/components/Dashboard/Profile/sections/ContactDetails/contactDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/contactDetailsSchema.ts
@@ -1,22 +1,20 @@
+import { VolunteerCommunicationType } from "need4deed-sdk";
 import { z } from "zod";
 
 export const createContactDetailsSchema = (t: (key: string) => string) => {
   return z.object({
-    phoneNumber: z
+    phone: z
       .string()
       .min(1, t("dashboard.volunteerProfile.contactDetails.validation.phoneRequired"))
-      .regex(
-        /^\+[0-9]+$/,
-        t("dashboard.volunteerProfile.contactDetails.validation.phoneInvalid")
-      ),
+      .regex(/^\+[0-9]+$/, t("dashboard.volunteerProfile.contactDetails.validation.phoneInvalid")),
     email: z
       .string()
       .min(1, t("dashboard.volunteerProfile.contactDetails.validation.emailRequired"))
       .email(t("dashboard.volunteerProfile.contactDetails.validation.emailInvalid")),
-    address: z
-      .string()
-      .min(1, t("dashboard.volunteerProfile.contactDetails.validation.addressRequired")),
-    waysToContact: z.array(z.string()).min(1, t("dashboard.volunteerProfile.contactDetails.validation.waysToContactRequired")),
+    address: z.string().min(1, t("dashboard.volunteerProfile.contactDetails.validation.addressRequired")),
+    preferredCommunicationType: z
+      .array(z.enum(Object.values(VolunteerCommunicationType)))
+      .min(1, t("dashboard.volunteerProfile.contactDetails.validation.preferredCommunicationTypeRequired")),
   });
 };
 

--- a/src/components/EditableField/EditableField.tsx
+++ b/src/components/EditableField/EditableField.tsx
@@ -1,7 +1,8 @@
+import { WarningCircle, XCircle } from "@phosphor-icons/react";
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { IoIosArrowDown } from "react-icons/io";
-import { XCircle, WarningCircle } from "@phosphor-icons/react";
 import styled from "styled-components";
+import { isDefined } from "ts-type-safe";
 
 const EditModeWrapper = styled.div`
   width: 100%;
@@ -58,8 +59,7 @@ const InputWrapper = styled.div<{ $hasError?: boolean }>`
 
     &:focus {
       outline: none;
-      border: ${(props) =>
-        props.$hasError ? "2px solid var(--color-red-600)" : "2px solid var(--color-green-200)"};
+      border: ${(props) => (props.$hasError ? "2px solid var(--color-red-600)" : "2px solid var(--color-green-200)")};
     }
   }
 `;
@@ -103,8 +103,7 @@ const DropdownButton = styled.div<{ $hasError?: boolean }>`
 
   &:focus-within {
     outline: none;
-    border: ${(props) =>
-      props.$hasError ? "2px solid var(--color-red-600)" : "2px solid var(--color-green-200)"};
+    border: ${(props) => (props.$hasError ? "2px solid var(--color-red-600)" : "2px solid var(--color-green-200)")};
   }
 `;
 
@@ -291,14 +290,14 @@ export const EditableField = forwardRef(function EditableField<T extends string 
           <InputWrapper $hasError={!!errorMessage}>
             <input
               type="text"
-              value={localValue as string}
+              value={localValue}
               onChange={(e) => {
                 const v = e.target.value as T;
                 setLocalValue(v);
                 setValue(v);
               }}
             />
-            {(localValue as string).length > 0 && (
+            {isDefined(localValue) && (
               <ClearButton
                 type="button"
                 onClick={() => {

--- a/src/components/EditableField/EditableField.tsx
+++ b/src/components/EditableField/EditableField.tsx
@@ -2,6 +2,10 @@ import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "re
 import { IoIosArrowDown } from "react-icons/io";
 import styled from "styled-components";
 
+const EditModeWrapper = styled.div`
+  width: 100%;
+`;
+
 const FieldWrapper = styled.div`
   display: var(--editableField-fieldWrapper-display);
   border-bottom: var(--editableField-fieldWrapper-borderBottom);
@@ -10,25 +14,33 @@ const FieldWrapper = styled.div`
   width: var(--editableField-fieldWrapper-width);
   align-items: var(--editableField-fieldWrapper-alignItems);
   font-size: var(--editableField-fieldWrapper-fontSize);
+  gap: var(--editableField-fieldWrapper-gap);
 
   label {
     font-weight: var(--editableField-fieldWrapper-label-fontWeight);
     font-size: var(--editableField-fieldWrapper-label-fontSize);
     width: var(--editableField-fieldWrapper-label-width);
+    flex-shrink: var(--editableField-fieldWrapper-label-flexShrink);
+  }
+
+  > span {
+    flex: 1;
   }
 
   input {
     border-radius: var(--editableField-fieldWrapper-input-borderRadius);
-    width: var(--editableField-fieldWrapper-input-width);
     padding: var(--editableField-fieldWrapper-input-padding);
     color: var(--color-midnight);
     border: var(--editableField-fieldWrapper-input-border);
+    flex: 1;
+    min-width: 0;
   }
 `;
 
 const DropdownWrapper = styled.div`
   position: var(--editableField-dropdownWrapper-position);
   width: var(--editableField-dropdownWrapper-width);
+  flex: 1;
 `;
 
 const DropdownButton = styled.div`
@@ -180,7 +192,7 @@ export const EditableField = forwardRef(function EditableField<T extends string 
 
   // edit mode
   return (
-    <div>
+    <EditModeWrapper>
       <FieldWrapper>
         {label && <label>{label}: </label>}
 
@@ -255,6 +267,6 @@ export const EditableField = forwardRef(function EditableField<T extends string 
         )}
       </FieldWrapper>
       {error && <p style={{ color: "red", paddingLeft: "1rem" }}>{error}</p>}
-    </div>
+    </EditModeWrapper>
   );
 });

--- a/src/components/EditableField/EditableField.tsx
+++ b/src/components/EditableField/EditableField.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { IoIosArrowDown } from "react-icons/io";
-import { X } from "@phosphor-icons/react";
+import { XCircle, WarningCircle } from "@phosphor-icons/react";
 import styled from "styled-components";
 
 const EditModeWrapper = styled.div`
@@ -88,8 +88,9 @@ const DropdownWrapper = styled.div`
   flex: 1;
 `;
 
-const DropdownButton = styled.div`
-  border: var(--editableField-dropdownButton-border);
+const DropdownButton = styled.div<{ $hasError?: boolean }>`
+  border: ${(props) =>
+    props.$hasError ? "2px solid var(--color-red-600)" : "var(--editableField-dropdownButton-border)"};
   padding: var(--editableField-dropdownButton-padding);
   border-radius: var(--editableField-dropdownButton-borderRadius);
   cursor: var(--editableField-dropdownButton-cursor);
@@ -98,6 +99,13 @@ const DropdownButton = styled.div`
   justify-content: var(--editableField-dropdownButton-justifyContent);
   align-items: var(--editableField-dropdownButton-alignItems);
   user-select: var(--editableField-dropdownButton-userSelect);
+  transition: border 0.2s ease;
+
+  &:focus-within {
+    outline: none;
+    border: ${(props) =>
+      props.$hasError ? "2px solid var(--color-red-600)" : "2px solid var(--color-green-200)"};
+  }
 `;
 
 const Arrow = styled(IoIosArrowDown)`
@@ -119,28 +127,62 @@ const DropdownList = styled.div`
   border-radius: var(--editableField-dropdownList-borderRadius);
   padding: var(--editableField-dropdownList-padding);
   z-index: var(--editableField-dropdownList-zIndex);
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
 `;
 
-const OptionRow = styled.div`
-  display: var(--editableField-optionRow-display);
-  align-items: var(--editableField-optionRow-alignItems);
-  justify-content: var(--editableField-optionRow-justifyContent);
-  padding: var(--editableField-optionRow-padding);
-  cursor: var(--editableField-optionRow-cursor);
-  user-select: var(--editableField-optionRow-userSelect);
-  width: var(--editableField-optionRow-width);
+const OptionRow = styled.div<{ $isSelected?: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 8px 12px;
+  cursor: pointer;
+  user-select: none;
+  width: 100%;
+  border-radius: 6px;
+  transition: background-color 0.2s ease;
+  gap: 12px;
+  background-color: ${(props) => (props.$isSelected ? "var(--color-orchid-subtle)" : "transparent")};
 
-  input {
-    width: var(--editableField-optionRow-input-width);
+  &:hover {
+    background-color: var(--color-orchid-light);
+  }
+
+  input[type="checkbox"],
+  input[type="radio"] {
+    width: 20px;
+    height: 20px;
+    cursor: pointer;
+    margin: 0;
+    flex: 0 0 auto;
+    accent-color: var(--color-green-500);
   }
 `;
 
 const Text = styled.span`
-  flex: var(--editableField-text-flex);
-  margin-left: var(--editableField-text-marginLeft);
-  white-space: var(--editableField-text-whiteSpace);
-  overflow-wrap: var(--editableField-text-overflow);
-  word-break: var(--editableField-text-wordBreak);
+  flex: 1;
+  white-space: normal;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  cursor: pointer;
+  font-size: 16px;
+  color: var(--color-midnight);
+`;
+
+const ErrorMessage = styled.div`
+  color: var(--color-red-600);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+  margin: 0;
+  padding-left: 252px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
 `;
 
 type EditableFieldType = "text" | "number" | "checkbox-list" | "radio-list";
@@ -160,6 +202,7 @@ interface EditableFieldProps<T = string | number | string[]> {
   validator?: (value: T) => string | null;
   options?: string[];
   hasError?: boolean;
+  errorMessage?: string;
 }
 
 export const EditableField = forwardRef(function EditableField<T extends string | number | string[]>(
@@ -173,6 +216,7 @@ export const EditableField = forwardRef(function EditableField<T extends string 
     validator,
     options = [],
     hasError = false,
+    errorMessage,
   }: EditableFieldProps<T>,
   ref: React.Ref<EditableFieldRef<T>>,
 ) {
@@ -222,17 +266,19 @@ export const EditableField = forwardRef(function EditableField<T extends string 
 
   if (mode === "display") {
     if (type === "checkbox-list" && Array.isArray(value)) {
+      const displayValue = value.length > 0 ? value.join(", ") : "–";
       return (
         <FieldWrapper>
           {label && <label>{label}: </label>}
-          <span>{(value as string[]).join(", ")}</span>
+          <span>{displayValue}</span>
         </FieldWrapper>
       );
     }
+    const displayValue = value && String(value).trim().length > 0 ? value : "–";
     return (
       <FieldWrapper>
         {label && <label>{label}: </label>}
-        <span>{value}</span>
+        <span>{displayValue}</span>
       </FieldWrapper>
     );
   }
@@ -263,7 +309,7 @@ export const EditableField = forwardRef(function EditableField<T extends string 
                   setValue(v);
                 }}
               >
-                <X size={20} weight="bold" />
+                <XCircle size={20} weight="bold" />
               </ClearButton>
             )}
           </InputWrapper>
@@ -289,7 +335,7 @@ export const EditableField = forwardRef(function EditableField<T extends string 
                   setValue(v);
                 }}
               >
-                <X size={20} weight="bold" />
+                <XCircle size={20} weight="bold" />
               </ClearButton>
             )}
           </InputWrapper>
@@ -297,7 +343,7 @@ export const EditableField = forwardRef(function EditableField<T extends string 
 
         {(type === "checkbox-list" || type === "radio-list") && (
           <DropdownWrapper ref={wrapperRef}>
-            <DropdownButton onClick={() => setOpen((o) => !o)}>
+            <DropdownButton $hasError={hasError} onClick={() => setOpen((o) => !o)}>
               <span>
                 {type === "checkbox-list"
                   ? Array.isArray(localValue) && localValue.length > 0
@@ -311,18 +357,16 @@ export const EditableField = forwardRef(function EditableField<T extends string 
 
             {open && (
               <DropdownList>
-                {options.map((option) => (
-                  <OptionRow key={option}>
-                    <input
-                      type={type === "checkbox-list" ? "checkbox" : "radio"}
-                      name={label}
-                      value={option}
-                      checked={
-                        type === "checkbox-list"
-                          ? Array.isArray(localValue) && localValue.includes(option)
-                          : localValue === option
-                      }
-                      onChange={() => {
+                {options.map((option) => {
+                  const isSelected =
+                    type === "checkbox-list"
+                      ? Array.isArray(localValue) && localValue.includes(option)
+                      : localValue === option;
+                  return (
+                    <OptionRow
+                      key={option}
+                      $isSelected={isSelected}
+                      onClick={() => {
                         if (type === "checkbox-list") {
                           handleCheckboxChange(option);
                         } else {
@@ -332,16 +376,33 @@ export const EditableField = forwardRef(function EditableField<T extends string 
                           setOpen(false);
                         }
                       }}
-                    />
-                    <Text>{option}</Text>
-                  </OptionRow>
-                ))}
+                    >
+                      <input
+                        type={type === "checkbox-list" ? "checkbox" : "radio"}
+                        name={label}
+                        value={option}
+                        checked={isSelected}
+                        onChange={() => {
+                          // Handled by parent OptionRow onClick
+                        }}
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                      <Text>{option}</Text>
+                    </OptionRow>
+                  );
+                })}
               </DropdownList>
             )}
           </DropdownWrapper>
         )}
       </FieldWrapper>
       {error && <p style={{ color: "red", paddingLeft: "1rem" }}>{error}</p>}
+      {errorMessage && (
+        <ErrorMessage>
+          <WarningCircle size={20} weight="fill" />
+          {errorMessage}
+        </ErrorMessage>
+      )}
     </EditModeWrapper>
   );
 });

--- a/src/components/EditableField/EditableField.tsx
+++ b/src/components/EditableField/EditableField.tsx
@@ -2,7 +2,6 @@ import { WarningCircle, XCircle } from "@phosphor-icons/react";
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { IoIosArrowDown } from "react-icons/io";
 import styled from "styled-components";
-import { isDefined } from "ts-type-safe";
 
 const EditModeWrapper = styled.div`
   width: 100%;
@@ -297,7 +296,7 @@ export const EditableField = forwardRef(function EditableField<T extends string 
                 setValue(v);
               }}
             />
-            {isDefined(localValue) && (
+            {Boolean(localValue) && (
               <ClearButton
                 type="button"
                 onClick={() => {

--- a/src/components/EditableField/EditableField.tsx
+++ b/src/components/EditableField/EditableField.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { IoIosArrowDown } from "react-icons/io";
+import { X } from "@phosphor-icons/react";
 import styled from "styled-components";
 
 const EditModeWrapper = styled.div`
@@ -34,6 +35,50 @@ const FieldWrapper = styled.div`
     border: var(--editableField-fieldWrapper-input-border);
     flex: 1;
     min-width: 0;
+  }
+`;
+
+const InputWrapper = styled.div<{ $hasError?: boolean }>`
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 1;
+  width: 100%;
+
+  input {
+    border-radius: var(--editableField-fieldWrapper-input-borderRadius);
+    padding: var(--editableField-fieldWrapper-input-padding);
+    padding-right: 48px;
+    color: var(--color-midnight);
+    border: ${(props) =>
+      props.$hasError ? "2px solid var(--color-red-600)" : "var(--editableField-fieldWrapper-input-border)"};
+    flex: 1;
+    min-width: 0;
+    width: 100%;
+
+    &:focus {
+      outline: none;
+      border: ${(props) =>
+        props.$hasError ? "2px solid var(--color-red-600)" : "2px solid var(--color-green-200)"};
+    }
+  }
+`;
+
+const ClearButton = styled.button`
+  position: absolute;
+  right: 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-grey-400);
+  transition: color 0.2s;
+
+  &:hover {
+    color: var(--color-midnight);
   }
 `;
 
@@ -114,6 +159,7 @@ interface EditableFieldProps<T = string | number | string[]> {
   submit?: (value: T) => void | Promise<void>;
   validator?: (value: T) => string | null;
   options?: string[];
+  hasError?: boolean;
 }
 
 export const EditableField = forwardRef(function EditableField<T extends string | number | string[]>(
@@ -126,6 +172,7 @@ export const EditableField = forwardRef(function EditableField<T extends string 
     // submit, // TODO: implement submit (on blur or enter?)
     validator,
     options = [],
+    hasError = false,
   }: EditableFieldProps<T>,
   ref: React.Ref<EditableFieldRef<T>>,
 ) {
@@ -197,27 +244,55 @@ export const EditableField = forwardRef(function EditableField<T extends string 
         {label && <label>{label}: </label>}
 
         {type === "text" && (
-          <input
-            type="text"
-            value={localValue as string}
-            onChange={(e) => {
-              const v = e.target.value as T;
-              setLocalValue(v);
-              setValue(v);
-            }}
-          />
+          <InputWrapper $hasError={hasError}>
+            <input
+              type="text"
+              value={localValue as string}
+              onChange={(e) => {
+                const v = e.target.value as T;
+                setLocalValue(v);
+                setValue(v);
+              }}
+            />
+            {(localValue as string).length > 0 && (
+              <ClearButton
+                type="button"
+                onClick={() => {
+                  const v = "" as T;
+                  setLocalValue(v);
+                  setValue(v);
+                }}
+              >
+                <X size={20} weight="bold" />
+              </ClearButton>
+            )}
+          </InputWrapper>
         )}
 
         {type === "number" && (
-          <input
-            type="number"
-            value={localValue as number}
-            onChange={(e) => {
-              const v = e.target.value as T;
-              setLocalValue(v);
-              setValue(v);
-            }}
-          />
+          <InputWrapper $hasError={hasError}>
+            <input
+              type="number"
+              value={localValue as number}
+              onChange={(e) => {
+                const v = e.target.value as T;
+                setLocalValue(v);
+                setValue(v);
+              }}
+            />
+            {String(localValue).length > 0 && (
+              <ClearButton
+                type="button"
+                onClick={() => {
+                  const v = "" as T;
+                  setLocalValue(v);
+                  setValue(v);
+                }}
+              >
+                <X size={20} weight="bold" />
+              </ClearButton>
+            )}
+          </InputWrapper>
         )}
 
         {(type === "checkbox-list" || type === "radio-list") && (

--- a/src/components/EditableField/EditableField.tsx
+++ b/src/components/EditableField/EditableField.tsx
@@ -201,7 +201,6 @@ interface EditableFieldProps<T = string | number | string[]> {
   submit?: (value: T) => void | Promise<void>;
   validator?: (value: T) => string | null;
   options?: string[];
-  hasError?: boolean;
   errorMessage?: string;
 }
 
@@ -215,7 +214,6 @@ export const EditableField = forwardRef(function EditableField<T extends string 
     // submit, // TODO: implement submit (on blur or enter?)
     validator,
     options = [],
-    hasError = false,
     errorMessage,
   }: EditableFieldProps<T>,
   ref: React.Ref<EditableFieldRef<T>>,
@@ -290,7 +288,7 @@ export const EditableField = forwardRef(function EditableField<T extends string 
         {label && <label>{label}: </label>}
 
         {type === "text" && (
-          <InputWrapper $hasError={hasError}>
+          <InputWrapper $hasError={!!errorMessage}>
             <input
               type="text"
               value={localValue as string}
@@ -316,7 +314,7 @@ export const EditableField = forwardRef(function EditableField<T extends string 
         )}
 
         {type === "number" && (
-          <InputWrapper $hasError={hasError}>
+          <InputWrapper $hasError={!!errorMessage}>
             <input
               type="number"
               value={localValue as number}
@@ -343,7 +341,7 @@ export const EditableField = forwardRef(function EditableField<T extends string 
 
         {(type === "checkbox-list" || type === "radio-list") && (
           <DropdownWrapper ref={wrapperRef}>
-            <DropdownButton $hasError={hasError} onClick={() => setOpen((o) => !o)}>
+            <DropdownButton $hasError={!!errorMessage} onClick={() => setOpen((o) => !o)}>
               <span>
                 {type === "checkbox-list"
                   ? Array.isArray(localValue) && localValue.length > 0

--- a/src/components/core/button/Button/Button.tsx
+++ b/src/components/core/button/Button/Button.tsx
@@ -40,12 +40,27 @@ const StyledButton = styled.button<StyledButtonProps>`
   gap: ${(props) => props.gap};
   padding: ${(props) => props.padding};
   flex-direction: ${(props) => (props.$iconPosition === "right" ? "row-reverse" : "row")};
+  cursor: ${(props) => (props.disabled ? "not-allowed" : "pointer")};
+  transition: background-color 0.2s ease, opacity 0.2s ease;
 
   &:hover {
     background-color: ${(props) => hoverBGColorMap[props.backgroundcolor || defaultBGColor]};
 
     ${ButtonSpan} {
       color: ${(props) => props.$textHoverColor};
+    }
+  }
+
+  &:disabled {
+    background-color: var(--color-grey-200);
+    opacity: 0.6;
+
+    &:hover {
+      background-color: var(--color-grey-200);
+    }
+
+    ${ButtonSpan} {
+      color: var(--color-grey-500);
     }
   }
 `;

--- a/src/hooks/useUpdateVolunteerContact.ts
+++ b/src/hooks/useUpdateVolunteerContact.ts
@@ -1,25 +1,10 @@
-import { ApiVolunteerGet } from "need4deed-sdk";
+import { ApiVolunteerGet, ApiPersonGet } from "need4deed-sdk";
 import { useMutationQuery } from "@/hooks";
 import { apiPathVolunteer } from "@/config/constants";
-
-export type UpdateVolunteerContactData = {
-  person: {
-    id: number;
-    phone?: string;
-    email?: string;
-    address?: {
-      id: string | number;
-      street?: string;
-      city?: string;
-      postcode?: {
-        code?: string;
-      };
-    };
-  };
-};
+import { DeepPartial } from "ts-type-safe";
 
 export const useUpdateVolunteerContact = (volunteerId: number) => {
-  return useMutationQuery<UpdateVolunteerContactData, ApiVolunteerGet>({
+  return useMutationQuery<{ person: DeepPartial<ApiPersonGet> & { id: number } }, ApiVolunteerGet>({
     apiPath: `${apiPathVolunteer}${volunteerId}`,
     method: "patch",
     successMessage: "dashboard.volunteerProfile.contactDetails.saveSuccess",

--- a/src/hooks/useUpdateVolunteerContact.ts
+++ b/src/hooks/useUpdateVolunteerContact.ts
@@ -1,10 +1,10 @@
-import { ApiVolunteerGet, ApiPersonGet } from "need4deed-sdk";
+import { ApiVolunteerGet } from "need4deed-sdk";
 import { useMutationQuery } from "@/hooks";
 import { apiPathVolunteer } from "@/config/constants";
 import { DeepPartial } from "ts-type-safe";
 
 export const useUpdateVolunteerContact = (volunteerId: string) => {
-  return useMutationQuery<{ person: DeepPartial<ApiPersonGet> & { id: number } }, ApiVolunteerGet>({
+  return useMutationQuery<DeepPartial<ApiVolunteerGet>, ApiVolunteerGet>({
     apiPath: `${apiPathVolunteer}${volunteerId}`,
     method: "patch",
     successMessage: "dashboard.volunteerProfile.contactDetails.saveSuccess",

--- a/src/hooks/useUpdateVolunteerContact.ts
+++ b/src/hooks/useUpdateVolunteerContact.ts
@@ -3,7 +3,7 @@ import { useMutationQuery } from "@/hooks";
 import { apiPathVolunteer } from "@/config/constants";
 import { DeepPartial } from "ts-type-safe";
 
-export const useUpdateVolunteerContact = (volunteerId: number) => {
+export const useUpdateVolunteerContact = (volunteerId: string) => {
   return useMutationQuery<{ person: DeepPartial<ApiPersonGet> & { id: number } }, ApiVolunteerGet>({
     apiPath: `${apiPathVolunteer}${volunteerId}`,
     method: "patch",

--- a/src/hooks/useUpdateVolunteerContact.ts
+++ b/src/hooks/useUpdateVolunteerContact.ts
@@ -1,0 +1,28 @@
+import { ApiVolunteerGet } from "need4deed-sdk";
+import { useMutationQuery } from "@/hooks";
+import { apiPathVolunteer } from "@/config/constants";
+
+export type UpdateVolunteerContactData = {
+  person: {
+    id: number;
+    phone?: string;
+    email?: string;
+    address?: {
+      id: string | number;
+      street?: string;
+      city?: string;
+      postcode?: {
+        code?: string;
+      };
+    };
+  };
+};
+
+export const useUpdateVolunteerContact = (volunteerId: number) => {
+  return useMutationQuery<UpdateVolunteerContactData, ApiVolunteerGet>({
+    apiPath: `${apiPathVolunteer}${volunteerId}`,
+    method: "patch",
+    successMessage: "dashboard.volunteerProfile.contactDetails.saveSuccess",
+    queryKeyToInvalidate: ["volunteer", volunteerId],
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2285,10 +2285,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@^0.0.19:
-  version "0.0.19"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.19.tgz#8cbb3444f69f91830ed18e2e77f3d2612a519271"
-  integrity sha512-fPG7lAEAoFqwxc9o+Er/tjvCfY0+tnuv7CnppF4TlxS9Rxs2kSxcz0brgei0UOiOhfP7kDYuuJXA04sPWsqxKw==
+need4deed-sdk@^0.0.23:
+  version "0.0.23"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.23.tgz#179abb5c52b6c1b7027b1d63de2018bdba0c049a"
+  integrity sha512-nkTBNY93yOelGd6rCLDnuUDQQjhALFMCuqDTZ0DDrYjlUsmrMg3oyVENpGMfXfuMyLjzkCbYk4hx+5/ff/FohA==
 
 next@15.3.1:
   version "15.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2969,6 +2969,11 @@ ts-api-utils@^2.1.0:
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.1.0.tgz#595f7094e46eed364c13fd23e75f9513d29baf91"
   integrity sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==
 
+ts-type-safe@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/ts-type-safe/-/ts-type-safe-1.5.0.tgz#92e126411145666ce8ab26a7f1a229787dd117eb"
+  integrity sha512-iQnih1wD7sZ2MQYtpSEIm+TThiVOLjC1jVAHsnHjD8a3Z2OsQQXow38bVXqX1xkBGuYoHhnJbzqPSjywWJcmCA==
+
 tsconfig-paths@^3.15.0:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz#5299ec605e55b1abb23ec939ef15edaf483070d4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2285,10 +2285,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@^0.0.23:
-  version "0.0.23"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.23.tgz#179abb5c52b6c1b7027b1d63de2018bdba0c049a"
-  integrity sha512-nkTBNY93yOelGd6rCLDnuUDQQjhALFMCuqDTZ0DDrYjlUsmrMg3oyVENpGMfXfuMyLjzkCbYk4hx+5/ff/FohA==
+need4deed-sdk@^0.0.24:
+  version "0.0.24"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.24.tgz#fc6a30894a765d9a283df1146ece33be759763a7"
+  integrity sha512-x9Nk2yh7fwIPbLDKU3tlkshG0LqW63LmezZEJU+GEfQWQhZ+oAHt7xhsr8w1sJnVvpLWSkn3rzeeLwUxcDR7LQ==
 
 next@15.3.8:
   version "15.3.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,6 +114,13 @@
     "@eslint/core" "^0.17.0"
     levn "^0.4.1"
 
+"@hookform/resolvers@^5.2.2":
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-5.2.2.tgz#5ac16cd89501ca31671e6e9f0f5c5d762a99aa12"
+  integrity sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==
+  dependencies:
+    "@standard-schema/utils" "^0.3.0"
+
 "@humanfs/core@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.1.tgz#17c55ca7d426733fe3c561906b8173c336b40a77"
@@ -459,6 +466,11 @@
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.14.1.tgz#5f7c5c335643cff62ad8e6a9432d708a9c51e98c"
   integrity sha512-jGTk8UD/RdjsNZW8qq10r0RBvxL8OWtoT+kImlzPDFilmozzM+9QmIJsmze9UiSBrFU45ZxhTYBypn9q9z/VfQ==
+
+"@standard-schema/utils@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/utils/-/utils-0.3.0.tgz#3d5e608f16c2390c10528e98e59aef6bf73cae7b"
+  integrity sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==
 
 "@swc/counter@0.1.3":
   version "0.1.3"
@@ -2503,6 +2515,11 @@ react-dom@^19.0.0:
   dependencies:
     scheduler "^0.27.0"
 
+react-hook-form@^7.68.0:
+  version "7.68.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.68.0.tgz#733c6871fa4ec5e5bfb13e7650a3a912eafe1721"
+  integrity sha512-oNN3fjrZ/Xo40SWlHf1yCjlMK417JxoSJVUXQjGdvdRCU07NTFei1i1f8ApUAts+IVh14e4EdakeLEA+BEAs/Q==
+
 react-i18next@^15.6.1:
   version "15.7.4"
   resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-15.7.4.tgz#146e50f220d204b842e22c75d1a3d23c6c589a30"
@@ -3192,3 +3209,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^4.1.13:
+  version "4.1.13"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.1.13.tgz#93699a8afe937ba96badbb0ce8be6033c0a4b6b1"
+  integrity sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==


### PR DESCRIPTION
## Description
Implements https://github.com/need4deed-org/fe/issues/90

## Required backend changes:

1. PATCH-Request fails without a `city`-column on the `address.entity.ts`.

  Requires something like:

  ```ts
  @Column({ nullable: true })
  @IsString()
  @Length(100)
  city: string;
  ```

2. `waysToContact`: frontend expects and sends array of lowercase string keys, e.g.:                                                                                                                                                                           
  `["whatsapp", "telegram", "mobilePhone", "email", "sms"]`. Frontend uses those string keys for `i18n`.

## Refactoring in subsequent PR

- [ ] Rename `ContactDetails` to `ContactDetailsSection`