### PR TITLE
Fix pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 yarn run lint
-yarn run build
+NODE_ENV=production yarn run build


### PR DESCRIPTION
## Description

Fixes `yarn run buld` which fails without `NODE_ENV=production`:

```sh
yarn run v1.22.22
$ next build
 ⚠ You are using a non-standard "NODE_ENV" value in your environment. This creates inconsistencies in the project and is strongly advised against. Read more: https://nextjs.org/docs/messages/non-standard-node-env
   ▲ Next.js 15.3.8
   - Environments: .env

   Creating an optimized production build ...
 ✓ Compiled successfully in 4.0s
 ✓ Linting and checking validity of types
 ✓ Collecting page data
Error: <Html> should not be imported outside of pages/_document.
Read more: https://nextjs.org/docs/messages/no-document-import-in-page
    at y (.next/server/chunks/548.js:6:1351)
Error occurred prerendering page "/404". Read more: https://nextjs.org/docs/messages/prerender-error
Error: <Html> should not be imported outside of pages/_document.
Read more: https://nextjs.org/docs/messages/no-document-import-in-page
    at K (/Users/USERID/git/privat/need4deed/fe/node_modules/next/dist/compiled/next-server/pages.runtime.prod.js:16:6526)
    at y (/Users/USERID/git/privat/need4deed/fe/.next/server/chunks/548.js:6:1351)
    at Object.react_stack_bottom_frame (/Users/USERID/git/privat/need4deed/fe/node_modules/react-dom/cjs/react-dom-server.edge.development.js:10313:18)
    at renderWithHooks (/Users/USERID/git/privat/need4deed/fe/node_modules/react-dom/cjs/react-dom-server.edge.development.js:5399:19)
    at renderElement (/Users/USERID/git/privat/need4deed/fe/node_modules/react-dom/cjs/react-dom-server.edge.development.js:5834:23)
    at retryNode (/Users/USERID/git/privat/need4deed/fe/node_modules/react-dom/cjs/react-dom-server.edge.development.js:6765:31)
    at renderNodeDestructive (/Users/USERID/git/privat/need4deed/fe/node_modules/react-dom/cjs/react-dom-server.edge.development.js:6715:11)
    at renderElement (/Users/USERID/git/privat/need4deed/fe/node_modules/react-dom/cjs/react-dom-server.edge.development.js:5820:11)
    at retryNode (/Users/USERID/git/privat/need4deed/fe/node_modules/react-dom/cjs/react-dom-server.edge.development.js:6765:31)
    at renderNodeDestructive (/Users/USERID/git/privat/need4deed/fe/node_modules/react-dom/cjs/react-dom-server.edge.development.js:6715:11)
Export encountered an error on /_error: /404, exiting the build.
 ⨯ Next.js build worker exited with code: 1 and signal: null
error Command failed with exit code 1.
```
