### PR TITLE
Fix I18nProvider

### DIFF
--- a/src/config/i18next.tsx
+++ b/src/config/i18next.tsx
@@ -6,7 +6,7 @@ import { initReactI18next, I18nextProvider } from "react-i18next";
 import deTranslation from "../../public/locales/de/translations.json";
 import enTranslation from "../../public/locales/en/translations.json";
 import { Env } from "@/types";
-import { useEffect } from "react";
+import { useMemo } from "react";
 
 i18next.use(initReactI18next).init({
   fallbackLng: Lang.DE,
@@ -24,12 +24,14 @@ interface I18nProviderProps {
 }
 
 export function I18nProvider({ children, initialLang }: I18nProviderProps) {
-  useEffect(() => {
-    // Check if the language actually needs changing to prevent unnecessary calls
+  // Set language synchronously during render to prevent race conditions
+  // with API calls that depend on the language. Using useMemo ensures this
+  // runs before children render but only when initialLang changes.
+  useMemo(() => {
     if (i18next.language !== initialLang) {
       i18next.changeLanguage(initialLang);
     }
-  }, [initialLang]); // Re-run effect only when initialLang changes
+  }, [initialLang]);
 
   return <I18nextProvider i18n={i18next}>{children}</I18nextProvider>;
 }


### PR DESCRIPTION
## Description

Fixes de + en requests for en-locale:

<img width="750" height="84" alt="image" src="https://github.com/user-attachments/assets/79c59549-5d57-4b35-8e6e-94f362b58e86" />


Changed `useEffect` → `useMemo` in `I18nProvider`.                                                                                            
                                                                                                                                          
  - `useEffect` runs AFTER render → children already fired requests with wrong language (de)                                                
  - `useMemo` runs DURING render → language is set before children render                                                                   
                                                                                                                                          
Now when navigating e.g. to `/en/dashboard/opportunities/7`, only one request will fire with `language=en`.

<img width="754" height="71" alt="image" src="https://github.com/user-attachments/assets/2228a926-cb3b-4fe9-af43-af2347dd1581" />
