### PR TITLE
Simplify pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 yarn run lint
-NODE_ENV=production yarn run build
+yarn run typecheck


### PR DESCRIPTION
## Description

Even on my M4 max with 64GB RAM, the build is quite slow and creates massive preassure on file I/O which makes my computer freeze. I don't see the value of running the build on every commit after linting and typechecking / compiling succeeded.