### PR TITLE
Fix API_URL env variable resolution and provide local docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-alpine AS builder
 WORKDIR /app
 
-ARG API_URL
+ARG API_URL=http://localhost:8000
 
 COPY package.json yarn.lock* ./
 RUN yarn install --frozen-lockfile
@@ -9,6 +9,8 @@ RUN yarn install --frozen-lockfile
 COPY . .
 
 ENV API_URL=${API_URL}
+ENV NEXT_TELEMETRY_DISABLED=1
+
 
 RUN yarn build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
 FROM node:22-alpine AS builder
 WORKDIR /app
 
+ARG API_URL
+
 COPY package.json yarn.lock* ./
 RUN yarn install --frozen-lockfile
 
 COPY . .
+
+ENV API_URL=${API_URL}
+
 RUN yarn build
 
 FROM node:22-alpine AS runner
@@ -14,10 +19,10 @@ ENV NODE_ENV=production
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 ENV NEXT_TELEMETRY_DISABLED=1
+
 RUN apk add --no-cache curl
 
-# Copy files (node user already has proper permissions)
-COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/standalone .
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,78 @@
 services:
-  fe:
+
+ be:
+    container_name: be
+    depends_on:
+      bootstrap:
+        condition: service_completed_successfully
+    build:
+      context: ../be
+      args:
+        NODE_ENV: development
+        JWT_SECRET: ${JWT_SECRET:-"dasdasfghghfjghjhgkl"}
+    env_file:
+      - .env
+    environment:
+      - NODE_ENV=development
+      - JWT_SECRET=dasdasfghghfjghjhgkl
+      - CORS_ORIGINS=http://localhost:3000
+      - PORT=8000
+      - DB_HOST=db
+      - DB_PORT=5432
+      - DB_USERNAME=postgres
+      - DB_PASSWORD=postgres
+      - DB_NAME=postgres
+      - DB_SCHEMA=public
+    ports:
+      - 8000:8000
+ bootstrap:
+    container_name: data-bootstrap
+    depends_on:
+      db:
+        condition: service_healthy
+    build:
+      context: ../be/data-bootstrap
+    environment:
+      - DB_HOST=db
+      - DB_PORT=5432
+      - DB_USER=postgres
+      - DB_PASSWORD=postgres
+      - DB_NAME=postgres
+      - DB_SCHEMA=public
+ db:
+    container_name: db
+    image: postgres:17.2
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    volumes:
+      - be_database:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+ fe:
     build:
       context: .
       dockerfile: Dockerfile
       args:
         NODE_ENV: ${NODE_ENV:-development}
+        API_URL: "http://be:8000"
     container_name: fe
     ports:
       - "3000:3000"
     env_file: .env
     environment:
       - NODE_ENV=${NODE_ENV:-development}
-    volumes:
-      - .:/app
-      - /app/node_modules
-    command: >
-      sh -c "yarn install --frozen-lockfile && yarn dev"
-
+      - API_URL=http://localhost:8000
+volumes:
+  be_database:
+    driver: local
 networks:
   n4d-net:
     external: true

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,7 @@ const CLOUDFRONT_HOSTNAME = "d2nwrdddg8skub.cloudfront.net";
 const nextConfig: NextConfig = {
   compiler: {
     styledComponents: true,
-  },
+  }, 
   async rewrites() {
     return [{ source: `/${apiPrefix}/:path*`, destination: `${apiURL}/:path*` }];
   },


### PR DESCRIPTION
## Description
This PR provide:

-  the resolution of the API_URL env variable. It is only evaluated during the build time and not runtime
- local docker setup to run frontend, backend and database. The prerequisite is to have backend (https://github.com/need4deed-org/be) checked out from the parent directory.

## Related Issues
Closes #ISSUE_ID (mandatory if applicable)

## Changes
- Bullet list of meaningful changes (optional)

## Screenshots / Demos
If UI-related, add before/after or GIFs.

## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

