### PR TITLE
Refactor: Extract display and edit modes

### DIFF
--- a/src/components/Dashboard/Profile/sections/Comments/common/Comment.tsx
+++ b/src/components/Dashboard/Profile/sections/Comments/common/Comment.tsx
@@ -1,21 +1,8 @@
 import { formatDateTime } from "@/utils";
-import { DotsThreeOutline } from "@phosphor-icons/react";
 import { TimedText } from "need4deed-sdk";
-import { useTranslation } from "react-i18next";
-import { CommentActionMenu } from "./CommentActionMenu";
-import {
-  AuthorName,
-  CommentContent,
-  CommentEditButtons,
-  CommentItem,
-  CommentText,
-  EditCancelButton,
-  EditSaveButton,
-  MenuAction,
-  TextArea,
-  Timestamp,
-  TopInfo,
-} from "./styles";
+import { CommentDisplay } from "./CommentDisplay";
+import { CommentEdit } from "./CommentEdit";
+import { AuthorName, CommentContent, CommentItem, Timestamp, TopInfo } from "./styles";
 
 type EditState = {
   isActive: boolean;
@@ -45,8 +32,6 @@ type Props = {
 };
 
 export function Comment({ comment, edit, menu }: Props) {
-  const { t } = useTranslation();
-
   return (
     <CommentItem>
       <CommentContent>
@@ -55,49 +40,11 @@ export function Comment({ comment, edit, menu }: Props) {
           <Timestamp>{formatDateTime(comment.timestamp)}</Timestamp>
         </TopInfo>
         {edit.isActive ? (
-          <>
-            <TextArea
-              value={edit.text}
-              onChange={(e) => edit.onTextChange(e.target.value)}
-              onKeyPress={edit.onKeyPress}
-              data-testid={`edit-comment-textarea-${comment.id}`}
-            />
-            <CommentEditButtons>
-              <EditCancelButton onClick={edit.onCancel} data-testid={`cancel-edit-${comment.id}`}>
-                {t("dashboard.commentsSection.cancelEdit")}
-              </EditCancelButton>
-              <EditSaveButton
-                onClick={edit.onSave}
-                disabled={!edit.canSave || edit.isUpdating}
-                data-testid={`save-edit-${comment.id}`}
-              >
-                {t("dashboard.commentsSection.saveEdit")}
-              </EditSaveButton>
-            </CommentEditButtons>
-          </>
+          <CommentEdit commentId={comment.id} edit={edit} />
         ) : (
-          <CommentText>{comment.content}</CommentText>
+          <CommentDisplay commentId={comment.id} content={comment.content} menu={menu} />
         )}
       </CommentContent>
-      {!edit.isActive && (
-        <>
-          <MenuAction
-            ref={menu.buttonRef}
-            onClick={menu.onToggle}
-            aria-label={t("dashboard.commentsSection.menuAction")}
-            data-testid={`comment-menu-${comment.id}`}
-          >
-            <DotsThreeOutline size={24} weight="fill" />
-          </MenuAction>
-          <CommentActionMenu
-            isOpen={menu.isOpen}
-            onClose={menu.onClose}
-            onEdit={menu.onEdit}
-            onDelete={menu.onDelete}
-            anchorElement={menu.anchorElement}
-          />
-        </>
-      )}
     </CommentItem>
   );
 }

--- a/src/components/Dashboard/Profile/sections/Comments/common/CommentDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/Comments/common/CommentDisplay.tsx
@@ -1,0 +1,45 @@
+import { DotsThreeOutline } from "@phosphor-icons/react";
+import { useTranslation } from "react-i18next";
+import { CommentActionMenu } from "./CommentActionMenu";
+import { CommentText, MenuAction } from "./styles";
+
+type MenuState = {
+  isOpen: boolean;
+  anchorElement: HTMLButtonElement | null;
+  buttonRef: (el: HTMLButtonElement | null) => void;
+  onToggle: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onClose: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+};
+
+type Props = {
+  commentId: string | number;
+  content: string;
+  menu: MenuState;
+};
+
+export function CommentDisplay({ commentId, content, menu }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <CommentText>{content}</CommentText>
+      <MenuAction
+        ref={menu.buttonRef}
+        onClick={menu.onToggle}
+        aria-label={t("dashboard.commentsSection.menuAction")}
+        data-testid={`comment-menu-${commentId}`}
+      >
+        <DotsThreeOutline size={24} weight="fill" />
+      </MenuAction>
+      <CommentActionMenu
+        isOpen={menu.isOpen}
+        onClose={menu.onClose}
+        onEdit={menu.onEdit}
+        onDelete={menu.onDelete}
+        anchorElement={menu.anchorElement}
+      />
+    </>
+  );
+}

--- a/src/components/Dashboard/Profile/sections/Comments/common/CommentEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/Comments/common/CommentEdit.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from "react-i18next";
+import { CommentEditButtons, EditCancelButton, EditSaveButton, TextArea } from "./styles";
+
+type EditState = {
+  text: string;
+  canSave: boolean;
+  isUpdating: boolean;
+  onTextChange: (text: string) => void;
+  onKeyPress: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  onSave: () => void;
+  onCancel: () => void;
+};
+
+type Props = {
+  commentId: string | number;
+  edit: EditState;
+};
+
+export function CommentEdit({ commentId, edit }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <TextArea
+        value={edit.text}
+        onChange={(e) => edit.onTextChange(e.target.value)}
+        onKeyPress={edit.onKeyPress}
+        data-testid={`edit-comment-textarea-${commentId}`}
+      />
+      <CommentEditButtons>
+        <EditCancelButton onClick={edit.onCancel} data-testid={`cancel-edit-${commentId}`}>
+          {t("dashboard.commentsSection.cancelEdit")}
+        </EditCancelButton>
+        <EditSaveButton
+          onClick={edit.onSave}
+          disabled={!edit.canSave || edit.isUpdating}
+          data-testid={`save-edit-${commentId}`}
+        >
+          {t("dashboard.commentsSection.saveEdit")}
+        </EditSaveButton>
+      </CommentEditButtons>
+    </>
+  );
+}

--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
@@ -1,19 +1,19 @@
 "use client";
-import Button from "@/components/core/button/Button/Button";
-import { EditableField } from "@/components/EditableField/EditableField";
 import { useUpdateOpportunityContact } from "@/hooks/useUpdateOpportunityContact";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ApiOpportunityGet, PreferredCommunicationType } from "need4deed-sdk";
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { FormButtonRow, FormContainer, FormDetails } from "../../shared/styles";
+import { FormContainer } from "../../shared/styles";
 import { EditableSectionRef } from "../../shared/types";
 import { useEnumTranslation } from "../shared";
 import {
   createOpportunityContactDetailsSchema,
   OpportunityContactDetailsFormData,
 } from "./opportunityContactDetailsSchema";
+import { OpportunityContactDetailsDisplay } from "./OpportunityContactDetailsDisplay";
+import { OpportunityContactDetailsEdit } from "./OpportunityContactDetailsEdit";
 
 type Props = {
   opportunity: ApiOpportunityGet;
@@ -38,16 +38,13 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
 
   const initialFormValues = opportunity.contact;
 
-  const {
-    control,
-    handleSubmit,
-    reset,
-    formState: { errors, isValid, isDirty },
-  } = useForm<OpportunityContactDetailsFormData>({
+  const methods = useForm<OpportunityContactDetailsFormData>({
     resolver: zodResolver(schema),
     mode: "onChange",
     defaultValues: initialFormValues,
   });
+
+  const { handleSubmit, reset, watch } = methods;
 
   const handleEditClick = () => setIsEditing(true);
 
@@ -78,93 +75,27 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
     }
   }, [initialFormValues, isEditing, reset]);
 
-  const mode = isEditing ? "edit" : "display";
+  const formValues = watch();
 
   return (
-    <FormContainer data-testid="opportunity-contact-details-container" $isEditing={isEditing}>
-      <FormDetails>
-        <Controller
-          name="name"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="text"
-              label={t("dashboard.opportunityProfile.contactDetails.name")}
-              value={field.value}
-              setValue={field.onChange}
-              errorMessage={errors.name?.message}
-            />
-          )}
-        />
-
-        <Controller
-          name="phone"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="text"
-              label={t("dashboard.opportunityProfile.contactDetails.phone")}
-              value={field.value}
-              setValue={field.onChange}
-              errorMessage={errors.phone?.message}
-            />
-          )}
-        />
-
-        <Controller
-          name="email"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="text"
-              label={t("dashboard.opportunityProfile.contactDetails.email")}
-              value={field.value}
-              setValue={field.onChange}
-              errorMessage={errors.email?.message}
-            />
-          )}
-        />
-
-        <Controller
-          name="waysToContact"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="checkbox-list"
-              label={t("dashboard.opportunityProfile.contactDetails.waysToContact.label")}
-              value={keysToLabels(field.value)}
-              setValue={(value) => field.onChange(labelsToKeys(Array.isArray(value) ? value : [value]))}
-              options={options}
-              errorMessage={errors.waysToContact?.message}
-            />
-          )}
-        />
-      </FormDetails>
-
-      {isEditing && (
-        <FormButtonRow>
-          <Button
-            text={t("dashboard.opportunityProfile.contactDetails.cancel")}
-            onClick={handleCancel}
-            width="auto"
-            padding="var(--volunteer-profile-section-card-header-button-padding)"
-            backgroundcolor="var(--color-white)"
-            textColor="var(--color-aubergine)"
-            border="var(--volunteer-profile-section-card-header-button-border)"
+    <FormProvider {...methods}>
+      <FormContainer data-testid="opportunity-contact-details-container" $isEditing={isEditing}>
+        {isEditing ? (
+          <OpportunityContactDetailsEdit
+            options={options}
+            keysToLabels={keysToLabels as (keys: string[]) => string[]}
+            labelsToKeys={labelsToKeys as (labels: (string | number)[]) => string[]}
+            onCancel={handleCancel}
+            onSubmit={handleSubmit(onSubmit)}
+            isPending={isPending}
           />
-          <Button
-            text={t("dashboard.opportunityProfile.contactDetails.saveChanges")}
-            onClick={handleSubmit(onSubmit)}
-            width="auto"
-            padding="var(--volunteer-profile-section-card-header-button-padding)"
-            disabled={!isDirty || !isValid || isPending}
+        ) : (
+          <OpportunityContactDetailsDisplay
+            values={formValues}
+            waysToContactLabels={keysToLabels(formValues.waysToContact ?? [])}
           />
-        </FormButtonRow>
-      )}
-    </FormContainer>
+        )}
+      </FormContainer>
+    </FormProvider>
   );
 });

--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
@@ -44,7 +44,7 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
     defaultValues: initialFormValues,
   });
 
-  const { handleSubmit, reset, watch } = methods;
+  const { handleSubmit, reset } = methods;
 
   const handleEditClick = () => setIsEditing(true);
 
@@ -75,8 +75,6 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
     }
   }, [initialFormValues, isEditing, reset]);
 
-  const formValues = watch();
-
   return (
     <FormProvider {...methods}>
       <FormContainer data-testid="opportunity-contact-details-container" $isEditing={isEditing}>
@@ -90,10 +88,7 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
             isPending={isPending}
           />
         ) : (
-          <OpportunityContactDetailsDisplay
-            values={formValues}
-            waysToContactLabels={keysToLabels(formValues.waysToContact ?? [])}
-          />
+          <OpportunityContactDetailsDisplay keysToLabels={keysToLabels} />
         )}
       </FormContainer>
     </FormProvider>

--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
@@ -83,8 +83,8 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
         {isEditing ? (
           <OpportunityContactDetailsEdit
             options={options}
-            keysToLabels={keysToLabels as (keys: string[]) => string[]}
-            labelsToKeys={labelsToKeys as (labels: (string | number)[]) => string[]}
+            keysToLabels={keysToLabels}
+            labelsToKeys={labelsToKeys}
             onCancel={handleCancel}
             onSubmit={handleSubmit(onSubmit)}
             isPending={isPending}

--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetailsDisplay.tsx
@@ -1,0 +1,50 @@
+import { EditableField } from "@/components/EditableField/EditableField";
+import { useTranslation } from "react-i18next";
+import { FormDetails } from "../../shared/styles";
+import { OpportunityContactDetailsFormData } from "./opportunityContactDetailsSchema";
+
+type Props = {
+  values: OpportunityContactDetailsFormData;
+  waysToContactLabels: string[];
+};
+
+export const OpportunityContactDetailsDisplay = ({ values, waysToContactLabels }: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <FormDetails data-testid="opportunity-contact-details-display">
+      <EditableField
+        mode="display"
+        type="text"
+        label={t("dashboard.opportunityProfile.contactDetails.name")}
+        value={values.name}
+        setValue={() => {}}
+      />
+
+      <EditableField
+        mode="display"
+        type="text"
+        label={t("dashboard.opportunityProfile.contactDetails.phone")}
+        value={values.phone}
+        setValue={() => {}}
+      />
+
+      <EditableField
+        mode="display"
+        type="text"
+        label={t("dashboard.opportunityProfile.contactDetails.email")}
+        value={values.email}
+        setValue={() => {}}
+      />
+
+      <EditableField
+        mode="display"
+        type="checkbox-list"
+        label={t("dashboard.opportunityProfile.contactDetails.waysToContact.label")}
+        value={waysToContactLabels}
+        setValue={() => {}}
+        options={[]}
+      />
+    </FormDetails>
+  );
+};

--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetailsDisplay.tsx
@@ -1,15 +1,18 @@
 import { EditableField } from "@/components/EditableField/EditableField";
+import { PreferredCommunicationType } from "need4deed-sdk";
+import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FormDetails } from "../../shared/styles";
 import { OpportunityContactDetailsFormData } from "./opportunityContactDetailsSchema";
 
 type Props = {
-  values: OpportunityContactDetailsFormData;
-  waysToContactLabels: string[];
+  keysToLabels: (keys: PreferredCommunicationType[]) => string[];
 };
 
-export const OpportunityContactDetailsDisplay = ({ values, waysToContactLabels }: Props) => {
+export const OpportunityContactDetailsDisplay = ({ keysToLabels }: Props) => {
   const { t } = useTranslation();
+  const { watch } = useFormContext<OpportunityContactDetailsFormData>();
+  const values = watch();
 
   return (
     <FormDetails data-testid="opportunity-contact-details-display">
@@ -41,7 +44,7 @@ export const OpportunityContactDetailsDisplay = ({ values, waysToContactLabels }
         mode="display"
         type="checkbox-list"
         label={t("dashboard.opportunityProfile.contactDetails.waysToContact.label")}
-        value={waysToContactLabels}
+        value={keysToLabels(values.waysToContact ?? [])}
         setValue={() => {}}
         options={[]}
       />

--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetailsEdit.tsx
@@ -1,5 +1,6 @@
 import Button from "@/components/core/button/Button/Button";
 import { EditableField } from "@/components/EditableField/EditableField";
+import { PreferredCommunicationType } from "need4deed-sdk";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FormButtonRow, FormDetails } from "../../shared/styles";
@@ -7,8 +8,8 @@ import { OpportunityContactDetailsFormData } from "./opportunityContactDetailsSc
 
 type Props = {
   options: string[];
-  keysToLabels: (keys: string[]) => string[];
-  labelsToKeys: (labels: (string | number)[]) => string[];
+  keysToLabels: (keys: PreferredCommunicationType[]) => string[];
+  labelsToKeys: (labels: (string | number)[]) => PreferredCommunicationType[];
   onCancel: () => void;
   onSubmit: () => void;
   isPending: boolean;

--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetailsEdit.tsx
@@ -1,0 +1,116 @@
+import Button from "@/components/core/button/Button/Button";
+import { EditableField } from "@/components/EditableField/EditableField";
+import { Controller, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { FormButtonRow, FormDetails } from "../../shared/styles";
+import { OpportunityContactDetailsFormData } from "./opportunityContactDetailsSchema";
+
+type Props = {
+  options: string[];
+  keysToLabels: (keys: string[]) => string[];
+  labelsToKeys: (labels: (string | number)[]) => string[];
+  onCancel: () => void;
+  onSubmit: () => void;
+  isPending: boolean;
+};
+
+export const OpportunityContactDetailsEdit = ({
+  options,
+  keysToLabels,
+  labelsToKeys,
+  onCancel,
+  onSubmit,
+  isPending,
+}: Props) => {
+  const { t } = useTranslation();
+  const {
+    control,
+    formState: { errors, isValid, isDirty },
+  } = useFormContext<OpportunityContactDetailsFormData>();
+
+  return (
+    <>
+      <FormDetails data-testid="opportunity-contact-details-edit">
+        <Controller
+          name="name"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t("dashboard.opportunityProfile.contactDetails.name")}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.name?.message}
+            />
+          )}
+        />
+
+        <Controller
+          name="phone"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t("dashboard.opportunityProfile.contactDetails.phone")}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.phone?.message}
+            />
+          )}
+        />
+
+        <Controller
+          name="email"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t("dashboard.opportunityProfile.contactDetails.email")}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.email?.message}
+            />
+          )}
+        />
+
+        <Controller
+          name="waysToContact"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="checkbox-list"
+              label={t("dashboard.opportunityProfile.contactDetails.waysToContact.label")}
+              value={keysToLabels(field.value)}
+              setValue={(value) => field.onChange(labelsToKeys(Array.isArray(value) ? value : [value]))}
+              options={options}
+              errorMessage={errors.waysToContact?.message}
+            />
+          )}
+        />
+      </FormDetails>
+
+      <FormButtonRow>
+        <Button
+          text={t("dashboard.opportunityProfile.contactDetails.cancel")}
+          onClick={onCancel}
+          width="auto"
+          padding="var(--volunteer-profile-section-card-header-button-padding)"
+          backgroundcolor="var(--color-white)"
+          textColor="var(--color-aubergine)"
+          border="var(--volunteer-profile-section-card-header-button-border)"
+        />
+        <Button
+          text={t("dashboard.opportunityProfile.contactDetails.saveChanges")}
+          onClick={onSubmit}
+          width="auto"
+          padding="var(--volunteer-profile-section-card-header-button-padding)"
+          disabled={!isDirty || !isValid || isPending}
+        />
+      </FormButtonRow>
+    </>
+  );
+};

--- a/src/components/Dashboard/Profile/sections/ContactDetails/volunteer/VolunteerContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/volunteer/VolunteerContactDetails.tsx
@@ -1,17 +1,17 @@
 "use client";
-import Button from "@/components/core/button/Button/Button";
-import { EditableField } from "@/components/EditableField/EditableField";
 import { useUpdateVolunteerContact } from "@/hooks/useUpdateVolunteerContact";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ApiVolunteerGet, VolunteerCommunicationType } from "need4deed-sdk";
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { FormButtonRow, FormContainer, FormDetails } from "../../shared/styles";
+import { FormContainer } from "../../shared/styles";
 import { EditableSectionRef } from "../../shared/types";
 import { useEnumTranslation } from "../shared";
 import { formatAddress, parseAddress } from "./volunteerAddressUtils";
 import { createVolunteerContactDetailsSchema, VolunteerContactDetailsFormData } from "./volunteerContactDetailsSchema";
+import { VolunteerContactDetailsDisplay } from "./VolunteerContactDetailsDisplay";
+import { VolunteerContactDetailsEdit } from "./VolunteerContactDetailsEdit";
 
 type Props = {
   volunteer: ApiVolunteerGet;
@@ -44,16 +44,13 @@ export const VolunteerContactDetails = forwardRef<EditableSectionRef, Props>(fun
     [volunteer],
   );
 
-  const {
-    control,
-    handleSubmit,
-    reset,
-    formState: { errors, isValid, isDirty },
-  } = useForm<VolunteerContactDetailsFormData>({
+  const methods = useForm<VolunteerContactDetailsFormData>({
     resolver: zodResolver(schema),
     mode: "onChange",
     defaultValues: initialFormValues,
   });
+
+  const { handleSubmit, reset, watch } = methods;
 
   const handleEditClick = () => setIsEditing(true);
 
@@ -89,93 +86,27 @@ export const VolunteerContactDetails = forwardRef<EditableSectionRef, Props>(fun
     reset(initialFormValues);
   }, [initialFormValues, isEditing, reset]);
 
-  const mode = isEditing ? "edit" : "display";
+  const formValues = watch();
 
   return (
-    <FormContainer data-testid="volunteer-contact-details-container" $isEditing={isEditing}>
-      <FormDetails>
-        <Controller
-          name="phone"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="text"
-              label={t("dashboard.volunteerProfile.contactDetails.phone")}
-              value={field.value}
-              setValue={field.onChange}
-              errorMessage={errors.phone?.message}
-            />
-          )}
-        />
-
-        <Controller
-          name="email"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="text"
-              label={t("dashboard.volunteerProfile.contactDetails.email")}
-              value={field.value}
-              setValue={field.onChange}
-              errorMessage={errors.email?.message}
-            />
-          )}
-        />
-
-        <Controller
-          name="address"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="text"
-              label={t("dashboard.volunteerProfile.contactDetails.address")}
-              value={field.value}
-              setValue={field.onChange}
-              errorMessage={errors.address?.message}
-            />
-          )}
-        />
-
-        <Controller
-          name="preferredCommunicationType"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="checkbox-list"
-              label={t("dashboard.volunteerProfile.contactDetails.preferredCommunicationType.label")}
-              value={keysToLabels(field.value)}
-              setValue={(value) => field.onChange(labelsToKeys(Array.isArray(value) ? value : [value]))}
-              options={options}
-              errorMessage={errors.preferredCommunicationType?.message}
-            />
-          )}
-        />
-      </FormDetails>
-
-      {isEditing && (
-        <FormButtonRow>
-          <Button
-            text={t("dashboard.volunteerProfile.contactDetails.cancel")}
-            onClick={handleCancel}
-            width="auto"
-            padding="var(--volunteer-profile-section-card-header-button-padding)"
-            backgroundcolor="var(--color-white)"
-            textColor="var(--color-aubergine)"
-            border="var(--volunteer-profile-section-card-header-button-border)"
+    <FormProvider {...methods}>
+      <FormContainer data-testid="volunteer-contact-details-container" $isEditing={isEditing}>
+        {isEditing ? (
+          <VolunteerContactDetailsEdit
+            options={options}
+            keysToLabels={keysToLabels as (keys: string[]) => string[]}
+            labelsToKeys={labelsToKeys as (labels: (string | number)[]) => string[]}
+            onCancel={handleCancel}
+            onSubmit={handleSubmit(onSubmit)}
+            isPending={isPending}
           />
-          <Button
-            text={t("dashboard.volunteerProfile.contactDetails.saveChanges")}
-            onClick={handleSubmit(onSubmit)}
-            width="auto"
-            padding="var(--volunteer-profile-section-card-header-button-padding)"
-            disabled={!isDirty || !isValid || isPending}
+        ) : (
+          <VolunteerContactDetailsDisplay
+            values={formValues}
+            communicationTypeLabels={keysToLabels(formValues.preferredCommunicationType ?? [])}
           />
-        </FormButtonRow>
-      )}
-    </FormContainer>
+        )}
+      </FormContainer>
+    </FormProvider>
   );
 });

--- a/src/components/Dashboard/Profile/sections/ContactDetails/volunteer/VolunteerContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/volunteer/VolunteerContactDetails.tsx
@@ -50,7 +50,7 @@ export const VolunteerContactDetails = forwardRef<EditableSectionRef, Props>(fun
     defaultValues: initialFormValues,
   });
 
-  const { handleSubmit, reset, watch } = methods;
+  const { handleSubmit, reset } = methods;
 
   const handleEditClick = () => setIsEditing(true);
 
@@ -86,8 +86,6 @@ export const VolunteerContactDetails = forwardRef<EditableSectionRef, Props>(fun
     reset(initialFormValues);
   }, [initialFormValues, isEditing, reset]);
 
-  const formValues = watch();
-
   return (
     <FormProvider {...methods}>
       <FormContainer data-testid="volunteer-contact-details-container" $isEditing={isEditing}>
@@ -101,10 +99,7 @@ export const VolunteerContactDetails = forwardRef<EditableSectionRef, Props>(fun
             isPending={isPending}
           />
         ) : (
-          <VolunteerContactDetailsDisplay
-            values={formValues}
-            communicationTypeLabels={keysToLabels(formValues.preferredCommunicationType ?? [])}
-          />
+          <VolunteerContactDetailsDisplay keysToLabels={keysToLabels} />
         )}
       </FormContainer>
     </FormProvider>

--- a/src/components/Dashboard/Profile/sections/ContactDetails/volunteer/VolunteerContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/volunteer/VolunteerContactDetails.tsx
@@ -94,8 +94,8 @@ export const VolunteerContactDetails = forwardRef<EditableSectionRef, Props>(fun
         {isEditing ? (
           <VolunteerContactDetailsEdit
             options={options}
-            keysToLabels={keysToLabels as (keys: string[]) => string[]}
-            labelsToKeys={labelsToKeys as (labels: (string | number)[]) => string[]}
+            keysToLabels={keysToLabels}
+            labelsToKeys={labelsToKeys}
             onCancel={handleCancel}
             onSubmit={handleSubmit(onSubmit)}
             isPending={isPending}

--- a/src/components/Dashboard/Profile/sections/ContactDetails/volunteer/VolunteerContactDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/volunteer/VolunteerContactDetailsDisplay.tsx
@@ -1,15 +1,18 @@
 import { EditableField } from "@/components/EditableField/EditableField";
+import { VolunteerCommunicationType } from "need4deed-sdk";
+import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FormDetails } from "../../shared/styles";
 import { VolunteerContactDetailsFormData } from "./volunteerContactDetailsSchema";
 
 type Props = {
-  values: VolunteerContactDetailsFormData;
-  communicationTypeLabels: string[];
+  keysToLabels: (keys: VolunteerCommunicationType[]) => string[];
 };
 
-export const VolunteerContactDetailsDisplay = ({ values, communicationTypeLabels }: Props) => {
+export const VolunteerContactDetailsDisplay = ({ keysToLabels }: Props) => {
   const { t } = useTranslation();
+  const { watch } = useFormContext<VolunteerContactDetailsFormData>();
+  const values = watch();
 
   return (
     <FormDetails data-testid="volunteer-contact-details-display">
@@ -41,7 +44,7 @@ export const VolunteerContactDetailsDisplay = ({ values, communicationTypeLabels
         mode="display"
         type="checkbox-list"
         label={t("dashboard.volunteerProfile.contactDetails.preferredCommunicationType.label")}
-        value={communicationTypeLabels}
+        value={keysToLabels(values.preferredCommunicationType ?? [])}
         setValue={() => {}}
         options={[]}
       />

--- a/src/components/Dashboard/Profile/sections/ContactDetails/volunteer/VolunteerContactDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/volunteer/VolunteerContactDetailsDisplay.tsx
@@ -1,0 +1,50 @@
+import { EditableField } from "@/components/EditableField/EditableField";
+import { useTranslation } from "react-i18next";
+import { FormDetails } from "../../shared/styles";
+import { VolunteerContactDetailsFormData } from "./volunteerContactDetailsSchema";
+
+type Props = {
+  values: VolunteerContactDetailsFormData;
+  communicationTypeLabels: string[];
+};
+
+export const VolunteerContactDetailsDisplay = ({ values, communicationTypeLabels }: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <FormDetails data-testid="volunteer-contact-details-display">
+      <EditableField
+        mode="display"
+        type="text"
+        label={t("dashboard.volunteerProfile.contactDetails.phone")}
+        value={values.phone}
+        setValue={() => {}}
+      />
+
+      <EditableField
+        mode="display"
+        type="text"
+        label={t("dashboard.volunteerProfile.contactDetails.email")}
+        value={values.email}
+        setValue={() => {}}
+      />
+
+      <EditableField
+        mode="display"
+        type="text"
+        label={t("dashboard.volunteerProfile.contactDetails.address")}
+        value={values.address}
+        setValue={() => {}}
+      />
+
+      <EditableField
+        mode="display"
+        type="checkbox-list"
+        label={t("dashboard.volunteerProfile.contactDetails.preferredCommunicationType.label")}
+        value={communicationTypeLabels}
+        setValue={() => {}}
+        options={[]}
+      />
+    </FormDetails>
+  );
+};

--- a/src/components/Dashboard/Profile/sections/ContactDetails/volunteer/VolunteerContactDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/volunteer/VolunteerContactDetailsEdit.tsx
@@ -1,0 +1,116 @@
+import Button from "@/components/core/button/Button/Button";
+import { EditableField } from "@/components/EditableField/EditableField";
+import { Controller, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { FormButtonRow, FormDetails } from "../../shared/styles";
+import { VolunteerContactDetailsFormData } from "./volunteerContactDetailsSchema";
+
+type Props = {
+  options: string[];
+  keysToLabels: (keys: string[]) => string[];
+  labelsToKeys: (labels: (string | number)[]) => string[];
+  onCancel: () => void;
+  onSubmit: () => void;
+  isPending: boolean;
+};
+
+export const VolunteerContactDetailsEdit = ({
+  options,
+  keysToLabels,
+  labelsToKeys,
+  onCancel,
+  onSubmit,
+  isPending,
+}: Props) => {
+  const { t } = useTranslation();
+  const {
+    control,
+    formState: { errors, isValid, isDirty },
+  } = useFormContext<VolunteerContactDetailsFormData>();
+
+  return (
+    <>
+      <FormDetails data-testid="volunteer-contact-details-edit">
+        <Controller
+          name="phone"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t("dashboard.volunteerProfile.contactDetails.phone")}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.phone?.message}
+            />
+          )}
+        />
+
+        <Controller
+          name="email"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t("dashboard.volunteerProfile.contactDetails.email")}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.email?.message}
+            />
+          )}
+        />
+
+        <Controller
+          name="address"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t("dashboard.volunteerProfile.contactDetails.address")}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.address?.message}
+            />
+          )}
+        />
+
+        <Controller
+          name="preferredCommunicationType"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="checkbox-list"
+              label={t("dashboard.volunteerProfile.contactDetails.preferredCommunicationType.label")}
+              value={keysToLabels(field.value)}
+              setValue={(value) => field.onChange(labelsToKeys(Array.isArray(value) ? value : [value]))}
+              options={options}
+              errorMessage={errors.preferredCommunicationType?.message}
+            />
+          )}
+        />
+      </FormDetails>
+
+      <FormButtonRow>
+        <Button
+          text={t("dashboard.volunteerProfile.contactDetails.cancel")}
+          onClick={onCancel}
+          width="auto"
+          padding="var(--volunteer-profile-section-card-header-button-padding)"
+          backgroundcolor="var(--color-white)"
+          textColor="var(--color-aubergine)"
+          border="var(--volunteer-profile-section-card-header-button-border)"
+        />
+        <Button
+          text={t("dashboard.volunteerProfile.contactDetails.saveChanges")}
+          onClick={onSubmit}
+          width="auto"
+          padding="var(--volunteer-profile-section-card-header-button-padding)"
+          disabled={!isDirty || !isValid || isPending}
+        />
+      </FormButtonRow>
+    </>
+  );
+};

--- a/src/components/Dashboard/Profile/sections/ContactDetails/volunteer/VolunteerContactDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/volunteer/VolunteerContactDetailsEdit.tsx
@@ -1,5 +1,6 @@
 import Button from "@/components/core/button/Button/Button";
 import { EditableField } from "@/components/EditableField/EditableField";
+import { VolunteerCommunicationType } from "need4deed-sdk";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FormButtonRow, FormDetails } from "../../shared/styles";
@@ -7,8 +8,8 @@ import { VolunteerContactDetailsFormData } from "./volunteerContactDetailsSchema
 
 type Props = {
   options: string[];
-  keysToLabels: (keys: string[]) => string[];
-  labelsToKeys: (labels: (string | number)[]) => string[];
+  keysToLabels: (keys: VolunteerCommunicationType[]) => string[];
+  labelsToKeys: (labels: (string | number)[]) => VolunteerCommunicationType[];
   onCancel: () => void;
   onSubmit: () => void;
   isPending: boolean;

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
@@ -7,7 +7,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FormContainer } from "../shared/styles";
 import { EditableSectionRef } from "../shared/types";
-import { apiLanguagesToFormValues, clientLanguagesToDisplay, toLanguagesForForm } from "./formatters";
+import { apiLanguagesToFormValues, toLanguagesForForm } from "./formatters";
 import { createOrganisationDetailsSchema, OrganisationDetailsFormData } from "./organisationDetailsSchema";
 import { OrganisationDetailsDisplay } from "./OrganisationDetailsDisplay";
 import { OrganisationDetailsEdit } from "./OrganisationDetailsEdit";
@@ -36,7 +36,7 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
     defaultValues: initialFormValues,
   });
 
-  const { handleSubmit, reset, watch } = methods;
+  const { handleSubmit, reset } = methods;
 
   const handleEditClick = () => setIsEditing(true);
 
@@ -51,8 +51,6 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
     setIsEditing(false);
   };
 
-  const formValues = watch();
-
   return (
     <FormProvider {...methods}>
       <FormContainer data-testid="organisation-details-container" $isEditing={isEditing}>
@@ -63,10 +61,7 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
             onSubmit={handleSubmit(onSubmit)}
           />
         ) : (
-          <OrganisationDetailsDisplay
-            values={formValues}
-            clientLanguagesDisplay={clientLanguagesToDisplay(details?.clientLanguages)}
-          />
+          <OrganisationDetailsDisplay rawClientLanguages={details?.clientLanguages} />
         )}
       </FormContainer>
     </FormProvider>

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
@@ -1,20 +1,16 @@
 "use client";
-import Button from "@/components/core/button/Button/Button";
-import { ErrorMessage } from "@/components/core/common";
 import { ApiAgentProfileGet } from "@/components/Dashboard/Profile/types";
-import { EditableField } from "@/components/EditableField/EditableField";
-import { LanguageFields } from "@/components/forms/LanguageFields";
 import { useApiLanguages } from "@/components/Dashboard/Profile/sections/VolunteerProfile/hooks";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { forwardRef, useImperativeHandle, useState } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { FormButtonRow, FormContainer, FormDetails } from "../shared/styles";
+import { FormContainer } from "../shared/styles";
 import { EditableSectionRef } from "../shared/types";
 import { apiLanguagesToFormValues, clientLanguagesToDisplay, toLanguagesForForm } from "./formatters";
 import { createOrganisationDetailsSchema, OrganisationDetailsFormData } from "./organisationDetailsSchema";
-
-const i18nPrefix = "dashboard.agentProfile.organisationDetails";
+import { OrganisationDetailsDisplay } from "./OrganisationDetailsDisplay";
+import { OrganisationDetailsEdit } from "./OrganisationDetailsEdit";
 
 type Props = {
   agent: ApiAgentProfileGet;
@@ -34,16 +30,13 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
     clientLanguages: apiLanguagesToFormValues(details?.clientLanguages),
   };
 
-  const {
-    control,
-    handleSubmit,
-    reset,
-    formState: { errors, isDirty, isValid },
-  } = useForm<OrganisationDetailsFormData>({
+  const methods = useForm<OrganisationDetailsFormData>({
     resolver: zodResolver(schema),
     mode: "onChange",
     defaultValues: initialFormValues,
   });
+
+  const { handleSubmit, reset, watch } = methods;
 
   const handleEditClick = () => setIsEditing(true);
 
@@ -58,145 +51,24 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
     setIsEditing(false);
   };
 
-  const mode = isEditing ? "edit" : "display";
+  const formValues = watch();
 
   return (
-    <FormContainer data-testid="organisation-details-container" $isEditing={isEditing}>
-      <FormDetails>
-        <Controller
-          name="about"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="text"
-              label={t(`${i18nPrefix}.about`)}
-              value={field.value}
-              setValue={field.onChange}
-              errorMessage={errors.about?.message}
-            />
-          )}
-        />
-        <Controller
-          name="website"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="text"
-              label={t(`${i18nPrefix}.website`)}
-              value={field.value}
-              setValue={field.onChange}
-              errorMessage={errors.website?.message}
-            />
-          )}
-        />
-        <Controller
-          name="address"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="text"
-              label={t(`${i18nPrefix}.address`)}
-              value={field.value}
-              setValue={field.onChange}
-              errorMessage={errors.address?.message}
-            />
-          )}
-        />
-        <Controller
-          name="organisationType"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="text"
-              label={t(`${i18nPrefix}.organisationType`)}
-              value={field.value}
-              setValue={field.onChange}
-              errorMessage={errors.organisationType?.message}
-            />
-          )}
-        />
-        <Controller
-          name="operator"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="text"
-              label={t(`${i18nPrefix}.operator`)}
-              value={field.value}
-              setValue={field.onChange}
-              errorMessage={errors.operator?.message}
-            />
-          )}
-        />
-        <Controller
-          name="services"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="text"
-              label={t(`${i18nPrefix}.services`)}
-              value={field.value}
-              setValue={field.onChange}
-              errorMessage={errors.services?.message}
-            />
-          )}
-        />
+    <FormProvider {...methods}>
+      <FormContainer data-testid="organisation-details-container" $isEditing={isEditing}>
         {isEditing ? (
-          <Controller
-            name="clientLanguages"
-            control={control}
-            render={({ field }) => (
-              <>
-                <LanguageFields
-                  languages={field.value}
-                  onChange={field.onChange}
-                  t={t}
-                  availableLanguages={languagesForForm}
-                  showLevel={false}
-                />
-                {errors.clientLanguages?.message && (
-                  <ErrorMessage message={errors.clientLanguages.message} />
-                )}
-              </>
-            )}
+          <OrganisationDetailsEdit
+            languagesForForm={languagesForForm}
+            onCancel={handleCancel}
+            onSubmit={handleSubmit(onSubmit)}
           />
         ) : (
-          <EditableField
-            mode="display"
-            type="text"
-            label={t(`${i18nPrefix}.clientLanguages`)}
-            value={clientLanguagesToDisplay(details?.clientLanguages)}
-            setValue={() => {}}
+          <OrganisationDetailsDisplay
+            values={formValues}
+            clientLanguagesDisplay={clientLanguagesToDisplay(details?.clientLanguages)}
           />
         )}
-      </FormDetails>
-
-      {isEditing && (
-        <FormButtonRow>
-          <Button
-            text={t(`${i18nPrefix}.cancel`)}
-            onClick={handleCancel}
-            width="auto"
-            padding="var(--volunteer-profile-section-card-header-button-padding)"
-            backgroundcolor="var(--color-white)"
-            textColor="var(--color-aubergine)"
-            border="var(--volunteer-profile-section-card-header-button-border)"
-          />
-          <Button
-            text={t(`${i18nPrefix}.saveChanges`)}
-            onClick={handleSubmit(onSubmit)}
-            width="auto"
-            padding="var(--volunteer-profile-section-card-header-button-padding)"
-            disabled={!isDirty || !isValid}
-          />
-        </FormButtonRow>
-      )}
-    </FormContainer>
+      </FormContainer>
+    </FormProvider>
   );
 });

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsDisplay.tsx
@@ -1,17 +1,20 @@
 import { EditableField } from "@/components/EditableField/EditableField";
+import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FormDetails } from "../shared/styles";
+import { clientLanguagesToDisplay } from "./formatters";
 import { OrganisationDetailsFormData } from "./organisationDetailsSchema";
 
 const i18nPrefix = "dashboard.agentProfile.organisationDetails";
 
 type Props = {
-  values: OrganisationDetailsFormData;
-  clientLanguagesDisplay: string;
+  rawClientLanguages?: Array<{ id: number; title: string }>;
 };
 
-export const OrganisationDetailsDisplay = ({ values, clientLanguagesDisplay }: Props) => {
+export const OrganisationDetailsDisplay = ({ rawClientLanguages }: Props) => {
   const { t } = useTranslation();
+  const { watch } = useFormContext<OrganisationDetailsFormData>();
+  const values = watch();
 
   return (
     <FormDetails data-testid="organisation-details-display">
@@ -61,7 +64,7 @@ export const OrganisationDetailsDisplay = ({ values, clientLanguagesDisplay }: P
         mode="display"
         type="text"
         label={t(`${i18nPrefix}.clientLanguages`)}
-        value={clientLanguagesDisplay}
+        value={clientLanguagesToDisplay(rawClientLanguages)}
         setValue={() => {}}
       />
     </FormDetails>

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsDisplay.tsx
@@ -1,0 +1,69 @@
+import { EditableField } from "@/components/EditableField/EditableField";
+import { useTranslation } from "react-i18next";
+import { FormDetails } from "../shared/styles";
+import { OrganisationDetailsFormData } from "./organisationDetailsSchema";
+
+const i18nPrefix = "dashboard.agentProfile.organisationDetails";
+
+type Props = {
+  values: OrganisationDetailsFormData;
+  clientLanguagesDisplay: string;
+};
+
+export const OrganisationDetailsDisplay = ({ values, clientLanguagesDisplay }: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <FormDetails data-testid="organisation-details-display">
+      <EditableField
+        mode="display"
+        type="text"
+        label={t(`${i18nPrefix}.about`)}
+        value={values.about}
+        setValue={() => {}}
+      />
+      <EditableField
+        mode="display"
+        type="text"
+        label={t(`${i18nPrefix}.website`)}
+        value={values.website}
+        setValue={() => {}}
+      />
+      <EditableField
+        mode="display"
+        type="text"
+        label={t(`${i18nPrefix}.address`)}
+        value={values.address}
+        setValue={() => {}}
+      />
+      <EditableField
+        mode="display"
+        type="text"
+        label={t(`${i18nPrefix}.organisationType`)}
+        value={values.organisationType}
+        setValue={() => {}}
+      />
+      <EditableField
+        mode="display"
+        type="text"
+        label={t(`${i18nPrefix}.operator`)}
+        value={values.operator}
+        setValue={() => {}}
+      />
+      <EditableField
+        mode="display"
+        type="text"
+        label={t(`${i18nPrefix}.services`)}
+        value={values.services}
+        setValue={() => {}}
+      />
+      <EditableField
+        mode="display"
+        type="text"
+        label={t(`${i18nPrefix}.clientLanguages`)}
+        value={clientLanguagesDisplay}
+        setValue={() => {}}
+      />
+    </FormDetails>
+  );
+};

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsEdit.tsx
@@ -1,0 +1,153 @@
+import Button from "@/components/core/button/Button/Button";
+import { ErrorMessage } from "@/components/core/common";
+import { EditableField } from "@/components/EditableField/EditableField";
+import { LanguageFields } from "@/components/forms/LanguageFields";
+import { Option } from "need4deed-sdk";
+import { Controller, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { FormButtonRow, FormDetails } from "../shared/styles";
+import { OrganisationDetailsFormData } from "./organisationDetailsSchema";
+
+const i18nPrefix = "dashboard.agentProfile.organisationDetails";
+
+type Props = {
+  languagesForForm: Option[];
+  onCancel: () => void;
+  onSubmit: () => void;
+};
+
+export const OrganisationDetailsEdit = ({ languagesForForm, onCancel, onSubmit }: Props) => {
+  const { t } = useTranslation();
+  const {
+    control,
+    formState: { errors, isDirty, isValid },
+  } = useFormContext<OrganisationDetailsFormData>();
+
+  return (
+    <>
+      <FormDetails data-testid="organisation-details-edit">
+        <Controller
+          name="about"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t(`${i18nPrefix}.about`)}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.about?.message}
+            />
+          )}
+        />
+        <Controller
+          name="website"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t(`${i18nPrefix}.website`)}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.website?.message}
+            />
+          )}
+        />
+        <Controller
+          name="address"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t(`${i18nPrefix}.address`)}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.address?.message}
+            />
+          )}
+        />
+        <Controller
+          name="organisationType"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t(`${i18nPrefix}.organisationType`)}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.organisationType?.message}
+            />
+          )}
+        />
+        <Controller
+          name="operator"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t(`${i18nPrefix}.operator`)}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.operator?.message}
+            />
+          )}
+        />
+        <Controller
+          name="services"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t(`${i18nPrefix}.services`)}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.services?.message}
+            />
+          )}
+        />
+        <Controller
+          name="clientLanguages"
+          control={control}
+          render={({ field }) => (
+            <>
+              <LanguageFields
+                languages={field.value}
+                onChange={field.onChange}
+                t={t}
+                availableLanguages={languagesForForm}
+                showLevel={false}
+              />
+              {errors.clientLanguages?.message && (
+                <ErrorMessage message={errors.clientLanguages.message} />
+              )}
+            </>
+          )}
+        />
+      </FormDetails>
+
+      <FormButtonRow>
+        <Button
+          text={t(`${i18nPrefix}.cancel`)}
+          onClick={onCancel}
+          width="auto"
+          padding="var(--volunteer-profile-section-card-header-button-padding)"
+          backgroundcolor="var(--color-white)"
+          textColor="var(--color-aubergine)"
+          border="var(--volunteer-profile-section-card-header-button-border)"
+        />
+        <Button
+          text={t(`${i18nPrefix}.saveChanges`)}
+          onClick={onSubmit}
+          width="auto"
+          padding="var(--volunteer-profile-section-card-header-button-padding)"
+          disabled={!isDirty || !isValid}
+        />
+      </FormButtonRow>
+    </>
+  );
+};

--- a/src/components/Dashboard/Profile/sections/RefugeeAccommodationCentre/RefugeeAccommodationCentre.tsx
+++ b/src/components/Dashboard/Profile/sections/RefugeeAccommodationCentre/RefugeeAccommodationCentre.tsx
@@ -46,7 +46,7 @@ export const RefugeeAccommodationCentre = forwardRef<EditableSectionRef, Props>(
     defaultValues: initialFormValues,
   });
 
-  const { handleSubmit, reset, watch } = methods;
+  const { handleSubmit, reset } = methods;
 
   const handleEditClick = () => setIsEditing(true);
 
@@ -75,8 +75,6 @@ export const RefugeeAccommodationCentre = forwardRef<EditableSectionRef, Props>(
     reset(initialFormValues);
   }, [initialFormValues, isEditing, reset]);
 
-  const formValues = watch();
-
   return (
     <FormProvider {...methods}>
       <FormContainer data-testid="refugee-accommodation-centre-container" $isEditing={isEditing}>
@@ -87,7 +85,7 @@ export const RefugeeAccommodationCentre = forwardRef<EditableSectionRef, Props>(
             isPending={isPending}
           />
         ) : (
-          <RefugeeAccommodationCentreDisplay values={formValues} />
+          <RefugeeAccommodationCentreDisplay />
         )}
       </FormContainer>
     </FormProvider>

--- a/src/components/Dashboard/Profile/sections/RefugeeAccommodationCentre/RefugeeAccommodationCentre.tsx
+++ b/src/components/Dashboard/Profile/sections/RefugeeAccommodationCentre/RefugeeAccommodationCentre.tsx
@@ -1,18 +1,18 @@
 "use client";
-import Button from "@/components/core/button/Button/Button";
-import { EditableField } from "@/components/EditableField/EditableField";
 import { useUpdateOpportunityAgent } from "@/hooks/useUpdateOpportunityAgent";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ApiOpportunityGet, Lang } from "need4deed-sdk";
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { FormButtonRow, FormContainer, FormDetails } from "../shared/styles";
+import { FormContainer } from "../shared/styles";
 import { EditableSectionRef } from "../shared/types";
 import {
   createRefugeeAccommodationCentreSchema,
   RefugeeAccommodationCentreFormData,
 } from "./refugeeAccommodationCentreSchema";
+import { RefugeeAccommodationCentreDisplay } from "./RefugeeAccommodationCentreDisplay";
+import { RefugeeAccommodationCentreEdit } from "./RefugeeAccommodationCentreEdit";
 
 type Props = {
   opportunity: ApiOpportunityGet;
@@ -40,16 +40,13 @@ export const RefugeeAccommodationCentre = forwardRef<EditableSectionRef, Props>(
     };
   }, [opportunity, i18n.language]);
 
-  const {
-    control,
-    handleSubmit,
-    reset,
-    formState: { errors, isValid, isDirty },
-  } = useForm<RefugeeAccommodationCentreFormData>({
+  const methods = useForm<RefugeeAccommodationCentreFormData>({
     resolver: zodResolver(schema),
     mode: "onChange",
     defaultValues: initialFormValues,
   });
+
+  const { handleSubmit, reset, watch } = methods;
 
   const handleEditClick = () => setIsEditing(true);
 
@@ -78,77 +75,21 @@ export const RefugeeAccommodationCentre = forwardRef<EditableSectionRef, Props>(
     reset(initialFormValues);
   }, [initialFormValues, isEditing, reset]);
 
-  const mode = isEditing ? "edit" : "display";
+  const formValues = watch();
 
   return (
-    <FormContainer data-testid="refugee-accommodation-centre-container" $isEditing={isEditing}>
-      <FormDetails>
-        <Controller
-          name="name"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="text"
-              label={t("dashboard.opportunityProfile.rac.name")}
-              value={field.value}
-              setValue={field.onChange}
-              errorMessage={errors.name?.message}
-            />
-          )}
-        />
-
-        <Controller
-          name="address"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="text"
-              label={t("dashboard.opportunityProfile.rac.address")}
-              value={field.value}
-              setValue={field.onChange}
-              errorMessage={errors.address?.message}
-            />
-          )}
-        />
-
-        <Controller
-          name="district"
-          control={control}
-          render={({ field }) => (
-            <EditableField
-              mode={mode}
-              type="text"
-              label={t("dashboard.opportunityProfile.rac.district")}
-              value={field.value}
-              setValue={field.onChange}
-              errorMessage={errors.district?.message}
-            />
-          )}
-        />
-      </FormDetails>
-
-      {isEditing && (
-        <FormButtonRow>
-          <Button
-            text={t("dashboard.opportunityProfile.rac.cancel")}
-            onClick={handleCancel}
-            width="auto"
-            padding="var(--volunteer-profile-section-card-header-button-padding)"
-            backgroundcolor="var(--color-white)"
-            textColor="var(--color-aubergine)"
-            border="var(--volunteer-profile-section-card-header-button-border)"
+    <FormProvider {...methods}>
+      <FormContainer data-testid="refugee-accommodation-centre-container" $isEditing={isEditing}>
+        {isEditing ? (
+          <RefugeeAccommodationCentreEdit
+            onCancel={handleCancel}
+            onSubmit={handleSubmit(onSubmit)}
+            isPending={isPending}
           />
-          <Button
-            text={t("dashboard.opportunityProfile.rac.saveChanges")}
-            onClick={handleSubmit(onSubmit)}
-            width="auto"
-            padding="var(--volunteer-profile-section-card-header-button-padding)"
-            disabled={!isDirty || !isValid || isPending}
-          />
-        </FormButtonRow>
-      )}
-    </FormContainer>
+        ) : (
+          <RefugeeAccommodationCentreDisplay values={formValues} />
+        )}
+      </FormContainer>
+    </FormProvider>
   );
 });

--- a/src/components/Dashboard/Profile/sections/RefugeeAccommodationCentre/RefugeeAccommodationCentreDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/RefugeeAccommodationCentre/RefugeeAccommodationCentreDisplay.tsx
@@ -1,0 +1,40 @@
+import { EditableField } from "@/components/EditableField/EditableField";
+import { useTranslation } from "react-i18next";
+import { FormDetails } from "../shared/styles";
+import { RefugeeAccommodationCentreFormData } from "./refugeeAccommodationCentreSchema";
+
+type Props = {
+  values: RefugeeAccommodationCentreFormData;
+};
+
+export const RefugeeAccommodationCentreDisplay = ({ values }: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <FormDetails data-testid="refugee-accommodation-centre-display">
+      <EditableField
+        mode="display"
+        type="text"
+        label={t("dashboard.opportunityProfile.rac.name")}
+        value={values.name}
+        setValue={() => {}}
+      />
+
+      <EditableField
+        mode="display"
+        type="text"
+        label={t("dashboard.opportunityProfile.rac.address")}
+        value={values.address}
+        setValue={() => {}}
+      />
+
+      <EditableField
+        mode="display"
+        type="text"
+        label={t("dashboard.opportunityProfile.rac.district")}
+        value={values.district}
+        setValue={() => {}}
+      />
+    </FormDetails>
+  );
+};

--- a/src/components/Dashboard/Profile/sections/RefugeeAccommodationCentre/RefugeeAccommodationCentreDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/RefugeeAccommodationCentre/RefugeeAccommodationCentreDisplay.tsx
@@ -1,14 +1,13 @@
 import { EditableField } from "@/components/EditableField/EditableField";
+import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FormDetails } from "../shared/styles";
 import { RefugeeAccommodationCentreFormData } from "./refugeeAccommodationCentreSchema";
 
-type Props = {
-  values: RefugeeAccommodationCentreFormData;
-};
-
-export const RefugeeAccommodationCentreDisplay = ({ values }: Props) => {
+export const RefugeeAccommodationCentreDisplay = () => {
   const { t } = useTranslation();
+  const { watch } = useFormContext<RefugeeAccommodationCentreFormData>();
+  const values = watch();
 
   return (
     <FormDetails data-testid="refugee-accommodation-centre-display">

--- a/src/components/Dashboard/Profile/sections/RefugeeAccommodationCentre/RefugeeAccommodationCentreEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/RefugeeAccommodationCentre/RefugeeAccommodationCentreEdit.tsx
@@ -1,0 +1,90 @@
+import Button from "@/components/core/button/Button/Button";
+import { EditableField } from "@/components/EditableField/EditableField";
+import { Controller, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { FormButtonRow, FormDetails } from "../shared/styles";
+import { RefugeeAccommodationCentreFormData } from "./refugeeAccommodationCentreSchema";
+
+type Props = {
+  onCancel: () => void;
+  onSubmit: () => void;
+  isPending: boolean;
+};
+
+export const RefugeeAccommodationCentreEdit = ({ onCancel, onSubmit, isPending }: Props) => {
+  const { t } = useTranslation();
+  const {
+    control,
+    formState: { errors, isValid, isDirty },
+  } = useFormContext<RefugeeAccommodationCentreFormData>();
+
+  return (
+    <>
+      <FormDetails data-testid="refugee-accommodation-centre-edit">
+        <Controller
+          name="name"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t("dashboard.opportunityProfile.rac.name")}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.name?.message}
+            />
+          )}
+        />
+
+        <Controller
+          name="address"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t("dashboard.opportunityProfile.rac.address")}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.address?.message}
+            />
+          )}
+        />
+
+        <Controller
+          name="district"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t("dashboard.opportunityProfile.rac.district")}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.district?.message}
+            />
+          )}
+        />
+      </FormDetails>
+
+      <FormButtonRow>
+        <Button
+          text={t("dashboard.opportunityProfile.rac.cancel")}
+          onClick={onCancel}
+          width="auto"
+          padding="var(--volunteer-profile-section-card-header-button-padding)"
+          backgroundcolor="var(--color-white)"
+          textColor="var(--color-aubergine)"
+          border="var(--volunteer-profile-section-card-header-button-border)"
+        />
+        <Button
+          text={t("dashboard.opportunityProfile.rac.saveChanges")}
+          onClick={onSubmit}
+          width="auto"
+          padding="var(--volunteer-profile-section-card-header-button-padding)"
+          disabled={!isDirty || !isValid || isPending}
+        />
+      </FormButtonRow>
+    </>
+  );
+};


### PR DESCRIPTION
## Description

Split components that had inline display/edit mode switching into separate Display and Edit files.
Edit components access form state via useFormContext (matching AccompanyingDetails pattern). Orchestrators wrap children with `FormProvider`. Display components receive pre-computed values as `props`.