### PR TITLE
fix: save button and checkbox uncheck in opportunity details (#289)

### DIFF
--- a/src/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema.ts
@@ -47,7 +47,7 @@ export const createOpportunityDetailsSchema = (t: (key: string) => string) =>
     eventDate: z.date().nullable().optional(),
     eventTime: z.string().optional(),
     activities: z.array(z.string()).min(1, t(`${i18nPrefix}.activitiesRequired`)),
-    skills: z.array(z.string()).min(1, t(`${i18nPrefix}.skillsRequired`)),
+    skills: z.array(z.string()),
   });
 
 export type OpportunityDetailsFormData = z.infer<ReturnType<typeof createOpportunityDetailsSchema>>;

--- a/src/components/EditableField/EditableField.tsx
+++ b/src/components/EditableField/EditableField.tsx
@@ -535,7 +535,9 @@ export const EditableField = forwardRef(function EditableField<T extends string 
                         value={option}
                         checked={isSelected}
                         onChange={() => {
-                          // Handled by parent OptionRow onClick
+                          if (type === "checkbox-list") {
+                            handleCheckboxChange(option);
+                          }
                         }}
                         onClick={(e) => e.stopPropagation()}
                       />


### PR DESCRIPTION
## Description
 Two bugs in the Opportunity Details card prevented users from saving their work:
  1. The save button was disabled whenever the skills list was empty, even when all other required
  fields were filled.                         
  2. Once a skill checkbox was checked, it could not be unchecked.     

## Related Issues
Closes #289

## Changes
 - Remove `.min(1)` skills validation that blocked saving when skills list is empty                 
 - Fix empty `onChange` handler on checkbox input that prevented unchecking skills   

## Screenshots / Demos
[oportunityCard.webm](https://github.com/user-attachments/assets/5d292b12-5c41-4bc9-9d55-f23582226ee6)

 ## Notes                                                                                           
  - Checkbox handler is called from both the row's `onClick` and the input's `onChange`  intentional, handles both interaction paths                                                        
  - `onClick={(e) => e.stopPropagation()}` on the checkbox prevents double-firing when the checkbox  
  itself is clicked        


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

