### PR TITLE
Fix: back button navigates to correct list page (#318)

### DIFF
--- a/src/components/Dashboard/Profile/ProfilePage.tsx
+++ b/src/components/Dashboard/Profile/ProfilePage.tsx
@@ -7,19 +7,12 @@ import { BackLink, PageContainer } from "./styles";
 import { ProfileEntityProps } from "./types";
 
 const ProfilePage = (props: ProfileEntityProps) => {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const { sections, heading, header } = useProfileSections(props);
-
-  const backHref =
-    "volunteer" in props
-      ? `/${i18n.language}/dashboard/volunteers`
-      : "opportunity" in props
-        ? `/${i18n.language}/dashboard/opportunities`
-        : `/${i18n.language}/dashboard/agents`;
 
   return (
     <PageContainer>
-      <BackLink href={backHref}>
+      <BackLink href=".">
         <ArrowLeftIcon size={24} />
         {t("dashboard.volunteerProfile.backToDashboard")}
       </BackLink>

--- a/src/components/Dashboard/Profile/ProfilePage.tsx
+++ b/src/components/Dashboard/Profile/ProfilePage.tsx
@@ -10,9 +10,16 @@ const ProfilePage = (props: ProfileEntityProps) => {
   const { t, i18n } = useTranslation();
   const { sections, heading, header } = useProfileSections(props);
 
+  const backHref =
+    "volunteer" in props
+      ? `/${i18n.language}/dashboard/volunteers`
+      : "opportunity" in props
+        ? `/${i18n.language}/dashboard/opportunities`
+        : `/${i18n.language}/dashboard/agents`;
+
   return (
     <PageContainer>
-      <BackLink href={`/${i18n.language}/dashboard`}>
+      <BackLink href={backHref}>
         <ArrowLeftIcon size={24} />
         {t("dashboard.volunteerProfile.backToDashboard")}
       </BackLink>


### PR DESCRIPTION
Fix: back button navigates to correct list page (#318)

## Description
The back button in volunteer, opportunity and agent profiles was navigating to the wrong URL. It was always sending the user to the generic dashboard instead of the correct list page.

## Related Issues
Closes #318 

## Changes
- Back button in volunteer profile now navigates to `/dashboard/volunteers`
- Back button in opportunity profile now navigates to `/dashboard/opportunities`
- Back button in agent profile now navigates to `/dashboard/agents`

## Screenshots / Demos

https://github.com/user-attachments/assets/5a559d47-0a68-4bdd-9439-1a450214810e



## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

