### PR TITLE
Fix: dashboard button+direct buttons to forms+ testimonials #321

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -423,7 +423,8 @@
     "header": {
       "button": {
         "login": "Anmelden",
-        "joinVolunteer": "Jetzt sich engagieren"
+        "joinVolunteer": "Jetzt sich engagieren",
+        "dashboard": "Dashboard"
       }
     },
     "login": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -423,7 +423,8 @@
     "header": {
       "button": {
         "login": "Log in",
-        "joinVolunteer": "Join as a volunteer"
+        "joinVolunteer": "Join as a volunteer",
+        "dashboard": "Dashboard"
       }
     },
     "login": {

--- a/src/app/[lang]/dashboard/page.tsx
+++ b/src/app/[lang]/dashboard/page.tsx
@@ -1,3 +1,17 @@
-export default function DashboardLandingPage() {
-  return <div>Welcome to your Dashboard!</div>;
+import { Landing } from "@/components/Dashboard/Landing";
+import { TestimonialsSection } from "@/components/Testimonials";
+import { Lang } from "need4deed-sdk";
+
+type Props = {
+  params: Promise<{ lang: string }>;
+};
+
+export default async function DashboardLandingPage({ params }: Props) {
+  const { lang } = await params;
+  return (
+    <>
+      <Landing />
+      <TestimonialsSection lang={lang as Lang} />
+    </>
+  );
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -10,6 +10,8 @@ import BurgerMenuItems from "./BurgerMenuItems";
 import LoginRegister from "./LoginRegister";
 import MenuItems from "./MenuItems";
 import UserProfile from "./UserProfile";
+import MenuItem from "./MenuItem";
+import Link from "next/link";
 
 interface HeaderContainerProps {
   height?: string;
@@ -47,7 +49,7 @@ export function Header({
   menuItemColor,
   burgerMenuItemColor = "var(--color-midnight)",
 }: Props) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [isBurgerMenuOpen, setIsBurgerMenuOpen] = useState<boolean>(false);
   const user = useCurrentUser();
 
@@ -77,6 +79,11 @@ export function Header({
         <MenuItems items={menuItems} menuItemColor={menuItemColor} />
       )}
 
+      {user && (
+        <Link href={`/${i18n.language}/dashboard/home`} style={{ textDecoration: "none" }}>
+          <MenuItem text={t("dashboard.header.button.dashboard")} color={menuItemColor} />
+        </Link>
+      )}
       {user ? <UserProfile /> : <LoginRegister />}
     </HeaderContainer>
   );

--- a/src/components/Header/LoginRegister.tsx
+++ b/src/components/Header/LoginRegister.tsx
@@ -10,13 +10,13 @@ const LoginRegisterContainer = styled.div`
 `;
 
 export function LoginRegister() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const router = useRouter();
 
   return (
     <LoginRegisterContainer>
       <Button
-        onClick={() => router.push("/login")}
+        onClick={() => router.push(`/${i18n.language}/login`)}
         text={t("dashboard.header.button.login")}
         height="var(--layout-static-page-header-button-height)"
         textFontSize="var(--layout-static-page-header-button-text-font-size)"
@@ -26,7 +26,7 @@ export function LoginRegister() {
       />
 
       <Button
-        onClick={() => {}}
+        onClick={() => router.push(`/${i18n.language}/forms/volunteer`)}
         text={t("dashboard.header.button.joinVolunteer")}
         height="var(--layout-static-page-header-button-height)"
         textFontSize="var(--layout-static-page-header-button-text-font-size)"

--- a/src/components/Website/Landing/Hero/Content.tsx
+++ b/src/components/Website/Landing/Hero/Content.tsx
@@ -4,9 +4,7 @@ import { useRouter } from "next/navigation";
 import styled from "styled-components";
 
 import { Button } from "../../../core/button";
-import { ATag } from "../../../styled/tags";
 import { CustomHeading } from "../../../styled/text";
-import { Subpage } from "@/types";
 
 const ContentDiv = styled.div`
   display: flex;
@@ -35,7 +33,7 @@ const HeroButtonsContainer = styled.div`
 `;
 
 export default function HeroContent() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const router = useRouter();
 
   return (
@@ -66,14 +64,13 @@ export default function HeroContent() {
           <Button
             backgroundcolor="var(--color-orchid-light)"
             textColor="var(--color-midnight)"
-            onClick={() => {
-              router.push(`/${Subpage.VOLUNTEER_FORM}`);
-            }}
+            onClick={() => router.push(`/${i18n.language}/forms/volunteer`)}
             text={t("dashboard.heroSection.buttonJoinVolunteer")}
           />
-          <ATag href="#rac-section-container">
-            <Button onClick={() => {}} text={t("dashboard.heroSection.buttonJoinRefugeeCenter")} />
-          </ATag>
+          <Button
+            onClick={() => router.push(`/${i18n.language}/forms/opportunity`)}
+            text={t("dashboard.heroSection.buttonJoinRefugeeCenter")}
+          />
         </HeroButtonsContainer>
       </ContentContainer>
     </ContentDiv>


### PR DESCRIPTION
Fix: dashboard button+direct buttons to forms+ testimonials #321

## Description
Update hero buttons to link to volunteer/opportunity forms, add testimonials section to the dashboard page, and add a dashboard link in the header.

## Related Issues
Closes #321

## Changes
- Updated hero buttons to navigate to `/forms/volunteer` and `/forms/opportunity`
- Added testimonials section to the dashboard landing page
- Added "Dashboard" link in the header for logged-in users

## Screenshots / Demos

https://github.com/user-attachments/assets/2455ce69-ada9-490e-9f04-b3f97becfd2f



## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

