### PR TITLE
fix: send ISO code instead of translated title for language submission

### DIFF
--- a/src/components/forms/LanguageFields/LanguageFieldRow.tsx
+++ b/src/components/forms/LanguageFields/LanguageFieldRow.tsx
@@ -58,16 +58,13 @@ export function LanguageFieldRow({
             {t("form.becomeVolunteer.fields.languages.chooseLanguage")}
           </option>
           <option key={language.id} value={language.language}>
-            {language.language}
+            {availableLanguages.find((item) => String(item.id) === language.language)?.title[i18n.language as Lang] ?? language.language}
           </option>
           {availableLanguages.map((item) => (
             <option
               key={item.id}
               value={String(item.id)}
-              disabled={
-                (disabledLanguages.includes(String(item.id)) && language.language !== String(item.id)) ||
-                disabledLanguages.includes(item.title[i18n.language as Lang] as string)
-              }
+              disabled={disabledLanguages.includes(String(item.id)) && language.language !== String(item.id)}
             >
               {item.title[i18n.language as Lang]}
             </option>

--- a/src/components/forms/LanguageFields/LanguageFieldRow.tsx
+++ b/src/components/forms/LanguageFields/LanguageFieldRow.tsx
@@ -63,7 +63,7 @@ export function LanguageFieldRow({
           {availableLanguages.map((item) => (
             <option
               key={item.id}
-              value={item.title[i18n.language as Lang]}
+              value={String(item.id)}
               disabled={
                 (disabledLanguages.includes(String(item.id)) && language.language !== String(item.id)) ||
                 disabledLanguages.includes(item.title[i18n.language as Lang] as string)


### PR DESCRIPTION
## Summary
- Fixes #347
- Language select options were storing the translated display title (e.g. `"Arabisch"`) as the value instead of the ISO code (e.g. `"ar"`)
- The BE's `getLanguageTitle` expects an ISO code, so all lookups returned `undefined`, falling back to the first DB row (Ghotuo)

## Change
One line in `LanguageFieldRow.tsx`:
```tsx
// before
value={item.title[i18n.language as Lang]}

// after
value={String(item.id)}
```

## Test plan
- [ ] Fill out volunteer form, select any language (e.g. Arabic)
- [ ] Submit and verify the correct language appears in the dashboard