### PR TITLE
fix: preserve language purpose when saving volunteer profile

### DIFF
--- a/src/components/Dashboard/Profile/sections/VolunteerProfile/formatters.ts
+++ b/src/components/Dashboard/Profile/sections/VolunteerProfile/formatters.ts
@@ -31,6 +31,7 @@ export function formatLanguages(
       id: lang.id,
       language: String(dbId),
       level: proficiencyToLevel[lang.proficiency?.toLowerCase() || "native"] || LanguageLevel.NATIVE,
+      purpose: lang.purpose,
     };
   });
 }

--- a/src/components/Dashboard/Profile/sections/VolunteerProfile/transformers.ts
+++ b/src/components/Dashboard/Profile/sections/VolunteerProfile/transformers.ts
@@ -1,5 +1,5 @@
 import { TFunction } from "i18next";
-import { ApiLanguage, ApiVolunteerGet, VolunteerStateTypeType } from "need4deed-sdk";
+import { ApiLanguage, ApiVolunteerGet, LangPurpose, VolunteerStateTypeType } from "need4deed-sdk";
 import { apiToFormAvailability } from "./availabilityUtils";
 import { LEVEL_TO_PROFICIENCY } from "./constants";
 import { formatActivities, formatDistricts, formatLanguages, formatSkills, getVolunteerTypeLabel } from "./formatters";
@@ -52,6 +52,7 @@ export function transformLanguagesToApi(languages: VolunteerProfileFormData["lan
           id: parseInt(lang.language, 10),
           title: languageMapping.idToTitle[parseInt(lang.language, 10)] || "",
           proficiency: LEVEL_TO_PROFICIENCY[lang.level as unknown as number],
+          purpose: lang.purpose ?? LangPurpose.GENERAL,
         }) as ApiLanguage,
     );
 }

--- a/src/components/Dashboard/Profile/sections/VolunteerProfile/volunteerProfileSchema.ts
+++ b/src/components/Dashboard/Profile/sections/VolunteerProfile/volunteerProfileSchema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Availability } from "@/components/forms/types";
 import { LanguageLevel, LanguageObject } from "@/types";
+import { LangPurpose } from "need4deed-sdk";
 
 export const createVolunteerProfileSchema = (t: (key: string) => string) => {
   return z.object({
@@ -10,6 +11,7 @@ export const createVolunteerProfileSchema = (t: (key: string) => string) => {
           id: z.number(),
           language: z.string(),
           level: z.union([z.enum(LanguageLevel), z.literal("")]),
+          purpose: z.nativeEnum(LangPurpose).optional(),
         }) satisfies z.ZodType<LanguageObject>,
       )
       .min(1, t("dashboard.volunteerProfile.profileSection.validation.languageRequired"))

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export type LanguageObject = {
   id: number;
   language: string;
   level: LanguageLevel | "";
+  purpose?: import("need4deed-sdk").LangPurpose;
 };
 
 export type FooterLink = [string, string];


### PR DESCRIPTION
Closes #367

## Description
When saving a volunteer's language section, the purpose field (GENERAL, TRANSLATION, RECIPIENT) was being stripped from every language entry. This meant that after saving, the languages would lose their purpose and stop appearing in the right place on the profile.

## Changes
The fix makes the form preserve the existing purpose throughout the data flow, from loading the volunteer data into the form all the way to the API payload on submit. Languages added from scratch in the edit form default to GENERAL.
