### PR TITLE
fix: replace district free-text with dropdown in RAC section

### DIFF
--- a/src/components/Dashboard/Profile/sections/RefugeeAccommodationCentre/RefugeeAccommodationCentre.tsx
+++ b/src/components/Dashboard/Profile/sections/RefugeeAccommodationCentre/RefugeeAccommodationCentre.tsx
@@ -8,6 +8,8 @@ import { useTranslation } from "react-i18next";
 import { FormContainer } from "../shared/styles";
 import { EditableSectionProps, EditableSectionRef } from "../shared/types";
 import { useEditingChangeNotifier } from "../shared/useEditingChangeNotifier";
+import { useApiDistricts } from "../VolunteerProfile/hooks";
+import { createMapping } from "../VolunteerProfile/mappingUtils";
 import { RefugeeAccommodationCentreDisplay } from "./RefugeeAccommodationCentreDisplay";
 import { RefugeeAccommodationCentreEdit } from "./RefugeeAccommodationCentreEdit";
 import {
@@ -28,6 +30,9 @@ export const RefugeeAccommodationCentre = forwardRef<EditableSectionRef, Props>(
   const [isEditing, setIsEditing] = useState(false);
 
   useEditingChangeNotifier(isEditing, onEditingChange);
+
+  const { data: apiDistricts = [] } = useApiDistricts();
+  const districtMapping = useMemo(() => createMapping(apiDistricts), [apiDistricts]);
 
   const schema = createRefugeeAccommodationCentreSchema(t);
 
@@ -61,11 +66,13 @@ export const RefugeeAccommodationCentre = forwardRef<EditableSectionRef, Props>(
   };
 
   const onSubmit = (values: RefugeeAccommodationCentreFormData) => {
+    const districtId = districtMapping.titleToId[values.district];
     updateAgent(
       {
         agent: {
           name: values.name,
           address: values.address,
+          ...(districtId && { district: districtId }),
         },
       },
       { onSuccess: () => setIsEditing(false) },
@@ -85,6 +92,7 @@ export const RefugeeAccommodationCentre = forwardRef<EditableSectionRef, Props>(
             onCancel={handleCancel}
             onSubmit={handleSubmit(onSubmit)}
             isPending={isPending}
+            districts={apiDistricts.map((d) => d.title)}
           />
         ) : (
           <RefugeeAccommodationCentreDisplay />

--- a/src/components/Dashboard/Profile/sections/RefugeeAccommodationCentre/RefugeeAccommodationCentre.tsx
+++ b/src/components/Dashboard/Profile/sections/RefugeeAccommodationCentre/RefugeeAccommodationCentre.tsx
@@ -72,7 +72,7 @@ export const RefugeeAccommodationCentre = forwardRef<EditableSectionRef, Props>(
         agent: {
           name: values.name,
           address: values.address,
-          ...(districtId && { district: districtId }),
+          ...(districtId !== undefined && { district: districtId }),
         },
       },
       { onSuccess: () => setIsEditing(false) },

--- a/src/components/Dashboard/Profile/sections/RefugeeAccommodationCentre/RefugeeAccommodationCentreEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/RefugeeAccommodationCentre/RefugeeAccommodationCentreEdit.tsx
@@ -9,9 +9,10 @@ type Props = {
   onCancel: () => void;
   onSubmit: () => void;
   isPending: boolean;
+  districts: string[];
 };
 
-export const RefugeeAccommodationCentreEdit = ({ onCancel, onSubmit, isPending }: Props) => {
+export const RefugeeAccommodationCentreEdit = ({ onCancel, onSubmit, isPending, districts }: Props) => {
   const { t } = useTranslation();
   const {
     control,
@@ -57,10 +58,11 @@ export const RefugeeAccommodationCentreEdit = ({ onCancel, onSubmit, isPending }
           render={({ field }) => (
             <EditableField
               mode="edit"
-              type="text"
+              type="radio-list"
               label={t("dashboard.opportunityProfile.rac.district")}
               value={field.value}
               setValue={field.onChange}
+              options={districts}
               errorMessage={errors.district?.message}
             />
           )}


### PR DESCRIPTION
Closes #357

## Description
The district field in the Refugee Accommodation Centre edit form was a plain text input, which made it impossible to consistently pick a valid district. On top of that, the value was not being sent to the API at all when saving, only name and address were submitted.

## Changes
The field is now a dropdown fed from the districts API, following the same pattern used in the volunteer profile. On submit, the selected district ID is sent correctly.

