### PR TITLE
fix: Stop sending filter titles to API when ID lookup fails

### DIFF
--- a/src/components/Dashboard/Volunteers/helpers.ts
+++ b/src/components/Dashboard/Volunteers/helpers.ts
@@ -80,10 +80,14 @@ export function serializeFilters(
   params.delete(QueryParamsKeys.DISTRICT);
   Object.entries(filter.district).forEach(([key, value]) => {
     if (value === true) {
-      const paramValue =
-        (options?.serializeToIDs && options.apiFilterOptions?.district?.find((d) => d.title === key)?.id) || key;
-
-      params.append(QueryParamsKeys.DISTRICT, String(paramValue));
+      if (options?.serializeToIDs && options.apiFilterOptions) {
+        const districtId = options.apiFilterOptions.district?.find((d) => d.title === key)?.id;
+        if (districtId !== undefined) {
+          params.append(QueryParamsKeys.DISTRICT, String(districtId));
+        }
+      } else {
+        params.append(QueryParamsKeys.DISTRICT, key);
+      }
     }
   });
 
@@ -91,10 +95,14 @@ export function serializeFilters(
   params.delete(QueryParamsKeys.LANGUAGE);
   Object.entries(filter.language).forEach(([key, value]) => {
     if (value === true) {
-      const paramValue =
-        (options?.serializeToIDs && options.apiFilterOptions?.language?.find((d) => d.title === key)?.id) || key;
-
-      params.append(QueryParamsKeys.LANGUAGE, String(paramValue));
+      if (options?.serializeToIDs && options.apiFilterOptions) {
+        const languageId = options.apiFilterOptions.language?.find((d) => d.title === key)?.id;
+        if (languageId !== undefined) {
+          params.append(QueryParamsKeys.LANGUAGE, String(languageId));
+        }
+      } else {
+        params.append(QueryParamsKeys.LANGUAGE, key);
+      }
     }
   });
 


### PR DESCRIPTION
Closes #368

## Description
When selecting a District or Language in the Volunteers filter, the code tried to convert the selection to a numeric ID before sending it to the API. If that lookup failed, it silently fell back to sending the text label instead (e.g. "Munich" instead of 1). The API doesn't understand text labels, so results would break or error out.

## Changes
- Volunteers/helpers.ts: removed the silent fallback in serializeFilters for district and language if the ID is found it gets sent, if not the param is skipped entirely
- Same bug exists in the Agents dashboard but is out of scope here


