### PR TITLE
fix: Fetch and display connected opportunities on agent profile

### DIFF
--- a/src/components/Dashboard/Profile/sections/AgentOpportunities/AgentOpportunities.tsx
+++ b/src/components/Dashboard/Profile/sections/AgentOpportunities/AgentOpportunities.tsx
@@ -1,32 +1,49 @@
-import { OpportunityVolunteerStatusType } from "need4deed-sdk";
+import { Heading4 } from "@/components/styled/text";
+import { apiPathAgent, cacheTTL } from "@/config/constants";
+import { useGetQuery } from "@/hooks/useGetQuery";
+import { ApiOpportunityGetList, Id } from "need4deed-sdk";
+import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
+import { Accordion } from "../shared/Accordion";
 import { SectionEmptyState } from "../shared/styles";
-import { Tabs } from "../shared/Tabs";
-import { useTabTransitions } from "../shared/useTabTransitions";
 import { AgentOpportunitiesContainer } from "./styles";
 
-const tabsKeys = ["lookingForVolunteers", "active", "past"] as const;
+type Props = { agentId: Id };
 
-const agentTabStatusOrder: OpportunityVolunteerStatusType[] = [
-  OpportunityVolunteerStatusType.PENDING,
-  OpportunityVolunteerStatusType.ACTIVE,
-  OpportunityVolunteerStatusType.PAST,
-];
+export const AgentOpportunities = ({ agentId }: Props) => {
+  const { t, i18n } = useTranslation();
+  const router = useRouter();
 
-export const AgentOpportunities = () => {
-  const { t } = useTranslation();
+  const { data, isLoading } = useGetQuery<ApiOpportunityGetList[]>({
+    queryKey: ["agent-opportunities", String(agentId)],
+    apiPath: `${apiPathAgent}/${agentId}/opportunity-linked`,
+    staleTime: cacheTTL,
+    enabled: !!agentId,
+    addLang: false,
+  });
 
-  const { selectedTabIndex, setSelectedTabIndex, tabCounts } = useTabTransitions([], agentTabStatusOrder);
+  const opportunities = data ?? [];
 
-  const tabs = tabsKeys.map((key, index) => ({
-    label: t(`dashboard.agentProfile.opportunitiesSec.tabs.${key}`),
-    count: tabCounts[index],
-  }));
+  if (isLoading) return <AgentOpportunitiesContainer data-testid="agent-opportunities" />;
 
   return (
     <AgentOpportunitiesContainer data-testid="agent-opportunities">
-      <Tabs tabs={tabs} selectedTabIndex={selectedTabIndex} setSelectedTabIndex={setSelectedTabIndex} />
-      <SectionEmptyState>{t("dashboard.volunteerProfile.opportunitiesSec.emptyState")}</SectionEmptyState>
+      {opportunities.length === 0 ? (
+        <SectionEmptyState>{t("dashboard.volunteerProfile.opportunitiesSec.emptyState")}</SectionEmptyState>
+      ) : (
+        opportunities.map((opp) => (
+          <Accordion
+            key={String(opp.id)}
+            headerLeft={
+              <Heading4 margin={0} color="var(--color-midnight)">
+                {opp.title}
+              </Heading4>
+            }
+            subtitle={t(`dashboard.opportunities.status.${opp.statusOpportunity}`)}
+            onGoToProfile={() => router.push(`/${i18n.language}/dashboard/opportunities/${opp.id}`)}
+          />
+        ))
+      )}
     </AgentOpportunitiesContainer>
   );
 };

--- a/src/components/Dashboard/Profile/sections/AgentOpportunities/AgentOpportunities.tsx
+++ b/src/components/Dashboard/Profile/sections/AgentOpportunities/AgentOpportunities.tsx
@@ -39,7 +39,7 @@ export const AgentOpportunities = ({ agentId }: Props) => {
                 {opp.title}
               </Heading4>
             }
-            subtitle={t(`dashboard.opportunities.status.${opp.statusOpportunity}`)}
+            subtitle={opp.statusOpportunity ? t(`dashboard.opportunities.status.${opp.statusOpportunity}`) : "-"}
             onGoToProfile={() => router.push(`/${i18n.language}/dashboard/opportunities/${opp.id}`)}
           />
         ))

--- a/src/hooks/useAgentProfileSections.tsx
+++ b/src/hooks/useAgentProfileSections.tsx
@@ -61,7 +61,7 @@ export const useAgentProfileSections = (agent: ApiAgentProfileGet | undefined) =
       iconName: IconName.ShootingStar,
       title: t("dashboard.volunteerProfile.opportunities"),
       headerButtonName: t("dashboard.agentProfile.opportunitiesSec.postOpportunity"),
-      subComponent: <AgentOpportunities />,
+      subComponent: <AgentOpportunities agentId={agent.id} />,
     },
     {
       iconName: IconName.ChatsTeardrop,


### PR DESCRIPTION
Closes #353
## Description
The Opportunities section on the agent profile existed as a stub, it always showed an empty state regardless of how many opportunities the agent had. The backend endpoint GET /api/agent/:id/opportunity-linked was already in place and returning the agent's opportunities, but the frontend was never calling it.

## Changes
- AgentOpportunities.tsx: replaced the stub with a real data fetch from the agent opportunities endpoint. Each opportunity is rendered as an accordion item showing its title and status, with a link to the opportunity profile.
- useAgentProfileSections.tsx: passes the agent ID down to AgentOpportunities so it can make the fetch.


