### PR TITLE
fix: rename language field to refugee language and enable multi-select

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1029,6 +1029,7 @@
         "refugeeNumber": "Geflüchtetennummer",
         "refugeeName": "Name des Geflüchteten",
         "languageToTranslate": "Zu übersetzende Sprache",
+        "refugeeLanguage": "Flüchtlingssprache",
         "cancel": "Abbrechen",
         "saveChanges": "Änderungen speichern",
         "saveSuccess": "Begleitdetails erfolgreich aktualisiert",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1028,6 +1028,7 @@
         "refugeeNumber": "Refugee number",
         "refugeeName": "Refugee name",
         "languageToTranslate": "Language to translate",
+        "refugeeLanguage": "Refugee language",
         "cancel": "Cancel",
         "saveChanges": "Save changes",
         "saveSuccess": "Accompanying details updated successfully",

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetails.tsx
@@ -77,7 +77,7 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
           appointmentTime: values.appointmentTime || undefined,
           refugeeNumber: values.refugeeNumber,
           refugeeName: values.refugeeName,
-          languagesToTranslate: values.languageToTranslate ? [values.languageToTranslate] : [],
+          languagesToTranslate: values.languagesToTranslate ?? [],
         },
       },
       {
@@ -104,7 +104,7 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
     );
   }
 
-  const languageLabel = keyToLabel[formValues.languageToTranslate || ""] || formValues.languageToTranslate || "";
+  const languageLabel = (formValues.languagesToTranslate ?? []).map((id) => keyToLabel[id] || id).join(", ");
 
   return (
     <FormProvider {...methods}>

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsDisplay.tsx
@@ -51,11 +51,10 @@ export const AccompanyingDetailsDisplay = ({ values, languageLabel }: Props) => 
 
       <EditableField
         mode="display"
-        type="radio-list"
-        label={t("dashboard.opportunityProfile.accompanyingDetails.languageToTranslate")}
+        type="text"
+        label={t("dashboard.opportunityProfile.accompanyingDetails.refugeeLanguage")}
         value={languageLabel}
         setValue={() => {}}
-        options={[]}
       />
     </Details>
   );

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsEdit.tsx
@@ -98,9 +98,7 @@ export const AccompanyingDetailsEdit = ({
                 />
                 {errors.appointmentTime && (
                   <ErrorText>
-                    {t(
-                      `dashboard.opportunityProfile.accompanyingDetails.validation.${errors.appointmentTime.message}`,
-                    )}
+                    {t(`dashboard.opportunityProfile.accompanyingDetails.validation.${errors.appointmentTime.message}`)}
                   </ErrorText>
                 )}
               </TimeInputWrapper>
@@ -139,20 +137,24 @@ export const AccompanyingDetailsEdit = ({
         />
 
         <Controller
-          name="languageToTranslate"
+          name="languagesToTranslate"
           control={control}
-          render={({ field }: { field: ControllerRenderProps<AccompanyingDetailsFormData, "languageToTranslate"> }) => (
+          render={({
+            field,
+          }: {
+            field: ControllerRenderProps<AccompanyingDetailsFormData, "languagesToTranslate">;
+          }) => (
             <EditableField
               mode="edit"
-              type="radio-list"
-              label={t("dashboard.opportunityProfile.accompanyingDetails.languageToTranslate")}
-              value={keyToLabel[field.value || ""] || field.value || ""}
+              type="checkbox-list"
+              label={t("dashboard.opportunityProfile.accompanyingDetails.refugeeLanguage")}
+              value={(field.value ?? []).map((id) => keyToLabel[id] || id)}
               setValue={(value) => {
-                const label = Array.isArray(value) ? value[0] : value;
-                field.onChange(labelToKey[label] || label);
+                const labels = Array.isArray(value) ? value : [value];
+                field.onChange(labels.map((label) => labelToKey[label] || label));
               }}
               options={languageOptions}
-              errorMessage={errors.languageToTranslate?.message}
+              errorMessage={errors.languagesToTranslate?.message}
             />
           )}
         />

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/accompanyingDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/accompanyingDetailsSchema.ts
@@ -13,7 +13,7 @@ export const accompanyingDetailsSchema = z.object({
     }),
   refugeeNumber: z.string().optional(),
   refugeeName: z.string().optional(),
-  languageToTranslate: z.string().optional(),
+  languagesToTranslate: z.array(z.string()).optional(),
 });
 
 export type AccompanyingDetailsFormData = z.infer<typeof accompanyingDetailsSchema>;

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
@@ -42,5 +42,5 @@ export const getInitialFormValues = (
   appointmentTime: parseTime(details?.appointmentTime),
   refugeeNumber: details?.refugeeNumber || "",
   refugeeName: details?.refugeeName || "",
-  languageToTranslate: details?.languageToTranslate?.toString() ?? "",
+  languagesToTranslate: details?.languageToTranslate !== undefined ? [details.languageToTranslate.toString()] : [],
 });


### PR DESCRIPTION
Closes #388
### Description
The "Language to translate" field in Accompanying Details only allowed selecting one language and the name did not match the intended purpose. It now shows as "Refugee language", allows selecting multiple languages via checkboxes, and sends the full array to the API.
### Changes:
- Renamed field label from "Language to translate" to "Refugee language" in EN and DE translations
- Changed form field from single string to string array in schema and form state
- Switched EditableField from radio-list to checkbox-list to allow multi-select
- Submit handler now sends the full selected array instead of wrapping a single value
### How to test:
1. Open an accompanying-type opportunity profile
2. Go to Accompanying Details and click Edit
3. Confirm the field is now labelled "Refugee language" and shows checkboxes
4. Select multiple languages, save, and confirm all selections are preserved