### PR TITLE
Fix: Accompanying details: add new row #386

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1034,6 +1034,13 @@
         "refugeeName": "Name des Geflüchteten",
         "languageToTranslate": "Zu übersetzende Sprache",
         "refugeeLanguage": "Flüchtlingssprache",
+        "appointmentLanguage": "Terminsprache",
+        "appointmentLanguageOptions": {
+          "german": "Deutsch",
+          "english": "Englisch",
+          "englishGerman": "Englisch/Deutsch",
+          "noTranslation": "Keine Übersetzung erforderlich"
+        },
         "cancel": "Abbrechen",
         "saveChanges": "Änderungen speichern",
         "saveSuccess": "Begleitdetails erfolgreich aktualisiert",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1033,6 +1033,13 @@
         "refugeeName": "Refugee name",
         "languageToTranslate": "Language to translate",
         "refugeeLanguage": "Refugee language",
+        "appointmentLanguage": "Appointment language",
+        "appointmentLanguageOptions": {
+          "german": "German",
+          "english": "English",
+          "englishGerman": "English/German",
+          "noTranslation": "No translation needed"
+        },
         "cancel": "Cancel",
         "saveChanges": "Save changes",
         "saveSuccess": "Accompanying details updated successfully",

--- a/src/components/Dashboard/Opportunities/OpportunityCard.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityCard.tsx
@@ -37,7 +37,9 @@ export function OpportunityCard({ opportunity, volunteerId, activitiesList }: Pr
     location,
     availability,
     accompanyingDetails,
-  } = opportunity;
+  } = opportunity as ApiVolunteerOpportunityGetList & {
+    accompanyingDetails?: { appointmentDate?: string; appointmentTime?: string };
+  };
 
   const mainCommunication = getLanguagesByPurpose(languages, LangPurpose.GENERAL);
   const recipientLanguage = getLanguagesByPurpose(languages, LangPurpose.RECIPIENT);

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetails.tsx
@@ -11,6 +11,7 @@ import { EditableSectionProps, EditableSectionRef } from "../shared/types";
 import { useEditingChangeNotifier } from "../shared/useEditingChangeNotifier";
 import { AccompanyingDetailsDisplay } from "./AccompanyingDetailsDisplay";
 import { AccompanyingDetailsEdit } from "./AccompanyingDetailsEdit";
+import { AppointmentLanguages } from "@/config/constants";
 import { getInitialFormValues, getMinAppointmentDate, isAccompanyingType } from "./helpers";
 import { AccompanyingDetailsFormData, accompanyingDetailsSchema } from "./accompanyingDetailsSchema";
 import { Container, NotAccompanyingMessage } from "./styles";
@@ -41,6 +42,16 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
     keyToLabel[String(lang.id)] = lang.title;
     labelToKey[lang.title] = String(lang.id);
   });
+
+  const appointmentLanguageKeys = Object.values(AppointmentLanguages);
+  const appointmentLanguageKeyToLabel: Record<string, string> = {};
+  const appointmentLanguageLabelToKey: Record<string, string> = {};
+  appointmentLanguageKeys.forEach((key) => {
+    const label = t(`dashboard.opportunityProfile.accompanyingDetails.appointmentLanguageOptions.${key}`);
+    appointmentLanguageKeyToLabel[key] = label;
+    appointmentLanguageLabelToKey[label] = key;
+  });
+  const appointmentLanguageOptions = appointmentLanguageKeys.map((key) => appointmentLanguageKeyToLabel[key]);
 
   const initialFormValues = getInitialFormValues(opportunity.accompanyingDetails);
 
@@ -78,6 +89,7 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
           refugeeNumber: values.refugeeNumber,
           refugeeName: values.refugeeName,
           languagesToTranslate: values.languagesToTranslate ?? [],
+          appointmentLanguage: values.appointmentLanguage || undefined,
         },
       },
       {
@@ -115,6 +127,9 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
             languageOptions={languageOptions}
             keyToLabel={keyToLabel}
             labelToKey={labelToKey}
+            appointmentLanguageOptions={appointmentLanguageOptions}
+            appointmentLanguageKeyToLabel={appointmentLanguageKeyToLabel}
+            appointmentLanguageLabelToKey={appointmentLanguageLabelToKey}
             onCancel={handleCancel}
             onSubmit={handleSubmit(onSubmit)}
             isPending={isPending}

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsDisplay.tsx
@@ -64,6 +64,21 @@ export const AccompanyingDetailsDisplay = ({ values, languageLabel }: Props) => 
         value={languageLabel}
         setValue={() => {}}
       />
+
+      <EditableField
+        mode="display"
+        type="radio-list"
+        label={t("dashboard.opportunityProfile.accompanyingDetails.appointmentLanguage")}
+        value={
+          values.appointmentLanguage
+            ? t(
+                `dashboard.opportunityProfile.accompanyingDetails.appointmentLanguageOptions.${values.appointmentLanguage}`,
+              )
+            : ""
+        }
+        setValue={() => {}}
+        options={[]}
+      />
     </Details>
   );
 };

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsEdit.tsx
@@ -20,6 +20,9 @@ type Props = {
   languageOptions: string[];
   keyToLabel: Record<string, string>;
   labelToKey: Record<string, string>;
+  appointmentLanguageOptions: string[];
+  appointmentLanguageKeyToLabel: Record<string, string>;
+  appointmentLanguageLabelToKey: Record<string, string>;
   onCancel: () => void;
   onSubmit: () => void;
   isPending: boolean;
@@ -31,6 +34,9 @@ export const AccompanyingDetailsEdit = ({
   languageOptions,
   keyToLabel,
   labelToKey,
+  appointmentLanguageOptions,
+  appointmentLanguageKeyToLabel,
+  appointmentLanguageLabelToKey,
   onCancel,
   onSubmit,
   isPending,
@@ -170,6 +176,25 @@ export const AccompanyingDetailsEdit = ({
               }}
               options={languageOptions}
               errorMessage={errors.languagesToTranslate?.message}
+            />
+          )}
+        />
+
+        <Controller
+          name="appointmentLanguage"
+          control={control}
+          render={({ field }: { field: ControllerRenderProps<AccompanyingDetailsFormData, "appointmentLanguage"> }) => (
+            <EditableField
+              mode="edit"
+              type="radio-list"
+              label={t("dashboard.opportunityProfile.accompanyingDetails.appointmentLanguage")}
+              value={appointmentLanguageKeyToLabel[field.value || ""] || field.value || ""}
+              setValue={(value) => {
+                const label = Array.isArray(value) ? value[0] : value;
+                field.onChange(appointmentLanguageLabelToKey[label] || label);
+              }}
+              options={appointmentLanguageOptions}
+              errorMessage={errors.appointmentLanguage?.message}
             />
           )}
         />

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/accompanyingDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/accompanyingDetailsSchema.ts
@@ -15,6 +15,7 @@ export const accompanyingDetailsSchema = z.object({
   refugeeNumber: z.string().optional(),
   refugeeName: z.string().optional(),
   languagesToTranslate: z.array(z.string()).optional(),
+  appointmentLanguage: z.string().optional(),
 });
 
 export type AccompanyingDetailsFormData = z.infer<typeof accompanyingDetailsSchema>;

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
@@ -45,4 +45,6 @@ export const getInitialFormValues = (
   refugeeNumber: details?.refugeeNumber || "",
   refugeeName: details?.refugeeName || "",
   languagesToTranslate: details?.languageToTranslate !== undefined ? [details.languageToTranslate.toString()] : [],
+  appointmentLanguage:
+    (details as ApiOpportunityAccompanyingDetails & { appointmentLanguage?: string })?.appointmentLanguage || "",
 });

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -74,3 +74,10 @@ export const MAX_DESCRIPTION_LENGTH = 500;
 export const PHONE_NUMBER_REGEX = /^\+[0-9\s]+$/;
 
 export const LOGGED_IN_COOKIE = "is_logged_in=true; path=/; max-age=6000; SameSite=Lax; Secure";
+
+export enum AppointmentLanguages {
+  GERMAN = "german",
+  ENGLISH = "english",
+  ENGLISH_GERMAN = "englishGerman",
+  NO_TRANSLATION = "noTranslation",
+}

--- a/src/hooks/useUpdateOpportunityAccompanyingDetails.ts
+++ b/src/hooks/useUpdateOpportunityAccompanyingDetails.ts
@@ -10,6 +10,7 @@ export type OpportunityAccompanyingDetailsUpdateData = {
     refugeeNumber?: string;
     refugeeName?: string;
     languagesToTranslate?: string[];
+    appointmentLanguage?: string;
   };
 };
 


### PR DESCRIPTION
Fix: Accompanying details: add new row #386

## Description
Adds a new "Appointment language" radio-list field to the Accompanying Details section, positioned below "Language to translate". The field is wired up to the PATCH request and ready for when the backend adds support.

## Related Issues
Closes #386 

## Changes
- Added `appointmentLanguage` field to the accompanying details schema
- Added radio-list with 4 fixed options: **German**, **English**, **English/German**, **No translation needed**
- Added field to both display and edit components
- Wired up to the PATCH request, ready for when the backend adds support
- Added translations (EN + DE)

## Screenshots / Demos
<img width="2520" height="706" alt="image" src="https://github.com/user-attachments/assets/fdf3ef01-aa5e-4309-aa79-968a9223c888" />


## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

