### PR TITLE
fix: split volunteer languages into main communication and translate fields

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -590,7 +590,8 @@
       "profileSection": {
         "title": "Freiwilligenprofil",
         "edit": "Bearbeiten",
-        "languages": "Sprachen",
+        "mainCommunication": "Hauptkommunikation",
+        "languagesToTranslate": "Sprache zum Übersetzen",
         "availability": "Verfügbarkeit",
         "districts": "Bezirke",
         "volunteerType": "Freiwilligen-Typ",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -590,6 +590,7 @@
       "profileSection": {
         "title": "Freiwilligenprofil",
         "edit": "Bearbeiten",
+        "languages": "Sprachen",
         "mainCommunication": "Hauptkommunikation",
         "languagesToTranslate": "Sprache zum Übersetzen",
         "availability": "Verfügbarkeit",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -589,6 +589,7 @@
       "profileSection": {
         "title": "Volunteer profile",
         "edit": "Edit",
+        "languages": "Languages",
         "mainCommunication": "Main communication",
         "languagesToTranslate": "Language to translate",
         "availability": "Availability",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -589,7 +589,8 @@
       "profileSection": {
         "title": "Volunteer profile",
         "edit": "Edit",
-        "languages": "Languages",
+        "mainCommunication": "Main communication",
+        "languagesToTranslate": "Language to translate",
         "availability": "Availability",
         "districts": "Districts",
         "volunteerType": "Volunteer type",

--- a/src/components/Dashboard/Profile/sections/VolunteerProfile/DisplayFields.tsx
+++ b/src/components/Dashboard/Profile/sections/VolunteerProfile/DisplayFields.tsx
@@ -40,7 +40,8 @@ const TagsWrapper = styled.div`
 `;
 
 type Props = {
-  languages: string;
+  mainCommunication: string;
+  languagesToTranslate: string;
   availability: string;
   districts: string;
   volunteerType: string;
@@ -51,7 +52,8 @@ type Props = {
 };
 
 export function DisplayFields({
-  languages,
+  mainCommunication,
+  languagesToTranslate,
   availability,
   districts,
   volunteerType,
@@ -63,8 +65,13 @@ export function DisplayFields({
   return (
     <>
       <FieldRow>
-        <FieldLabel>{t("dashboard.volunteerProfile.profileSection.languages")}</FieldLabel>
-        <FieldValue>{languages}</FieldValue>
+        <FieldLabel>{t("dashboard.volunteerProfile.profileSection.mainCommunication")}</FieldLabel>
+        <FieldValue>{mainCommunication}</FieldValue>
+      </FieldRow>
+
+      <FieldRow>
+        <FieldLabel>{t("dashboard.volunteerProfile.profileSection.languagesToTranslate")}</FieldLabel>
+        <FieldValue>{languagesToTranslate}</FieldValue>
       </FieldRow>
 
       <FieldRow>

--- a/src/components/Dashboard/Profile/sections/VolunteerProfile/VolunteerProfile.tsx
+++ b/src/components/Dashboard/Profile/sections/VolunteerProfile/VolunteerProfile.tsx
@@ -2,7 +2,7 @@
 import Button from "@/components/core/button/Button/Button";
 import { useUpdateVolunteerProfile } from "@/hooks/useUpdateVolunteerProfile";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ApiVolunteerGet, Lang, VolunteerStateTypeType } from "need4deed-sdk";
+import { ApiVolunteerGet, Lang, LangPurpose, VolunteerStateTypeType } from "need4deed-sdk";
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -151,7 +151,18 @@ export const VolunteerProfile = forwardRef<VolunteerProfileRef, Props>(function 
           />
         ) : (
           <DisplayFields
-            languages={formatLanguagesForDisplay(volunteer.languages, languageMapping.idToTitle, t)}
+            mainCommunication={formatLanguagesForDisplay(
+              volunteer.languages,
+              languageMapping.idToTitle,
+              t,
+              LangPurpose.GENERAL,
+            )}
+            languagesToTranslate={formatLanguagesForDisplay(
+              volunteer.languages,
+              languageMapping.idToTitle,
+              t,
+              LangPurpose.TRANSLATION,
+            )}
             availability={formatAvailability(volunteer.availability, t)}
             districts={formatLocationsForDisplay(volunteer.locations)}
             volunteerType={getVolunteerTypeLabel(volunteer.statusType, t)}

--- a/src/components/Dashboard/Profile/sections/VolunteerProfile/formatters.ts
+++ b/src/components/Dashboard/Profile/sections/VolunteerProfile/formatters.ts
@@ -2,7 +2,7 @@ import { getScheduleState } from "@/components/forms/utils";
 import { EMPTY_PLACEHOLDER_VALUE } from "@/config/constants";
 import { LanguageLevel, LanguageObject } from "@/types";
 import { TFunction } from "i18next";
-import { ApiVolunteerGet, VolunteerStateTypeType } from "need4deed-sdk";
+import { ApiVolunteerGet, LangPurpose, VolunteerStateTypeType } from "need4deed-sdk";
 
 type VolunteerLanguages = ApiVolunteerGet["languages"];
 type VolunteerLocations = ApiVolunteerGet["locations"];
@@ -56,9 +56,12 @@ export function formatLanguagesForDisplay(
   langs: VolunteerLanguages,
   languageIdToTitle: Record<number, string>,
   t: TFunction,
+  purpose?: LangPurpose,
 ): string {
   if (!langs || langs.length === 0) return EMPTY_PLACEHOLDER_VALUE;
-  return langs
+  const filtered = purpose ? langs.filter((lang) => lang.purpose === purpose) : langs;
+  if (filtered.length === 0) return EMPTY_PLACEHOLDER_VALUE;
+  return filtered
     .map((lang) => {
       const localizedTitle = languageIdToTitle[lang.id] || lang.title;
       const proficiencyKey = lang.proficiency?.toLowerCase();


### PR DESCRIPTION
Closes #396

### Description
On the volunteer profile page all languages were displayed in a single "Languages" row regardless of their purpose. The volunteer.languages array has a purpose field on each entry (LangPurpose.GENERAL for main communication, LangPurpose.TRANSLATION for translation) that was being ignored, so both types were mixed into one block with no distinction.

The section now filters the languages array by purpose and renders two separate rows: "Main communication" and "Language to translate". Translation labels updated in EN and DE.

### Changes:
- Add optional purpose filter to `formatLanguagesForDisplay`
- Replace single languages prop in DisplayFields with `mainCommunication` and `languagesToTranslate`
- Pass both filtered language strings from `VolunteerProfile`
- Add i18n keys `mainCommunication` and `languagesToTranslate` in EN and DE
- Restore languages translation key alongside new keys (keeps backwards compatibility)
How to test:
1. Open any volunteer profile at /dashboard/volunteers/[id]
2. Confirm languages section shows two rows: Main communication and Language to translate
3. Confirm each row only shows languages matching its purpose