### PR TITLE
Fix hero overlap caused by fixed header by adding layout spacing in Landing page

### DIFF
--- a/src/components/Website/Landing/Landing.tsx
+++ b/src/components/Website/Landing/Landing.tsx
@@ -18,8 +18,9 @@ import { Hero } from "./Hero";
 export function Landing({ lang }: { lang: Lang }) {
   const screenType = useScreenType();
   const isBurgerMenu = screenType === ScreenTypes.MOBILE;
+
   return (
-    <AppContainer id="app-container" style={{ paddingTop: "80px" }}>
+    <AppContainer id="app-container" style={{ paddingTop: "var(--layout-static-page-header-height)" }}>
       <Header
         logo={<N4DLogo />}
         isBurgerMenu={isBurgerMenu}

--- a/src/components/Website/Landing/Landing.tsx
+++ b/src/components/Website/Landing/Landing.tsx
@@ -19,7 +19,7 @@ export function Landing({ lang }: { lang: Lang }) {
   const screenType = useScreenType();
   const isBurgerMenu = screenType === ScreenTypes.MOBILE;
   return (
-    <AppContainer id="app-container">
+    <AppContainer id="app-container" style={{ paddingTop: "80px" }}>
       <Header
         logo={<N4DLogo />}
         isBurgerMenu={isBurgerMenu}


### PR DESCRIPTION
## Description
Fixes an issue where the hero section was rendered under the fixed header.

The header uses position: fixed which removes it from normal document flow, causing the hero content to overlap.

This fix adds layout spacing in the Landing page to offset the header height and ensure proper rendering of all sections.

## Related Issues
Thanks for pointing that out — you're right, this fix is not related to issue #385. I've removed the reference from the PR description.

## Changes
- Added top spacing in Landing layout to prevent hero overlap with fixed header

## Screenshots / Demos
N/A (layout fix)

## Checklist
- [ x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ x] CI passes

