### PR TITLE
fix: convert appointment time from UTC to local time for display

### DIFF
--- a/src/components/Dashboard/Opportunities/OpportunityCard.helpers.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityCard.helpers.tsx
@@ -1,4 +1,5 @@
 import { ConfettiIcon, PersonSimpleWalkIcon, ShootingStarIcon, TranslateIcon } from "@phosphor-icons/react";
+import { utcHhmmToLocal } from "@/utils";
 import { format } from "date-fns";
 import { ApiVolunteerOpportunityGetList, OpportunityStatusType, ProfileVolunteeringType } from "need4deed-sdk";
 import { JSX } from "react";
@@ -19,17 +20,7 @@ export function formatAccompanyingDate(details?: {
   const date = new Date(details.appointmentDate);
   const formattedDate = isNaN(date.getTime()) ? details.appointmentDate : format(date, "dd.MM.yyyy");
 
-  let formattedTime: string | null = null;
-  if (details.appointmentTime) {
-    const [h, m] = details.appointmentTime.split(":").map(Number);
-    if (!isNaN(h) && !isNaN(m)) {
-      const d = new Date();
-      d.setUTCHours(h, m, 0, 0);
-      formattedTime = d.toTimeString().slice(0, 5);
-    } else {
-      formattedTime = details.appointmentTime;
-    }
-  }
+  const formattedTime = details.appointmentTime ? utcHhmmToLocal(details.appointmentTime) : null;
 
   return [formattedDate, formattedTime].filter(Boolean).join(" ");
 }

--- a/src/components/Dashboard/Opportunities/OpportunityCard.helpers.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityCard.helpers.tsx
@@ -1,4 +1,5 @@
 import { ConfettiIcon, PersonSimpleWalkIcon, ShootingStarIcon, TranslateIcon } from "@phosphor-icons/react";
+import { format } from "date-fns";
 import { ApiVolunteerOpportunityGetList, OpportunityStatusType, ProfileVolunteeringType } from "need4deed-sdk";
 import { JSX } from "react";
 
@@ -7,6 +8,30 @@ export function formatAvailability(availability: ApiVolunteerOpportunityGetList[
   if (!first) return "";
   const parts = [first.day, first.daytime].filter(Boolean);
   return parts.join(", ");
+}
+
+export function formatAccompanyingDate(details?: {
+  appointmentDate?: string;
+  appointmentTime?: string;
+}): string | null {
+  if (!details?.appointmentDate) return null;
+
+  const date = new Date(details.appointmentDate);
+  const formattedDate = isNaN(date.getTime()) ? details.appointmentDate : format(date, "dd.MM.yyyy");
+
+  let formattedTime: string | null = null;
+  if (details.appointmentTime) {
+    const [h, m] = details.appointmentTime.split(":").map(Number);
+    if (!isNaN(h) && !isNaN(m)) {
+      const d = new Date();
+      d.setUTCHours(h, m, 0, 0);
+      formattedTime = d.toTimeString().slice(0, 5);
+    } else {
+      formattedTime = details.appointmentTime;
+    }
+  }
+
+  return [formattedDate, formattedTime].filter(Boolean).join(" ");
 }
 
 export const statusColorMap: Record<OpportunityStatusType, string> = {

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsDisplay.tsx
@@ -1,5 +1,6 @@
 import { EditableField } from "@/components/EditableField/EditableField";
 import { EMPTY_PLACEHOLDER_VALUE } from "@/config/constants";
+import { utcHhmmToLocal } from "@/utils";
 import { format } from "date-fns";
 import { useTranslation } from "react-i18next";
 import { AccompanyingDetailsFormData } from "./accompanyingDetailsSchema";
@@ -30,7 +31,7 @@ export const AccompanyingDetailsDisplay = ({ values, languageLabel }: Props) => 
 
       <DateFieldRow data-testid="appointment-time-field">
         <label>{t("dashboard.opportunityProfile.accompanyingDetails.appointmentTime")}</label>
-        <span>{values.appointmentTime || EMPTY_PLACEHOLDER_VALUE}</span>
+        <span>{values.appointmentTime ? utcHhmmToLocal(values.appointmentTime) : EMPTY_PLACEHOLDER_VALUE}</span>
       </DateFieldRow>
 
       <EditableField

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
@@ -30,16 +30,8 @@ export const parseDate = (date: Date | string | undefined): Date | null => {
 
 export const parseTime = (time: Date | string | undefined): string => {
   if (!time) return "";
-  if (typeof time === "string") {
-    const [h, m] = time.split(":").map(Number);
-    if (!isNaN(h) && !isNaN(m)) {
-      const d = new Date();
-      d.setUTCHours(h, m, 0, 0);
-      return d.toTimeString().slice(0, 5);
-    }
-    return time;
-  }
-  return time.toTimeString().slice(0, 5);
+  if (typeof time === "string") return time;
+  return String(time.getHours()).padStart(2, "0") + ":" + String(time.getMinutes()).padStart(2, "0");
 };
 
 export const getInitialFormValues = (

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
@@ -30,7 +30,15 @@ export const parseDate = (date: Date | string | undefined): Date | null => {
 
 export const parseTime = (time: Date | string | undefined): string => {
   if (!time) return "";
-  if (typeof time === "string") return time;
+  if (typeof time === "string") {
+    const [h, m] = time.split(":").map(Number);
+    if (!isNaN(h) && !isNaN(m)) {
+      const d = new Date();
+      d.setUTCHours(h, m, 0, 0);
+      return d.toTimeString().slice(0, 5);
+    }
+    return time;
+  }
   return time.toTimeString().slice(0, 5);
 };
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,6 +3,18 @@ export * from "./helpers";
 import { cloudfrontURL } from "@/config/constants";
 import { DocumentStatusType } from "need4deed-sdk";
 
+/**
+ * Converts a UTC "HH:mm" string to the browser's local time "HH:mm" string.
+ * Returns the original value unchanged if it cannot be parsed.
+ */
+export function utcHhmmToLocal(hhmm: string): string {
+  const [h, m] = hhmm.split(":").map(Number);
+  if (isNaN(h) || isNaN(m)) return hhmm;
+  const d = new Date();
+  d.setUTCHours(h, m, 0, 0);
+  return String(d.getHours()).padStart(2, "0") + ":" + String(d.getMinutes()).padStart(2, "0");
+}
+
 export function getDateLocalTooUTC(dateStr: string | undefined) {
   if (!dateStr) return undefined;
 


### PR DESCRIPTION
Closes #393

Appointment times were stored as UTC HH:mm strings by the API but rendered without any timezone conversion, causing them to appear 2 hours early for users in CEST (UTC+2). For example, an appointment at 10:30 CEST would show as 08:30.

Changes:
- `parseTime` in `AccompanyingDetails` helpers now converts a UTC HH:mm string to local time by setting UTC hours on a Date object and extracting via `toTimeString`, so the profile detail view shows the correct local time
- `formatAccompanyingDate` in OpportunityCard.helpers now formats the raw `appointmentDate` ISO string with date-fns and applies the same UTC-to-local conversion for `appointmentTime`, so the card view shows a human-readable date and the correct local time