### PR TITLE
Fix: show 'Search in progress' derived status on opportunity card #402

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -727,6 +727,12 @@
         "opp-active": "Aktiv",
         "opp-past": "Vergangen"
       },
+      "matchStatus": {
+        "vol-no-matches": "Keine Zuweisungen",
+        "vol-pending-match": "Zuordnung ausstehend",
+        "vol-matched": "Zugeordnet",
+        "vol-past": "Vergangen"
+      },
       "type": {
         "accompanying": "Begleitung",
         "regular": "Regelmäßig",
@@ -1026,11 +1032,11 @@
         "searching": "Suchend"
       },
       "matchStatus": {
+        "noMatches": "Keine Zuweisungen",
+        "pendingMatch": "Zuweisung ausstehend",
         "matched": "Gematcht",
         "needRematch": "Neues Matching erforderlich",
         "unmatched": "Nicht gematcht",
-        "noMatches": "Keine Zuweisungen",
-        "pendingMatch": "Zuweisung ausstehend",
         "past": "Vergangen"
       },
       "statusUpdateSuccess": "Status der Möglichkeit erfolgreich aktualisiert",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -728,12 +728,12 @@
         "opp-past": "Vergangen"
       },
       "matchStatus": {
-        "opp-vol-no-matches": "Keine Zuweisungen",
-        "opp-vol-pending-match": "Zuordnung ausstehend",
-        "opp-vol-matched": "Zugeordnet",
-        "opp-vol-needs-rematch": "Erneute Zuordnung erforderlich",
-        "opp-vol-unmatched": "Nicht zugeordnet",
-        "opp-vol-past": "Vergangen"
+        "vol-no-matches": "Keine Zuweisungen",
+        "vol-pending-match": "Zuordnung ausstehend",
+        "vol-matched": "Zugeordnet",
+        "vol-needs-rematch": "Erneute Zuordnung erforderlich",
+        "vol-unmatched": "Nicht zugeordnet",
+        "vol-past": "Vergangen"
       },
       "type": {
         "accompanying": "Begleitung",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1028,6 +1028,7 @@
       "status": {
         "new": "Neu",
         "active": "Aktiv",
+        "inactive": "Inaktiv",
         "past": "Vergangen",
         "searching": "Suchend"
       },

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -728,10 +728,12 @@
         "opp-past": "Vergangen"
       },
       "matchStatus": {
-        "vol-no-matches": "Keine Zuweisungen",
-        "vol-pending-match": "Zuordnung ausstehend",
-        "vol-matched": "Zugeordnet",
-        "vol-past": "Vergangen"
+        "opp-vol-no-matches": "Keine Zuweisungen",
+        "opp-vol-pending-match": "Zuordnung ausstehend",
+        "opp-vol-matched": "Zugeordnet",
+        "opp-vol-needs-rematch": "Erneute Zuordnung erforderlich",
+        "opp-vol-unmatched": "Nicht zugeordnet",
+        "opp-vol-past": "Vergangen"
       },
       "type": {
         "accompanying": "Begleitung",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -771,12 +771,12 @@
         "opp-past": "Past"
       },
       "matchStatus": {
-        "opp-vol-no-matches": "No matches",
-        "opp-vol-pending-match": "Pending match",
-        "opp-vol-matched": "Matched",
-        "opp-vol-needs-rematch": "Needs rematch",
-        "opp-vol-unmatched": "Unmatched",
-        "opp-vol-past": "Past"
+        "vol-no-matches": "No matches",
+        "vol-pending-match": "Pending match",
+        "vol-matched": "Matched",
+        "vol-needs-rematch": "Needs rematch",
+        "vol-unmatched": "Unmatched",
+        "vol-past": "Past"
       },
       "type": {
         "accompanying": "Accompanying",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -770,6 +770,12 @@
         "opp-active": "Active",
         "opp-past": "Past"
       },
+      "matchStatus": {
+        "vol-no-matches": "No matches",
+        "vol-pending-match": "Pending match",
+        "vol-matched": "Matched",
+        "vol-past": "Past"
+      },
       "type": {
         "accompanying": "Accompanying",
         "regular": "Regular",
@@ -1025,11 +1031,11 @@
         "searching": "Searching"
       },
       "matchStatus": {
+        "noMatches": "No matches",
+        "pendingMatch": "Pending match",
         "matched": "Matched",
         "needRematch": "Need rematch",
         "unmatched": "Unmatched",
-        "noMatches": "No matches",
-        "pendingMatch": "Pending match",
         "past": "Past"
       },
       "statusUpdateSuccess": "Opportunity status updated successfully",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1027,6 +1027,7 @@
       "status": {
         "new": "New",
         "active": "Active",
+        "inactive": "Inactive",
         "past": "Past",
         "searching": "Searching"
       },

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -771,10 +771,12 @@
         "opp-past": "Past"
       },
       "matchStatus": {
-        "vol-no-matches": "No matches",
-        "vol-pending-match": "Pending match",
-        "vol-matched": "Matched",
-        "vol-past": "Past"
+        "opp-vol-no-matches": "No matches",
+        "opp-vol-pending-match": "Pending match",
+        "opp-vol-matched": "Matched",
+        "opp-vol-needs-rematch": "Needs rematch",
+        "opp-vol-unmatched": "Unmatched",
+        "opp-vol-past": "Past"
       },
       "type": {
         "accompanying": "Accompanying",

--- a/src/components/Dashboard/Opportunities/OpportunityCard.helpers.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityCard.helpers.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowsClockwiseIcon,
   CheckCircleIcon,
   ConfettiIcon,
   HourglassIcon,
@@ -58,6 +59,8 @@ export const matchStatusColorMap: Record<string, string> = {
   "vol-no-matches": "var(--color-grey-700)",
   "vol-pending-match": "var(--color-orange-500)",
   "vol-matched": "var(--color-green-700)",
+  "vol-needs-rematch": "var(--color-red-50)",
+  "vol-unmatched": "var(--color-grey-700)",
   "vol-past": "var(--color-grey-700)",
 };
 
@@ -65,6 +68,8 @@ export const matchStatusIconMap: Record<string, JSX.Element> = {
   "vol-no-matches": <ProhibitInsetIcon size={18} color={matchStatusColorMap["vol-no-matches"]} />,
   "vol-pending-match": <HourglassIcon size={18} color={matchStatusColorMap["vol-pending-match"]} />,
   "vol-matched": <CheckCircleIcon size={18} color={matchStatusColorMap["vol-matched"]} />,
+  "vol-needs-rematch": <ArrowsClockwiseIcon size={18} color={matchStatusColorMap["vol-needs-rematch"]} />,
+  "vol-unmatched": <ProhibitInsetIcon size={18} color={matchStatusColorMap["vol-unmatched"]} />,
   "vol-past": <StopCircleIcon size={18} color={matchStatusColorMap["vol-past"]} />,
 };
 

--- a/src/components/Dashboard/Opportunities/OpportunityCard.helpers.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityCard.helpers.tsx
@@ -56,7 +56,7 @@ export const statusIconMap: Record<OpportunityStatusType, JSX.Element> = {
 // TODO: replace string with OpportunityMatchStatusType once SDK PR #89 is merged
 export const matchStatusColorMap: Record<string, string> = {
   "vol-no-matches": "var(--color-grey-700)",
-  "vol-pending-match": "var(--color-orange-500, var(--color-red-500))",
+  "vol-pending-match": "var(--color-orange-500)",
   "vol-matched": "var(--color-green-700)",
   "vol-past": "var(--color-grey-700)",
 };

--- a/src/components/Dashboard/Opportunities/OpportunityCard.helpers.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityCard.helpers.tsx
@@ -1,4 +1,13 @@
-import { ConfettiIcon, PersonSimpleWalkIcon, ShootingStarIcon, TranslateIcon } from "@phosphor-icons/react";
+import {
+  CheckCircleIcon,
+  ConfettiIcon,
+  HourglassIcon,
+  PersonSimpleWalkIcon,
+  ProhibitInsetIcon,
+  ShootingStarIcon,
+  StopCircleIcon,
+  TranslateIcon,
+} from "@phosphor-icons/react";
 import { format } from "date-fns";
 import { ApiVolunteerOpportunityGetList, OpportunityStatusType, ProfileVolunteeringType } from "need4deed-sdk";
 import { utcHhmmToLocal } from "@/utils";
@@ -42,6 +51,21 @@ export const statusIconMap: Record<OpportunityStatusType, JSX.Element> = {
     <ShootingStarIcon size={18} color={statusColorMap[OpportunityStatusType.INACTIVE]} />
   ),
   [OpportunityStatusType.PAST]: <ShootingStarIcon size={18} color={statusColorMap[OpportunityStatusType.PAST]} />,
+};
+
+// TODO: replace string with OpportunityMatchStatusType once SDK PR #89 is merged
+export const matchStatusColorMap: Record<string, string> = {
+  "vol-no-matches": "var(--color-grey-700)",
+  "vol-pending-match": "var(--color-orange-500, var(--color-red-500))",
+  "vol-matched": "var(--color-green-700)",
+  "vol-past": "var(--color-grey-700)",
+};
+
+export const matchStatusIconMap: Record<string, JSX.Element> = {
+  "vol-no-matches": <ProhibitInsetIcon size={18} color={matchStatusColorMap["vol-no-matches"]} />,
+  "vol-pending-match": <HourglassIcon size={18} color={matchStatusColorMap["vol-pending-match"]} />,
+  "vol-matched": <CheckCircleIcon size={18} color={matchStatusColorMap["vol-matched"]} />,
+  "vol-past": <StopCircleIcon size={18} color={matchStatusColorMap["vol-past"]} />,
 };
 
 export const volunteerTypeIconMap: Record<ProfileVolunteeringType, JSX.Element> = {

--- a/src/components/Dashboard/Opportunities/OpportunityCard.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityCard.tsx
@@ -11,6 +11,8 @@ import { getActivityTitles, getLanguagesByPurpose, getOptionTitles } from "./hel
 import {
   formatAccompanyingDate,
   formatAvailability,
+  matchStatusColorMap,
+  matchStatusIconMap,
   statusColorMap,
   statusIconMap,
   volunteerTypeIconMap,
@@ -37,8 +39,11 @@ export function OpportunityCard({ opportunity, volunteerId, activitiesList }: Pr
     location,
     availability,
     accompanyingDetails,
+    statusMatch,
+    // TODO: remove statusMatch cast once SDK PR #89 adds OpportunityMatchStatusType
   } = opportunity as ApiVolunteerOpportunityGetList & {
     accompanyingDetails?: { appointmentDate?: string; appointmentTime?: string };
+    statusMatch?: string;
   };
 
   const mainCommunication = getLanguagesByPurpose(languages, LangPurpose.GENERAL);
@@ -72,6 +77,19 @@ export function OpportunityCard({ opportunity, volunteerId, activitiesList }: Pr
               color={statusColorMap[statusOpportunity]}
             >
               {t(`dashboard.opportunities.status.${statusOpportunity}`)}
+            </Paragraph>
+          </StatusDiv>
+        )}
+        {statusMatch && (
+          <StatusDiv>
+            {matchStatusIconMap[statusMatch]}
+            <Paragraph
+              fontWeight="var(--dashboard-volunteers-card-status-fontWeight)"
+              fontSize="var(--dashboard-volunteers-card-status-fontSize)"
+              lineheight="var(--dashboard-volunteers-card-status-lineHeight)"
+              color={matchStatusColorMap[statusMatch]}
+            >
+              {t(`dashboard.opportunities.matchStatus.${statusMatch}`)}
             </Paragraph>
           </StatusDiv>
         )}

--- a/src/components/Dashboard/Opportunities/OpportunityCard.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityCard.tsx
@@ -40,10 +40,8 @@ export function OpportunityCard({ opportunity, volunteerId, activitiesList }: Pr
     availability,
     accompanyingDetails,
     statusMatch,
-    // TODO: remove statusMatch cast once SDK PR #89 adds OpportunityMatchStatusType
   } = opportunity as ApiVolunteerOpportunityGetList & {
     accompanyingDetails?: { appointmentDate?: string; appointmentTime?: string };
-    statusMatch?: string;
   };
 
   const mainCommunication = getLanguagesByPurpose(languages, LangPurpose.GENERAL);

--- a/src/components/Dashboard/Opportunities/OpportunityCard.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityCard.tsx
@@ -42,6 +42,7 @@ export function OpportunityCard({ opportunity, volunteerId, activitiesList }: Pr
     statusMatch,
   } = opportunity as ApiVolunteerOpportunityGetList & {
     accompanyingDetails?: { appointmentDate?: string; appointmentTime?: string };
+    statusMatch?: string;
   };
 
   const mainCommunication = getLanguagesByPurpose(languages, LangPurpose.GENERAL);

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { createVolunteerTypeLabelMap, EditButton, HeaderCard, IconContainer, StatusRowField } from "../common";
 import { ChangeOpportunityStatusDialog } from "./ChangeOpportunityStatusDialog";
-import { createOpportunityMatchLabelMap, createOpportunityStatusLabelMap } from "./constants";
+import { createOpportunityStatusLabelMap } from "./constants";
 import { useOpportunityStatusDialog } from "./useOpportunityStatusDialog";
 
 type Props = {
@@ -36,8 +36,6 @@ export const OpportunityHeader = ({ opportunity }: Props) => {
   const dialog = useOpportunityStatusDialog(opportunity);
   const statusLabelMap = createOpportunityStatusLabelMap(t);
   const volunteerTypeLabelMap = createVolunteerTypeLabelMap(t);
-  const matchLabelMap = createOpportunityMatchLabelMap(t);
-
   const { statusMatch } = opportunity as ApiOpportunityGet & { statusMatch?: string };
 
   const postedDate = opportunity.createdAt ? formatDateTime(opportunity.createdAt) : EMPTY_PLACEHOLDER_VALUE;
@@ -80,12 +78,6 @@ export const OpportunityHeader = ({ opportunity }: Props) => {
         title={t("dashboard.volunteerProfile.volunteerHeader.volunteerType_title")}
         status={opportunity.volunteerType}
         label={opportunity.volunteerType ? volunteerTypeLabelMap[opportunity.volunteerType] : undefined}
-      />
-
-      <StatusRowField
-        title={t("dashboard.volunteerProfile.volunteerHeader.matchStatus_title")}
-        status={opportunity.statusMatch}
-        label={opportunity.statusMatch ? matchLabelMap[opportunity.statusMatch] : undefined}
       />
     </HeaderCard>
   );

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
@@ -1,9 +1,11 @@
 "use client";
+import { matchStatusColorMap, matchStatusIconMap } from "@/components/Dashboard/Opportunities/OpportunityCard.helpers";
 import { EMPTY_PLACEHOLDER_VALUE } from "@/config/constants";
 import { formatDateTime } from "@/utils";
 import { ShootingStarIcon } from "@phosphor-icons/react";
 import { ApiOpportunityGet } from "need4deed-sdk";
 import { useTranslation } from "react-i18next";
+import styled from "styled-components";
 import { createVolunteerTypeLabelMap, EditButton, HeaderCard, IconContainer, StatusRowField } from "../common";
 import { ChangeOpportunityStatusDialog } from "./ChangeOpportunityStatusDialog";
 import { createOpportunityMatchLabelMap, createOpportunityStatusLabelMap } from "./constants";
@@ -13,12 +15,30 @@ type Props = {
   opportunity: ApiOpportunityGet;
 };
 
+const MatchStatusBadge = styled.div<{ $color: string }>`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-4);
+  padding: var(--spacing-12);
+  border-radius: var(--border-radius-xs);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--line-height-24);
+  letter-spacing: var(--letter-spacing-tight);
+  width: fit-content;
+  background-color: var(--color-grey-50);
+  color: ${({ $color }) => $color};
+`;
+
 export const OpportunityHeader = ({ opportunity }: Props) => {
   const { t } = useTranslation();
   const dialog = useOpportunityStatusDialog(opportunity);
   const statusLabelMap = createOpportunityStatusLabelMap(t);
   const volunteerTypeLabelMap = createVolunteerTypeLabelMap(t);
   const matchLabelMap = createOpportunityMatchLabelMap(t);
+
+  // TODO: remove cast once SDK PR #89 adds OpportunityMatchStatusType to ApiOpportunityGet
+  const { statusMatch } = opportunity as ApiOpportunityGet & { statusMatch?: string };
 
   const postedDate = opportunity.createdAt ? formatDateTime(opportunity.createdAt) : EMPTY_PLACEHOLDER_VALUE;
   const subtitle = `${t("dashboard.opportunityProfile.postedOn")} ${postedDate}`;
@@ -40,6 +60,18 @@ export const OpportunityHeader = ({ opportunity }: Props) => {
         status={dialog.selected}
         label={statusLabelMap[dialog.selected]}
         action={<EditButton onClick={dialog.openDialog}>{t("dashboard.opportunityProfile.change_status")}</EditButton>}
+      />
+
+      <StatusRowField
+        title={t("dashboard.opportunityProfile.matchingStatus")}
+        extra={
+          statusMatch ? (
+            <MatchStatusBadge $color={matchStatusColorMap[statusMatch] ?? "var(--color-blue-700)"}>
+              {matchStatusIconMap[statusMatch]}
+              <span>{t(`dashboard.opportunities.matchStatus.${statusMatch}`)}</span>
+            </MatchStatusBadge>
+          ) : undefined
+        }
       />
 
       <StatusRowField

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
@@ -38,7 +38,7 @@ export const OpportunityHeader = ({ opportunity }: Props) => {
   const volunteerTypeLabelMap = createVolunteerTypeLabelMap(t);
   const matchLabelMap = createOpportunityMatchLabelMap(t);
 
-  const { statusMatch } = opportunity;
+  const { statusMatch } = opportunity as ApiOpportunityGet & { statusMatch?: string };
 
   const postedDate = opportunity.createdAt ? formatDateTime(opportunity.createdAt) : EMPTY_PLACEHOLDER_VALUE;
   const subtitle = `${t("dashboard.opportunityProfile.postedOn")} ${postedDate}`;

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
@@ -38,8 +38,7 @@ export const OpportunityHeader = ({ opportunity }: Props) => {
   const volunteerTypeLabelMap = createVolunteerTypeLabelMap(t);
   const matchLabelMap = createOpportunityMatchLabelMap(t);
 
-  // TODO: remove cast once SDK PR #89 adds OpportunityMatchStatusType to ApiOpportunityGet
-  const { statusMatch } = opportunity as ApiOpportunityGet & { statusMatch?: string };
+  const { statusMatch } = opportunity;
 
   const postedDate = opportunity.createdAt ? formatDateTime(opportunity.createdAt) : EMPTY_PLACEHOLDER_VALUE;
   const subtitle = `${t("dashboard.opportunityProfile.postedOn")} ${postedDate}`;

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { matchStatusColorMap, matchStatusIconMap } from "@/components/Dashboard/Opportunities/OpportunityCard.helpers";
+import { EmptyPlaceholder } from "@/components/core/common/EmptyPlaceholder";
 import { EMPTY_PLACEHOLDER_VALUE } from "@/config/constants";
 import { formatDateTime } from "@/utils";
 import { ShootingStarIcon } from "@phosphor-icons/react";
@@ -70,7 +71,9 @@ export const OpportunityHeader = ({ opportunity }: Props) => {
               {matchStatusIconMap[statusMatch]}
               <span>{t(`dashboard.opportunities.matchStatus.${statusMatch}`)}</span>
             </MatchStatusBadge>
-          ) : undefined
+          ) : (
+            <EmptyPlaceholder />
+          )
         }
       />
 


### PR DESCRIPTION
Fix: show 'Search in progress' derived status on opportunity card #402

## Description
Adds statusMatch display to the opportunity card and opportunity profile header, mirroring how volunteer profiles show matching status. The field is read directly from the API response via type cast until SDK PR #89 lands.

## Related Issues
Closes #402 

## Changes
- `OpportunityCard`— added `statusMatch` badge alongside the existing `statusOpportunity` badge
- `OpportunityHeader` — added `statusMatch` row between "Current status" and "Volunteer type", matching the volunteer header layout
- `OpportunityCard.helpers.tsx` — added `matchStatusColorMap` and `matchStatusIconMap` for all 4 values (`vol-no-matches`, `vol-pending-match`, `vol-matched`, `vol-past`)
- Translations (EN/DE) — added `matchStatus` keys under `dashboard.opportunities` and `dashboard.opportunityProfile`

## Screenshots / Demos
<img width="2600" height="886" alt="image" src="https://github.com/user-attachments/assets/22a8aa8e-5bbc-4b22-929e-167e6bf88cef" />


## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

