### PR TITLE
Fix waysToContact not displaying when API returns a string value

### DIFF
--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
@@ -39,13 +39,20 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
 
   const schema = createOpportunityContactDetailsSchema(t);
 
-  const initialFormValues = useMemo(
-    () => ({
-      ...opportunity.contact,
-      waysToContact: Array.isArray(opportunity.contact.waysToContact) ? opportunity.contact.waysToContact : [],
-    }),
-    [opportunity.contact],
-  );
+  const initialFormValues = useMemo(() => {
+    const raw = opportunity.contact.waysToContact;
+    const waysToContact: PreferredCommunicationType[] = Array.isArray(raw)
+      ? raw
+      : typeof raw === "string" && raw
+        ? [raw as PreferredCommunicationType]
+        : [];
+    return {
+      name: opportunity.contact.name ?? "",
+      phone: opportunity.contact.phone ?? "",
+      email: opportunity.contact.email ?? "",
+      waysToContact,
+    };
+  }, [opportunity.contact]);
 
   const methods = useForm<OpportunityContactDetailsFormData>({
     resolver: zodResolver(schema),

--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
@@ -41,11 +41,16 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
 
   const initialFormValues = useMemo(() => {
     const raw = opportunity.contact.waysToContact;
+    const validTypes = new Set<string>(COMMUNICATION_TYPES);
+
     const waysToContact: PreferredCommunicationType[] = Array.isArray(raw)
-      ? raw
-      : typeof raw === "string" && raw
+      ? raw.filter((v): v is PreferredCommunicationType => validTypes.has(v))
+      : typeof raw === "string" && validTypes.has(raw)
         ? [raw as PreferredCommunicationType]
         : [];
+
+    // Fields are listed explicitly to stay in sync with OpportunityContactDetailsFormData.
+    // If the schema adds or removes fields, update this object accordingly.
     return {
       name: opportunity.contact.name ?? "",
       phone: opportunity.contact.phone ?? "",


### PR DESCRIPTION
Closes #399
The API returns `waysToContact` as a plain string (e.g. `"mobilePhone"`) instead of an array. The existing guard only checked `Array.isArray`, so a string value was silently dropped and the field always displayed "–" even when data existed.
Changes:
- `OpportunityContactDetails.tsx`: handle `waysToContact` as either a `PreferredCommunicationType[]` or a single string, wrapping the string case in a one-element array
- Made the other contact fields (`name`, `phone`, `email`) explicitly default to `""` instead of relying on the spread to avoid undefined values slipping through