### PR TITLE
Fix opportunity details form blocked when no schedule is set

### DIFF
--- a/src/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema.ts
@@ -34,17 +34,7 @@ export const createOpportunityDetailsSchema = (t: (key: string) => string) =>
     }),
     mainCommunication: languagesValidator(t),
     residentsSpeak: languagesValidator(t),
-    availability: z
-      .custom<Availability>(
-        (data) => {
-          if (data === null || data === undefined) return true;
-          if (!Array.isArray(data)) return false;
-          return data.some((day) => day.timeSlots.some((slot: { selected: boolean }) => slot.selected));
-        },
-        t(`${i18nPrefix}.availabilityRequired`),
-      )
-      .nullable()
-      .optional(),
+    availability: z.custom<Availability>().nullable().optional(),
     eventDate: z.date().nullable().optional(),
     eventTime: z.string().optional(),
     activities: z.array(z.string()).min(1, t(`${i18nPrefix}.activitiesRequired`)),


### PR DESCRIPTION
Closes #400

The Save Changes button on the opportunity details edit form was permanently
disabled for opportunities with no schedule set. The Zod schema for the
availability field ran a custom validator that required at least one time slot
to be selected, but `apiToFormAvailability()` always returns a full grid
(all slots deselected) even when the opportunity has no schedule, making the
form invalid on load with no way to fix it.

Since schedule is an optional field for opportunities, the custom validator is
not needed here. Removed it so the form is valid regardless of whether a
schedule has been entered.

Changes:
- `opportunityDetailsSchema.ts`: replaced the custom availability validator
  (which required ≥1 selected slot) with z.custom().nullable().optional(),
  making the field truly optional
