### PR TITLE
Fix: Missing comments row on Volunteer Profile #413

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -607,6 +607,7 @@
         "volunteerType": "Freiwilligen-Typ",
         "activities": "Aktivitäten",
         "skills": "Fähigkeiten & Erfahrungen",
+        "comments": "Kommentare",
         "cancel": "Abbrechen",
         "saveChanges": "Änderungen speichern",
         "saveSuccess": "Profil erfolgreich aktualisiert",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -606,6 +606,7 @@
         "volunteerType": "Volunteer type",
         "activities": "Activities",
         "skills": "Skills & experience",
+        "comments": "Comments",
         "cancel": "Cancel",
         "saveChanges": "Save changes",
         "saveSuccess": "Profile updated successfully",

--- a/src/components/Dashboard/Profile/sections/VolunteerProfile/DisplayFields.tsx
+++ b/src/components/Dashboard/Profile/sections/VolunteerProfile/DisplayFields.tsx
@@ -48,7 +48,7 @@ type Props = {
   volunteerTypeStatus: StatusValue | undefined;
   activities: string[];
   skills: string[];
-  infoAbout: string;
+  comments: string | undefined;
   t: (key: string) => string;
 };
 
@@ -61,7 +61,7 @@ export function DisplayFields({
   volunteerTypeStatus,
   activities,
   skills,
-  infoAbout,
+  comments,
   t,
 }: Props) {
   return (
@@ -125,7 +125,7 @@ export function DisplayFields({
 
       <FieldRow>
         <FieldLabel>{t("dashboard.volunteerProfile.profileSection.comments")}</FieldLabel>
-        <FieldValue>{infoAbout || <EmptyPlaceholder />}</FieldValue>
+        <FieldValue>{comments || <EmptyPlaceholder />}</FieldValue>
       </FieldRow>
     </>
   );

--- a/src/components/Dashboard/Profile/sections/VolunteerProfile/DisplayFields.tsx
+++ b/src/components/Dashboard/Profile/sections/VolunteerProfile/DisplayFields.tsx
@@ -48,6 +48,7 @@ type Props = {
   volunteerTypeStatus: StatusValue | undefined;
   activities: string[];
   skills: string[];
+  infoAbout: string;
   t: (key: string) => string;
 };
 
@@ -60,6 +61,7 @@ export function DisplayFields({
   volunteerTypeStatus,
   activities,
   skills,
+  infoAbout,
   t,
 }: Props) {
   return (
@@ -119,6 +121,11 @@ export function DisplayFields({
             <EmptyPlaceholder />
           )}
         </FieldValue>
+      </FieldRow>
+
+      <FieldRow>
+        <FieldLabel>{t("dashboard.volunteerProfile.profileSection.comments")}</FieldLabel>
+        <FieldValue>{infoAbout || <EmptyPlaceholder />}</FieldValue>
       </FieldRow>
     </>
   );

--- a/src/components/Dashboard/Profile/sections/VolunteerProfile/VolunteerProfile.tsx
+++ b/src/components/Dashboard/Profile/sections/VolunteerProfile/VolunteerProfile.tsx
@@ -169,6 +169,7 @@ export const VolunteerProfile = forwardRef<VolunteerProfileRef, Props>(function 
             volunteerTypeStatus={volunteer.statusType}
             activities={extractTitles(volunteer.activities)}
             skills={extractTitles(volunteer.skills)}
+            infoAbout={volunteer.infoAbout || ""}
             t={t}
           />
         )}

--- a/src/components/Dashboard/Profile/sections/VolunteerProfile/VolunteerProfile.tsx
+++ b/src/components/Dashboard/Profile/sections/VolunteerProfile/VolunteerProfile.tsx
@@ -169,7 +169,7 @@ export const VolunteerProfile = forwardRef<VolunteerProfileRef, Props>(function 
             volunteerTypeStatus={volunteer.statusType}
             activities={extractTitles(volunteer.activities)}
             skills={extractTitles(volunteer.skills)}
-            infoAbout={volunteer.infoAbout || ""}
+            comments={volunteer.infoAbout}
             t={t}
           />
         )}


### PR DESCRIPTION
Fix: Missing comments row on Volunteer Profile #413

## Description
The volunteer profile was missing the Comments field from the display view, this adds the missing row.

## Related Issues
Closes #413 

## Changes
Added comments translation key to EN and DE locale files under dashboard.volunteerProfile.profileSection
Added infoAbout prop to DisplayFields and rendered it as a new field row below "Skills & experience"
Passed volunteer.infoAbout from VolunteerProfile into DisplayFields

## Screenshots / Demos
<img width="2498" height="1466" alt="image" src="https://github.com/user-attachments/assets/b77d5362-62c3-4e1d-9a5c-970f201b0c52" />

## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

