### PR TITLE
fix: show Farsi/Dari instead of Persian in the language filter

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1655,6 +1655,7 @@
     "farsi/dari": "Farsi/Dari",
     "farsi": "Farsi",
     "dari": "Dari",
+    "persian": "Farsi/Dari",
     "turkish": "Türkisch",
     "russian": "Russisch",
     "ukrainian": "Ukrainisch",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1287,6 +1287,7 @@
     "farsi/dari": "Farsi/Dari",
     "farsi": "Farsi",
     "dari": "Dari",
+    "persian": "Farsi/Dari",
     "turkish": "Turkish",
     "russian": "Russian",
     "ukrainian": "Ukrainian",

--- a/src/components/Dashboard/Opportunities/Filters/helpers.ts
+++ b/src/components/Dashboard/Opportunities/Filters/helpers.ts
@@ -20,7 +20,11 @@ export const createOpportunityFilterItems = (
     filter[QueryParamsKeys.LANGUAGE],
     setFilter,
     QueryParamsKeys.LANGUAGE,
-    (key) => key,
+    (key) => {
+      const translationKey = `languageNames.${key.toLowerCase()}`;
+      const translated = t(translationKey);
+      return translated !== translationKey ? translated : key;
+    },
   );
 
   const statusFilters = generateNestedFilterControlItems(filter.status, setFilter, "status", (key) =>


### PR DESCRIPTION
Closes #404

The opportunity language filter was showing "Persian" as the checkbox label
because it used the raw title returned by the API options endpoint. However,
the rest of the UI (volunteer profiles, opportunity profiles) refers to this
language as "Farsi/Dari" using the languageNames translation section. The
mismatch meant users looking for Farsi/Dari speakers could not find the
correct filter option.

Changes:
- Opportunities/Filters/helpers.ts: language label resolver now looks up
  the API title in the languageNames translation namespace (with fallback
  to the raw title), making filter labels consistent with how languages
  appear in profiles
- translations (EN/DE): added "persian": "Farsi/Dari" to languageNames so
  the API title "Persian" maps to the display name "Farsi/Dari"

