### PR TITLE
Feature 411: adds newest opportunities and volunteers to dashboard home page

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -399,6 +399,12 @@
       }
     },
     "home": {
+      "content": {
+        "header": "Dashboard Startseite",
+        "newOpportunities": "Neueste Möglichkeiten",
+        "newVolunteers": "Neueste Freiwillige",
+        "loading": "Wird geladen..."
+      },
       "sidebar": {
         "home": "Startseite",
         "volunteers": "Freiwillige",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -399,6 +399,12 @@
       }
     },
     "home": {
+      "content": {
+        "header": "Dashboard Home",
+        "newOpportunities": "Newest Opportunities",
+        "newVolunteers": "Newest Volunteers",
+        "loading": "Loading..."
+      },
       "sidebar": {
         "home": "Home",
         "volunteers": "Volunteers",

--- a/src/app/[lang]/globals.css
+++ b/src/app/[lang]/globals.css
@@ -1305,6 +1305,7 @@ html {
 
     --dashboard-home-container-padding: 40px 120px 100px 132px;
     --dashboard-home-container-gap: 20px;
+    --dashboard-home-container-min-height: 300px;
 
     --search-container-height: 64px;
     --search-container-border-radius: 160px;

--- a/src/components/Dashboard/Home/Home.tsx
+++ b/src/components/Dashboard/Home/Home.tsx
@@ -1,15 +1,8 @@
 "use client";
 
-import styled from "styled-components";
 import DashboardHomeContent from "./HomeContent";
 import { DashboardLayout } from "@/components/Layout";
-
-const HomeContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  padding: var(--dashboard-home-container-padding);
-  gap: var(--dashboard-home-container-gap);
-`;
+import { HomeContainer } from "./styles";
 
 export function DashboardHome() {
   return (

--- a/src/components/Dashboard/Home/HomeContent.tsx
+++ b/src/components/Dashboard/Home/HomeContent.tsx
@@ -1,16 +1,23 @@
-import { Heading2 } from "@/components/styled/text";
+import { Heading2, Heading3 } from "@/components/styled/text";
 import React from "react";
-import styled from "styled-components";
-
-const DashboardContentContainer = styled.div`
-  display: flex;
-  height: 300px;
-`;
+import { NewestOpportunities } from "./NewestOpportunities";
+import { NewestVolunteers } from "./NewestVolunteers";
+import { DashboardCardContainer, DashboardContentContainer } from "./styles";
+import { useTranslation } from "react-i18next";
 
 export default function DashboardHomeContent() {
+  const { t } = useTranslation();
   return (
     <DashboardContentContainer>
-      <Heading2>Dashboard Content...</Heading2>
+      <Heading2>{t("dashboard.home.content.header")}</Heading2>
+      <Heading3>{t("dashboard.home.content.newOpportunities")}</Heading3>
+      <DashboardCardContainer>
+        <NewestOpportunities />
+      </DashboardCardContainer>
+      <Heading3>{t("dashboard.home.content.newVolunteers")}</Heading3>
+      <DashboardCardContainer>
+        <NewestVolunteers />
+      </DashboardCardContainer>
     </DashboardContentContainer>
   );
 }

--- a/src/components/Dashboard/Home/NewestOpportunities.tsx
+++ b/src/components/Dashboard/Home/NewestOpportunities.tsx
@@ -8,8 +8,8 @@ import { Heading4 } from "@/components/styled/text";
 export function NewestOpportunities() {
   const { t } = useTranslation();
   const { data: apiFilterOptions } = useGetQuery<ApiOptionLists>({ queryKey: ["options"], apiPath: apiPathOption });
-  const { data: opportunities } = useGetQuery<ApiVolunteerOpportunityGetList[]>({
-    queryKey: ["opportunities"],
+  const { data: opportunities, isLoading } = useGetQuery<ApiVolunteerOpportunityGetList[]>({
+    queryKey: ["opportunities", "newest"],
     apiPath: `${apiPathOpportunity}/`,
     params: {
       limit: 2,
@@ -21,8 +21,8 @@ export function NewestOpportunities() {
   });
   const activitiesList = apiFilterOptions?.activity;
 
-  if (opportunities?.length === 0) {
-    <Heading4>{t("dashboard.home.content.loading")}</Heading4>;
+  if (isLoading) {
+    return <Heading4>{t("dashboard.home.content.loading")}</Heading4>;
   }
 
   return opportunities?.map((opp) => (

--- a/src/components/Dashboard/Home/NewestOpportunities.tsx
+++ b/src/components/Dashboard/Home/NewestOpportunities.tsx
@@ -1,0 +1,31 @@
+import { apiPathOpportunity, apiPathOption, cacheTTL } from "@/config/constants";
+import { useGetQuery } from "@/hooks";
+import { ApiOptionLists, ApiVolunteerOpportunityGetList, OpportunityStatusType, SortOrder } from "need4deed-sdk";
+import { OpportunityCard } from "../Opportunities/OpportunityCard";
+import { useTranslation } from "react-i18next";
+import { Heading4 } from "@/components/styled/text";
+
+export function NewestOpportunities() {
+  const { t } = useTranslation();
+  const { data: apiFilterOptions } = useGetQuery<ApiOptionLists>({ queryKey: ["options"], apiPath: apiPathOption });
+  const { data: opportunities } = useGetQuery<ApiVolunteerOpportunityGetList[]>({
+    queryKey: ["opportunities"],
+    apiPath: `${apiPathOpportunity}/`,
+    params: {
+      limit: 2,
+      page: 1,
+      sortOrder: SortOrder.NewToOld,
+      filter: { status: OpportunityStatusType.NEW },
+    },
+    staleTime: cacheTTL,
+  });
+  const activitiesList = apiFilterOptions?.activity;
+
+  if (opportunities?.length === 0) {
+    <Heading4>{t("dashboard.home.content.loading")}</Heading4>;
+  }
+
+  return opportunities?.map((opp) => (
+    <OpportunityCard key={opp.id} opportunity={opp} volunteerId={undefined} activitiesList={activitiesList} />
+  ));
+}

--- a/src/components/Dashboard/Home/NewestVolunteers.tsx
+++ b/src/components/Dashboard/Home/NewestVolunteers.tsx
@@ -1,0 +1,27 @@
+import { apiPathVolunteer, cacheTTL } from "@/config/constants";
+import { useGetQuery } from "@/hooks";
+import { ApiVolunteerGetList, SortOrder, VolunteerStateEngagementType } from "need4deed-sdk";
+import VolunteerCard from "../Volunteers/VolunteerCard";
+import { Heading4 } from "@/components/styled/text";
+import { useTranslation } from "react-i18next";
+
+export function NewestVolunteers() {
+  const { t } = useTranslation();
+  const { data: volunteers } = useGetQuery<ApiVolunteerGetList[]>({
+    queryKey: ["volunteers"],
+    apiPath: `${apiPathVolunteer}/`,
+    params: {
+      limit: 2,
+      page: 1,
+      sortOrder: SortOrder.NewToOld,
+      filter: { status: VolunteerStateEngagementType.NEW },
+    },
+    staleTime: cacheTTL,
+  });
+
+  if (volunteers?.length === 0) {
+    <Heading4>{t("dashboard.home.content.loading")}</Heading4>;
+  }
+
+  return volunteers?.map((vol) => <VolunteerCard key={vol.id} volunteer={vol} />);
+}

--- a/src/components/Dashboard/Home/NewestVolunteers.tsx
+++ b/src/components/Dashboard/Home/NewestVolunteers.tsx
@@ -7,8 +7,8 @@ import { useTranslation } from "react-i18next";
 
 export function NewestVolunteers() {
   const { t } = useTranslation();
-  const { data: volunteers } = useGetQuery<ApiVolunteerGetList[]>({
-    queryKey: ["volunteers"],
+  const { data: volunteers, isLoading } = useGetQuery<ApiVolunteerGetList[]>({
+    queryKey: ["volunteers", "newest"],
     apiPath: `${apiPathVolunteer}/`,
     params: {
       limit: 2,
@@ -19,8 +19,8 @@ export function NewestVolunteers() {
     staleTime: cacheTTL,
   });
 
-  if (volunteers?.length === 0) {
-    <Heading4>{t("dashboard.home.content.loading")}</Heading4>;
+  if (isLoading) {
+    return <Heading4>{t("dashboard.home.content.loading")}</Heading4>;
   }
 
   return volunteers?.map((vol) => <VolunteerCard key={vol.id} volunteer={vol} />);

--- a/src/components/Dashboard/Home/styles.ts
+++ b/src/components/Dashboard/Home/styles.ts
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+
+export const HomeContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  padding: var(--dashboard-home-container-padding);
+  gap: var(--dashboard-home-container-gap);
+`;
+
+export const DashboardContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--dashboard-home-container-gap);
+`;
+
+export const DashboardCardContainer = styled.div`
+  display: flex;
+  gap: var(--dashboard-home-container-gap);
+`;

--- a/src/components/Dashboard/Home/styles.ts
+++ b/src/components/Dashboard/Home/styles.ts
@@ -11,6 +11,7 @@ export const DashboardContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: var(--dashboard-home-container-gap);
+  min-height: var(--dashboard-home-container-min-height);
 `;
 
 export const DashboardCardContainer = styled.div`


### PR DESCRIPTION
## Description
 Adds newest opportunities and volunteers to dashboard home page (2 of each)

## Related Issues
Closes #411 

## Changes
- Fetches two of newest opportunities and volunteers on `/dashboard` page

## Screenshots / Demos
<img width="1681" height="884" alt="image" src="https://github.com/user-attachments/assets/9887b2a1-8872-454e-9290-307ec0e4a48f" />


## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

