### PR TITLE
fix: correct agent profile save mutations and cache invalidation

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -954,6 +954,7 @@
         "clientLanguages": "Sprachen der Klient:innen",
         "cancel": "Abbrechen",
         "saveChanges": "Änderungen speichern",
+        "saveSuccess": "Organisationsdetails erfolgreich aktualisiert",
         "validation": {
           "required": "Dieses Feld ist erforderlich",
           "websiteInvalid": "Webseite muss mit http:// oder https:// beginnen",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -953,6 +953,7 @@
         "clientLanguages": "Client languages",
         "cancel": "Cancel",
         "saveChanges": "Save changes",
+        "saveSuccess": "Organisation details updated successfully",
         "validation": {
           "required": "This field is required",
           "websiteInvalid": "Website must start with http:// or https://",

--- a/src/components/Dashboard/Profile/sections/ContactDetails/agent/AgentContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/agent/AgentContactDetails.tsx
@@ -30,7 +30,7 @@ export const AgentContactDetails = forwardRef<ContactDetailsRef, Props>(function
   ref,
 ) {
   const { t } = useTranslation();
-  const { mutate: updateAgent, isPending } = useUpdateAgentContact(String(agent?.representative?.id));
+  const { mutate: updateAgent, isPending } = useUpdateAgentContact(String(agent?.representative?.id), String(agent?.id));
   const [isEditing, setIsEditing] = useState(false);
 
   useEditingChangeNotifier(isEditing, onEditingChange);

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
@@ -24,7 +24,7 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
 ) {
   const { t, i18n } = useTranslation();
   const [isEditing, setIsEditing] = useState(false);
-  const { mutate: updateOrganization /*, isPending */ } = useUpdateOrganization(String(agent?.operator));
+  const { mutate: updateOrganization /*, isPending */ } = useUpdateOrganization(String(agent?.id));
 
   useEditingChangeNotifier(isEditing, onEditingChange);
   const { data: apiLanguages } = useApiLanguages();
@@ -56,12 +56,15 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
   };
 
   const onSubmit = (values: OrganisationDetailsFormData) => {
-    updateOrganization(values as unknown as ApiAgentProfileGet, {
-      onSuccess: () => {
-        reset(values);
-        setIsEditing(false);
+    updateOrganization(
+      { about: values.about, website: values.website },
+      {
+        onSuccess: () => {
+          reset(values);
+          setIsEditing(false);
+        },
       },
-    });
+    );
   };
 
   return (

--- a/src/hooks/useUpdateAgentContact.ts
+++ b/src/hooks/useUpdateAgentContact.ts
@@ -4,11 +4,11 @@ import { useMutationQuery } from "@/hooks";
 import { ApiRepresentativeGet } from "need4deed-sdk";
 import { DeepPartial } from "ts-type-safe";
 
-export const useUpdateAgentContact = (personId: string) => {
+export const useUpdateAgentContact = (personId: string, agentId: string) => {
   return useMutationQuery<DeepPartial<ApiRepresentativeGet>, ApiAgentProfileGet>({
     apiPath: `${apiPathPerson}${personId}`,
     method: "patch",
     successMessage: "dashboard.agentProfile.contactDetails.saveSuccess",
-    queryKeyToInvalidate: ["agent", personId],
+    queryKeyToInvalidate: ["agent", agentId],
   });
 };

--- a/src/hooks/useUpdateOrganizationDetails.ts
+++ b/src/hooks/useUpdateOrganizationDetails.ts
@@ -1,14 +1,16 @@
 import { ApiAgentProfileGet } from "@/components/Dashboard/Profile/types";
-import { apiPathOrganization } from "@/config/constants";
+import { apiPathAgent } from "@/config/constants";
 import { useMutationQuery } from "@/hooks";
-import { ApiRepresentativeGet } from "need4deed-sdk";
-import { DeepPartial } from "ts-type-safe";
+import { ApiAgentPatch } from "need4deed-sdk";
 
-export const useUpdateOrganization = (organizationId: string) => {
-  return useMutationQuery<DeepPartial<ApiRepresentativeGet>, ApiAgentProfileGet>({
-    apiPath: `${apiPathOrganization}${organizationId}`,
+// Patches agent-level org details (about, website) via the agent endpoint.
+// Note: address and district require the organization's numeric ID which is not
+// currently exposed in the agent API response — those fields need a BE change.
+export const useUpdateOrganization = (agentId: string) => {
+  return useMutationQuery<Pick<ApiAgentPatch, "about" | "website">, ApiAgentProfileGet>({
+    apiPath: `${apiPathAgent}/${agentId}`,
     method: "patch",
-    successMessage: "__dashboard.agentProfile.contactDetails.saveSuccess",
-    queryKeyToInvalidate: ["organization", organizationId],
+    successMessage: "dashboard.agentProfile.organisationDetails.saveSuccess",
+    queryKeyToInvalidate: ["agent", agentId],
   });
 };


### PR DESCRIPTION
## Summary

Fixes two broken save hooks in the agent profile that caused edits to silently fail or not refresh the UI:

**Contact details** (https://github.com/need4deed-org/fe/issues/392):
- `useUpdateAgentContact` was invalidating `["agent", personId]` (the representative's person ID) instead of `["agent", agentId]` (the agent entity ID). The cache key used when fetching the profile is `["agent", entityId]` where `entityId` is the agent's own ID, so the profile never refreshed after saving.

**Organisation details** (https://github.com/need4deed-org/fe/issues/354):
- `useUpdateOrganization` was calling `PATCH /api/organization/:operator` where `operator` is a free-text string (e.g. "Bayern Rotes Kreuz"), not a numeric ID — every save was a 404 that silently failed.
- The hook also used `DeepPartial<ApiRepresentativeGet>` (a person type) as the request body, had a double-underscore typo in the success message key, and invalidated the wrong cache key.
- Fixed to call `PATCH /api/agent/:agentId` which accepts `about` and `website`. The organisation's numeric ID is not exposed in the current agent API response, so the `address` field cannot yet be saved — this needs a separate BE change to expose the org ID.

## Test plan

- [ ] Edit agent contact details (name, role, email, phone) — profile refreshes after save
- [ ] Edit organisation details (about, website) — profile refreshes after save showing updated values
- [ ] Confirm address field still displays correctly (read-only for now, pending BE change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)