### PR TITLE
feat: add schedule availability filter to opportunities dashboard

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -740,6 +740,9 @@
           "opp-searching": "Suche läuft",
           "opp-active": "Aktiv",
           "opp-past": "Vergangen"
+        },
+        "schedule": {
+          "header": "Zeitplan"
         }
       },
       "accompanyingTranslation": {

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -743,6 +743,30 @@
         },
         "schedule": {
           "header": "Zeitplan"
+        },
+        "preferredAv": {
+          "days": {
+            "header": "Tage",
+            "Monday": "Mo",
+            "Tuesday": "Di",
+            "Wednesday": "Mi",
+            "Thursday": "Do",
+            "Friday": "Fr",
+            "Saturday": "Sa",
+            "Sunday": "So"
+          },
+          "times": {
+            "header": "Zeiten",
+            "08-11": "08-11",
+            "11-14": "11-14",
+            "14-17": "14-17",
+            "17-20": "17-20"
+          },
+          "occasional": {
+            "header": "Gelegentlich",
+            "weekdays": "Wochentage",
+            "weekends": "Wochenenden"
+          }
         }
       },
       "accompanyingTranslation": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -784,6 +784,30 @@
         },
         "schedule": {
           "header": "Schedule"
+        },
+        "preferredAv": {
+          "days": {
+            "header": "Days",
+            "Monday": "Mon",
+            "Tuesday": "Tue",
+            "Wednesday": "Wed",
+            "Thursday": "Thu",
+            "Friday": "Fr",
+            "Saturday": "Sat",
+            "Sunday": "Sun"
+          },
+          "times": {
+            "header": "Times",
+            "08-11": "08-11",
+            "11-14": "11-14",
+            "14-17": "14-17",
+            "17-20": "17-20"
+          },
+          "occasional": {
+            "header": "Occasional",
+            "weekdays": "Weekdays",
+            "weekends": "Weekends"
+          }
         }
       },
       "accompanyingTranslation": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -781,6 +781,9 @@
           "opp-searching": "Searching",
           "opp-active": "Active",
           "opp-past": "Past"
+        },
+        "schedule": {
+          "header": "Schedule"
         }
       },
       "accompanyingTranslation": {

--- a/src/components/Dashboard/Opportunities/Filters/FiltersContent.tsx
+++ b/src/components/Dashboard/Opportunities/Filters/FiltersContent.tsx
@@ -13,7 +13,7 @@ type Props = {
 export default function FiltersContent({ setFilter, filter }: Props) {
   const { t } = useTranslation();
 
-  const { districtFilters, languageFilters, statusFilters, typeFilters, activityFilters } =
+  const { districtFilters, languageFilters, statusFilters, typeFilters, activityFilters, availabilityFilters } =
     createOpportunityFilterItems(filter, setFilter, t);
   return (
     <FiltersContentContainer data-testid="opportunity-filters-content">
@@ -22,6 +22,11 @@ export default function FiltersContent({ setFilter, filter }: Props) {
       <AccordionFilter header={t("dashboard.volunteers.filters.district")} items={districtFilters} />
       <AccordionFilter header={t("dashboard.volunteers.filters.languages")} items={languageFilters} />
       <AccordionFilter header={t("dashboard.volunteers.filters.activities")} items={activityFilters} />
+      <AccordionFilter
+        header={t("dashboard.opportunities.filters.schedule.header")}
+        groupedItems={availabilityFilters}
+        groupedItemsDisplayType="button"
+      />
     </FiltersContentContainer>
   );
 }

--- a/src/components/Dashboard/Opportunities/Filters/constants.ts
+++ b/src/components/Dashboard/Opportunities/Filters/constants.ts
@@ -1,4 +1,12 @@
-import { EntityTableName, OpportunityStatusType, OpportunityType, QueryParamsKeys } from "need4deed-sdk";
+import {
+  ByDay,
+  EntityTableName,
+  OccasionalType,
+  OpportunityStatusType,
+  OpportunityType,
+  QueryParamsKeys,
+  TimeSlot,
+} from "need4deed-sdk";
 import { OpportunityCardsFilter } from "./types";
 
 export const defaultOpportunityCardsFilter: OpportunityCardsFilter = {
@@ -17,4 +25,29 @@ export const defaultOpportunityCardsFilter: OpportunityCardsFilter = {
     [OpportunityType.REGULAR]: false,
   },
   [EntityTableName.ACTIVITY]: {},
+  [QueryParamsKeys.AVAILABILITY]: {
+    times: {
+      [TimeSlot.morning]: false,
+      [TimeSlot.noon]: false,
+      [TimeSlot.afternoon]: false,
+      [TimeSlot.evening]: false,
+    },
+    days: {
+      [ByDay.MO]: false,
+      [ByDay.TU]: false,
+      [ByDay.WE]: false,
+      [ByDay.TH]: false,
+      [ByDay.FR]: false,
+      [ByDay.SA]: false,
+      [ByDay.SU]: false,
+    },
+    occasional: {
+      [OccasionalType.WEEKDAYS]: false,
+      [OccasionalType.WEEKENDS]: false,
+    },
+  },
 };
+
+export const SEPARATOR = "~";
+export type AvailabilityKeys = keyof OpportunityCardsFilter["availability"];
+export type AvailabilitySubKeys = TimeSlot | ByDay | OccasionalType;

--- a/src/components/Dashboard/Opportunities/Filters/helpers.ts
+++ b/src/components/Dashboard/Opportunities/Filters/helpers.ts
@@ -54,9 +54,9 @@ export const createAvailabilityFilterItems = (
   const { days, times, occasional } = availability;
 
   const createAvailabilityGroup = <K extends keyof ScheduleFilter, T extends SelectionMap>(labelKey: K, obj: T) => ({
-    label: t(`dashboard.volunteers.filters.preferredAv.${labelKey}.header`),
+    label: t(`dashboard.opportunities.filters.preferredAv.${labelKey}.header`),
     items: Object.keys(obj).map((key) => ({
-      label: t(`dashboard.volunteers.filters.preferredAv.${labelKey}.${key}`),
+      label: t(`dashboard.opportunities.filters.preferredAv.${labelKey}.${key}`),
       checked: obj[key],
       onChange: (checked: boolean) => {
         const updated = { ...obj, [key]: checked };

--- a/src/components/Dashboard/Opportunities/Filters/helpers.ts
+++ b/src/components/Dashboard/Opportunities/Filters/helpers.ts
@@ -1,6 +1,6 @@
 import { TFunction } from "i18next";
 import { generateNestedFilterControlItems } from "../../common/CardsFilter/helpers";
-import { SetFilter } from "../../common/CardsFilter/types";
+import { ScheduleFilter, SelectionMap, SetFilter } from "../../common/CardsFilter/types";
 import { EntityTableName, QueryParamsKeys } from "need4deed-sdk";
 import { OpportunityCardsFilter } from "./types";
 
@@ -38,7 +38,41 @@ export const createOpportunityFilterItems = (
     (key) => key,
   );
 
-  return { districtFilters, languageFilters, statusFilters, typeFilters, activityFilters };
+  const availabilityFilters = createAvailabilityFilterItems(filter[QueryParamsKeys.AVAILABILITY], setFilter, t);
+
+  return { districtFilters, languageFilters, statusFilters, typeFilters, activityFilters, availabilityFilters };
+};
+
+/**
+ * Builds availability-based filter sections (days, times, occasional).
+ */
+export const createAvailabilityFilterItems = (
+  availability: ScheduleFilter,
+  setFilter: SetFilter<OpportunityCardsFilter>,
+  t: TFunction,
+) => {
+  const { days, times, occasional } = availability;
+
+  const createAvailabilityGroup = <K extends keyof ScheduleFilter, T extends SelectionMap>(labelKey: K, obj: T) => ({
+    label: t(`dashboard.volunteers.filters.preferredAv.${labelKey}.header`),
+    items: Object.keys(obj).map((key) => ({
+      label: t(`dashboard.volunteers.filters.preferredAv.${labelKey}.${key}`),
+      checked: obj[key],
+      onChange: (checked: boolean) => {
+        const updated = { ...obj, [key]: checked };
+        setFilter((prev) => ({
+          ...prev,
+          [QueryParamsKeys.AVAILABILITY]: { ...availability, [labelKey]: updated },
+        }));
+      },
+    })),
+  });
+
+  return [
+    createAvailabilityGroup("days", days),
+    createAvailabilityGroup("times", times),
+    createAvailabilityGroup("occasional", occasional),
+  ];
 };
 
 export const createSelectedOpportunityFiltersAsFlatArray = (
@@ -46,9 +80,15 @@ export const createSelectedOpportunityFiltersAsFlatArray = (
   setFilter: SetFilter<OpportunityCardsFilter>,
   t: TFunction,
 ) => {
-  const { districtFilters, languageFilters, statusFilters, typeFilters, activityFilters } =
+  const { districtFilters, languageFilters, statusFilters, typeFilters, activityFilters, availabilityFilters } =
     createOpportunityFilterItems(filter, setFilter, t);
-  return [...districtFilters, ...languageFilters, ...statusFilters, ...typeFilters, ...activityFilters].filter(
-    (f) => f.checked,
-  );
+  const flatAvFilters = availabilityFilters.map((avFilter) => avFilter.items).flat();
+  return [
+    ...districtFilters,
+    ...languageFilters,
+    ...statusFilters,
+    ...typeFilters,
+    ...activityFilters,
+    ...flatAvFilters,
+  ].filter((f) => f.checked);
 };

--- a/src/components/Dashboard/Opportunities/Filters/types.ts
+++ b/src/components/Dashboard/Opportunities/Filters/types.ts
@@ -1,5 +1,5 @@
 import { EntityTableName, QueryParamsKeys } from "need4deed-sdk";
-import { SelectionMap } from "../../common/CardsFilter/types";
+import { ScheduleFilter, SelectionMap } from "../../common/CardsFilter/types";
 
 export interface OpportunityCardsFilter {
   [QueryParamsKeys.SEARCH]: string;
@@ -8,6 +8,7 @@ export interface OpportunityCardsFilter {
   status: SelectionMap;
   type: SelectionMap;
   [EntityTableName.ACTIVITY]: SelectionMap;
+  [QueryParamsKeys.AVAILABILITY]: ScheduleFilter;
 }
 
 export type OpportunityCardFilterKeys = keyof OpportunityCardsFilter;

--- a/src/components/Dashboard/Opportunities/helpers.ts
+++ b/src/components/Dashboard/Opportunities/helpers.ts
@@ -8,6 +8,7 @@ import {
   QueryParamsKeys,
 } from "need4deed-sdk";
 import { ReadonlyURLSearchParams } from "next/navigation";
+import { AvailabilityKeys, AvailabilitySubKeys, SEPARATOR } from "./Filters/constants";
 import { OpportunityCardsFilter } from "./Filters/types";
 
 interface SerializeFiltersOptions {
@@ -67,6 +68,16 @@ export function serializeOpportunityFilters(
     }
   });
 
+  params.delete(QueryParamsKeys.AVAILABILITY);
+  Object.entries(filter.availability).forEach(([key, subSlot]) => {
+    const availabilityKey = key as AvailabilityKeys;
+    Object.entries(subSlot).forEach(([slot, value]) => {
+      if (value) {
+        params.append(QueryParamsKeys.AVAILABILITY, `${availabilityKey}${SEPARATOR}${slot}`);
+      }
+    });
+  });
+
   return asString ? params.toString() : params;
 }
 
@@ -101,6 +112,17 @@ export function deserializeOpportunityFilters(
   const queryActivities = searchParams.getAll(EntityTableName.ACTIVITY);
   queryActivities.forEach((l) => {
     newFilter.activity[l] = true;
+  });
+
+  const queryAvailability = searchParams.getAll(QueryParamsKeys.AVAILABILITY);
+  queryAvailability.forEach((item) => {
+    const [firstKey, secondKey] = item.split(SEPARATOR);
+    const avKey = firstKey as AvailabilityKeys;
+    const avSubKey = secondKey as AvailabilitySubKeys;
+    const subFilter = newFilter.availability[avKey] as Record<AvailabilitySubKeys, boolean>;
+    if (subFilter && subFilter[avSubKey] !== undefined) {
+      subFilter[avSubKey] = true;
+    }
   });
 
   return newFilter;

--- a/src/components/Dashboard/Volunteers/Filters/types.ts
+++ b/src/components/Dashboard/Volunteers/Filters/types.ts
@@ -1,5 +1,7 @@
-import { ByDay, OccasionalType, QueryParamsKeys, TimeSlot } from "need4deed-sdk";
-import { SelectionMap } from "../../common/CardsFilter/types";
+import { QueryParamsKeys } from "need4deed-sdk";
+import { ScheduleFilter, SelectionMap } from "../../common/CardsFilter/types";
+
+export type Availability = ScheduleFilter;
 
 export interface CardsFilter {
   [QueryParamsKeys.SEARCH]: string;
@@ -8,12 +10,6 @@ export interface CardsFilter {
   [QueryParamsKeys.AVAILABILITY]: Availability;
   [QueryParamsKeys.DISTRICT]: SelectionMap;
   [QueryParamsKeys.LANGUAGE]: SelectionMap;
-}
-
-export interface Availability {
-  times: Record<TimeSlot, boolean>;
-  days: Record<ByDay, boolean>;
-  occasional: Record<OccasionalType, boolean>;
 }
 
 export type CardFilterKeys = keyof CardsFilter;

--- a/src/components/Dashboard/common/CardsFilter/types.ts
+++ b/src/components/Dashboard/common/CardsFilter/types.ts
@@ -1,8 +1,15 @@
 import { Dispatch, SetStateAction } from "react";
+import { ByDay, OccasionalType, TimeSlot } from "need4deed-sdk";
 
 export type SetFilter<TFilter> = Dispatch<SetStateAction<TFilter>>;
 
 export type SelectionMap = Record<string, boolean>;
+
+export interface ScheduleFilter {
+  times: Record<TimeSlot, boolean>;
+  days: Record<ByDay, boolean>;
+  occasional: Record<OccasionalType, boolean>;
+}
 
 export type FilterItem = {
   label: string;


### PR DESCRIPTION
Closes #405

The opportunities dashboard had no way to filter by volunteer availability/schedule. This adds the same schedule filter that already exists on the volunteers dashboard.

The ScheduleFilter type (days / times / occasional) was moved to the shared common/CardsFilter/types.ts so both dashboards can reference it without duplication. The volunteer filter now imports Availability from that shared location. Opportunity filter constants, serializer, deserializer, filter-item builder, and FiltersContent were all extended to include the availability accordion.

Changes:
- src/components/Dashboard/common/CardsFilter/types.ts: extract ScheduleFilter interface to shared location
- src/components/Dashboard/Volunteers/Filters/types.ts: import ScheduleFilter from common (backward-compatible)
- src/components/Dashboard/Opportunities/Filters/types.ts: add QueryParamsKeys.AVAILABILITY: ScheduleFilter to OpportunityCardsFilter
- src/components/Dashboard/Opportunities/Filters/constants.ts: add availability defaults plus SEPARATOR/AvailabilityKeys/AvailabilitySubKeys exports
- src/components/Dashboard/Opportunities/helpers.ts: serialize and deserialize availability params using tilde-separated format
- src/components/Dashboard/Opportunities/Filters/helpers.ts: add createAvailabilityFilterItems, wire into createOpportunityFilterItems and flat array helper
- src/components/Dashboard/Opportunities/Filters/FiltersContent.tsx: render AccordionFilter with groupedItems and groupedItemsDisplayType="button"
- public/locales/en/translations.json: add dashboard.opportunities.filters.schedule.header
- public/locales/de/translations.json: add dashboard.opportunities.filters.schedule.header (Zeitplan)

