### PR TITLE
fix: add Inactive option to opportunity status filter

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -746,6 +746,7 @@
           "opp-new": "Neu",
           "opp-searching": "Suche läuft",
           "opp-active": "Aktiv",
+          "opp-inactive": "Inaktiv",
           "opp-past": "Vergangen"
         },
         "schedule": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -789,6 +789,7 @@
           "opp-new": "New",
           "opp-searching": "Searching",
           "opp-active": "Active",
+          "opp-inactive": "Inactive",
           "opp-past": "Past"
         },
         "schedule": {

--- a/src/components/Dashboard/Opportunities/Filters/constants.ts
+++ b/src/components/Dashboard/Opportunities/Filters/constants.ts
@@ -17,6 +17,7 @@ export const defaultOpportunityCardsFilter: OpportunityCardsFilter = {
     [OpportunityStatusType.NEW]: false,
     [OpportunityStatusType.SEARCHING]: false,
     [OpportunityStatusType.ACTIVE]: false,
+    [OpportunityStatusType.INACTIVE]: false,
     [OpportunityStatusType.PAST]: false,
   },
   type: {


### PR DESCRIPTION
Closes #431

## Summary
- Added `OpportunityStatusType.INACTIVE` to the opportunity filter default state
- Added `"opp-inactive"` translation key to EN (`"Inactive"`) and DE (`"Inaktiv"`) locales under `dashboard.opportunities.filters.status`

The serializer/deserializer already handles any key in `filter.status` dynamically, so no other changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)