### PR TITLE
fix: enforce email validation on form submit

### DIFF
--- a/src/components/forms/AddOpportunity/AddOpportunity.tsx
+++ b/src/components/forms/AddOpportunity/AddOpportunity.tsx
@@ -146,17 +146,19 @@ export default function AddOpportunity() {
             name="email"
             FieldTag={formOpportunity.Field}
             label={t("form.addOpportunity.fields.contactGroup.email.label")}
-            onChangeValidator={({ value }) => {
-              if (!value) {
-                return t("form.error.required");
-              }
-              if (!validateEmail(value as string)) {
-                return t("form.error.email");
-              }
-              return undefined;
-            }}
-            onChangeAsyncValidator={({ value }) => {
-              return validateRACEmail(value as string, t("form.error.badEmail"));
+            validators={{
+              onChange: ({ value }) => {
+                if (!value) return t("form.error.required");
+                if (!validateEmail(value as string)) return t("form.error.email");
+                return undefined;
+              },
+              onSubmit: ({ value }) => {
+                if (!value) return t("form.error.required");
+                if (!validateEmail(value as string)) return t("form.error.email");
+                return undefined;
+              },
+              onChangeAsync: ({ value }) => validateRACEmail(value as string, t("form.error.badEmail")),
+              onChangeAsyncDebounceMs: 500,
             }}
           />
           <SimpleInputField<OpportunityData>

--- a/src/components/forms/BecomeVolunteer/BecomeVolunteer.tsx
+++ b/src/components/forms/BecomeVolunteer/BecomeVolunteer.tsx
@@ -141,14 +141,17 @@ export default function BecomeVolunteer() {
           name="email"
           FieldTag={formVolunteer.Field}
           label={t("form.becomeVolunteer.fields.email.label")}
-          onChangeValidator={({ value }) => {
-            if (!value) {
-              return t("form.error.required");
-            }
-            if (!validateEmail(value as string)) {
-              return t("form.error.email");
-            }
-            return undefined;
+          validators={{
+            onChange: ({ value }) => {
+              if (!value) return t("form.error.required");
+              if (!validateEmail(value as string)) return t("form.error.email");
+              return undefined;
+            },
+            onSubmit: ({ value }) => {
+              if (!value) return t("form.error.required");
+              if (!validateEmail(value as string)) return t("form.error.email");
+              return undefined;
+            },
           }}
         />
         <SimpleInputField<VolunteerData>


### PR DESCRIPTION
Closes #421

## Summary
TanStack Form's `onChange` validators don't run when `handleSubmit()` is called — only validators registered under `onSubmit` fire at that point. If a user submits without ever focusing the email field, validation was silently skipped.

- Replaced `onChangeValidator` + `onChangeAsyncValidator` props with the unified `validators` object on the email field in `AddOpportunity` and `BecomeVolunteer`
- Added `onSubmit` validator with the same sync format check, so invalid emails are caught at submission time
- `onChangeAsync` (domain check) preserved as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)