### PR TITLE
Fix: Refugee language and Appointment language fields are swapped in #462

### DIFF
--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetails.tsx
@@ -3,7 +3,7 @@ import { useApiDistricts, useApiLanguages } from "@/components/Dashboard/Profile
 import { useUpdateOpportunityAccompanyingDetails } from "@/hooks/useUpdateOpportunityAccompanyingDetails";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { de, enUS } from "date-fns/locale";
-import { ApiOpportunityGet } from "need4deed-sdk";
+import { ApiOpportunityGet, LangPurpose } from "need4deed-sdk";
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -127,7 +127,11 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
     );
   }
 
-  const languageLabel = (formValues.languagesToTranslate ?? []).map((id) => keyToLabel[id] || id).join(", ");
+  // Refugee language = the language the refugee speaks (LangPurpose.RECIPIENT on the opportunity)
+  const languageLabel = (opportunity.languages ?? [])
+    .filter((lang) => lang.purpose === LangPurpose.RECIPIENT)
+    .map((lang) => lang.title)
+    .join(", ");
   const districtLabel =
     districtKeyToLabel[formValues.appointmentDistrict || ""] || formValues.appointmentDistrict || "";
 


### PR DESCRIPTION

Fix: Refugee language and Appointment language fields are swapped in #462

## Description
In the Accompanying details section, the Refugee language field was reading from `accompanyingDetails.languagesToTranslate` (which is the appointment language), causing both fields to display the wrong data.

## Related Issues
Closes #462

## Changes
- Fix `AccompanyingDetails.tsx`: refugee language now reads from `opportunity.languages` filtered by `LangPurpose.RECIPIENT`, matching the language the refugee speaks

## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

