### PR TITLE
fix: 'Temporarily Unavailable' engagement filter not working

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -356,6 +356,7 @@
           "new": "Neu",
           "available": "Verfügbar",
           "temporarilyUnavailable": "Vorübergehend nicht verfügbar",
+          "temp-unavailable": "Vorübergehend nicht verfügbar",
           "unresponsive": "Reagiert nicht"
         },
         "preferredAv": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -356,6 +356,7 @@
           "new": "New",
           "available": "Available",
           "temporarilyUnavailable": "Temporarily Unavailable",
+          "temp-unavailable": "Temporarily Unavailable",
           "unresponsive": "Unresponsive"
         },
         "preferredAv": {

--- a/src/components/Dashboard/Volunteers/Filters/constants.tsx
+++ b/src/components/Dashboard/Volunteers/Filters/constants.tsx
@@ -10,7 +10,7 @@ export const defaultVolunteerCardsFilter: CardsFilter = {
     new: false,
     active: false,
     available: false,
-    temporarilyUnavailable: false,
+    "temp-unavailable": false,
     inactive: false,
     unresponsive: false,
   },


### PR DESCRIPTION
## Summary
- The BE prepends `vol-` to filter keys, so `temporarilyUnavailable` became `vol-temporarilyUnavailable` which doesn't match the enum value `vol-temp-unavailable`
- All other engagement filter keys (`new`, `active`, `available`, `inactive`, `unresponsive`) happened to produce correct `vol-*` values
- Fix: rename the filter key to `temp-unavailable` so `vol-temp-unavailable` matches the enum
- Old translation key kept alongside new one to avoid breaking any existing references

Fixes https://github.com/need4deed-org/fe/issues/430

## Test plan
- [ ] Open volunteer filter panel, select "Temporarily Unavailable" — list should filter correctly
- [ ] Verify other engagement filters still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)