### PR TITLE
Fix phone and email not saved in volunteer contact details

### DIFF
--- a/src/components/Dashboard/Profile/sections/ContactDetails/volunteer/VolunteerContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/volunteer/VolunteerContactDetails.tsx
@@ -71,6 +71,8 @@ export const VolunteerContactDetails = forwardRef<EditableSectionRef, Props>(fun
       {
         person: {
           ...volunteer.person,
+          phone: values.phone,
+          email: values.email,
           address: {
             id: volunteer.person.address?.id,
             street: addressData.street,


### PR DESCRIPTION
Closes #454

The onSubmit handler in VolunteerContactDetails spread volunteer.person into the PATCH payload without including the form values for phone and email. Any edits to those fields were silently discarded since the old values from the API were sent back unchanged. The fix adds phone and email from the form values explicitly after the spread so they correctly override the stale data.

Changes:
- VolunteerContactDetails.tsx: add phone and email from form values to the person object in the updateContact payload

How to test:
1. Open a volunteer profile as an agent
2. Click Edit on the Contact Details section
3. Change the phone number and email address
4. Save
5. Verify the updated values appear in the display view and persist on page refresh