### PR TITLE
Add locations field to accompanying opportunity registration form

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -291,6 +291,9 @@
           },
           "information": {
             "label": "Gib Informationen über die Aufgabe, die von den Freiwilligen erwartet wird"
+          },
+          "locations": {
+            "header": "Bezirke"
           }
         },
         "voGroup": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -291,6 +291,9 @@
           },
           "information": {
             "label": "Provide information about the task the volunteers are expected to perform"
+          },
+          "locations": {
+            "header": "Locations"
           }
         },
         "voGroup": {

--- a/src/components/forms/AddOpportunity/AddOpportunity.tsx
+++ b/src/components/forms/AddOpportunity/AddOpportunity.tsx
@@ -396,6 +396,35 @@ export default function AddOpportunity() {
                       return undefined;
                     }}
                   />
+                  <formOpportunity.Field
+                    name="locations"
+                    validators={{
+                      onBlur: ({ value }) => isSelected(value, t("form.error.location")),
+                    }}
+                  >
+                    {(field) => {
+                      return (
+                        <fieldset>
+                          <HeaderWithHelp
+                            className={style["form-chiplist-header-within-group"]}
+                            classNamePopup={style["form-help"]}
+                          >
+                            {t("form.addOpportunity.fields.aaGroup.locations.header")}
+                          </HeaderWithHelp>
+                          <WithParentRef
+                            className={`${style["form-chip-list"]} ${style["form-pick"]}`}
+                            onFocus={() => setTimeout(field.handleBlur, 0)}
+                          >
+                            <MultipleCheckBoxInputsWithMore<OpportunityData, "locations">
+                              FieldTag={formOpportunity.Field}
+                              field={field}
+                            />
+                            <FieldInfo field={field} />
+                          </WithParentRef>
+                        </fieldset>
+                      );
+                    }}
+                  </formOpportunity.Field>
                   <SimpleInputField<OpportunityData>
                     name="aaInformation"
                     FieldTag={formOpportunity.Field}


### PR DESCRIPTION
Closes #472

The accompanying opportunity registration form was missing the locations/district selector that the regular opportunity form already includes. The locations field already existed in the shared form state (OpportunityData) but was never rendered when the user selected the accompanying type. This adds the same field with the same validation, and adds the corresponding i18n keys for EN and DE.

Changes:
- AddOpportunity.tsx: render the locations field in the accompanying opportunity section, before the aaInformation field
- locales/en/translations.json: add aaGroup.locations.header key ("Locations")
- locales/de/translations.json: add aaGroup.locations.header key ("Bezirke")

How to test:
1. Open the site and click "Join as a refugee center"
2. Fill in the initial fields and select "Accompanying Opportunity" as the type
3. Verify the Locations/Bezirke district selector now appears in the form
4. Confirm the Regular Opportunity type still shows its own locations selector unchanged