### PR TITLE
Remove redundant Begleitung prefix and asterisks from activity titles on opportunity cards

### DIFF
--- a/src/components/Dashboard/Opportunities/helpers.ts
+++ b/src/components/Dashboard/Opportunities/helpers.ts
@@ -141,8 +141,18 @@ export function getOptionTitles(items: OptionById[] | undefined): string[] {
   return items.map((item) => (typeof item.title === "string" ? item.title : "")).filter(Boolean);
 }
 
+function cleanActivityTitle(title: string): string {
+  return title
+    .replace(/^Begleitung:\s*/i, "")
+    .replace(/\*\s*$/, "")
+    .trim();
+}
+
 export function getActivityTitles(activities: OptionById[], activityList: OptionItem[] | undefined): string[] {
   if (!activities?.length || !activityList?.length) return [];
   const activityMap = new Map(activityList.map((item) => [String(item.id), item.title]));
-  return activities.map((act) => activityMap.get(String(act.id))).filter((title): title is string => Boolean(title));
+  return activities
+    .map((act) => activityMap.get(String(act.id)))
+    .filter((title): title is string => Boolean(title))
+    .map(cleanActivityTitle);
 }

--- a/src/components/forms/fallbackLists/activitiesFallback.ts
+++ b/src/components/forms/fallbackLists/activitiesFallback.ts
@@ -38,11 +38,11 @@ export const activities = [
   },
   {
     id: "Activities-women",
-    title: { en: "Activities for women", de: "Aktivitäten für Frauen*" },
+    title: { en: "Activities for women", de: "Aktivitäten für Frauen" },
   },
   {
     id: "Activities-men",
-    title: { en: "Activities for men", de: "Aktivitäten für Männer*" },
+    title: { en: "Activities for men", de: "Aktivitäten für Männer" },
   },
   { id: "Tutoring", title: { en: "Assist with homework", de: "Nachhilfe" } },
   {
@@ -62,26 +62,26 @@ export const activitiesAccompanying = [
     id: "Accompanying to government appointments",
     title: {
       en: "Accompanying to government appointments",
-      de: "Begleitung: Termine bei Behörden* ",
+      de: "Termine bei Behörden",
     },
   },
   {
     id: "Apartment viewing accompanying",
     title: {
       en: "Apartment viewing accompanying",
-      de: "Begleitung: Wohnungsbesichtigungen",
+      de: "Wohnungsbesichtigungen",
     },
   },
   {
     id: "Schools meetings ccompanying",
     title: {
       en: "Schools meetings ccompanying",
-      de: "Begleitung: Termine in Schulen und Kitas",
+      de: "Termine in Schulen und Kitas",
     },
   },
   { id: "Accompanying", title: { en: "Accompanying", de: "Wegbegleitung" } },
   {
     id: "Accompanying to doctors'",
-    title: { en: "Accompanying to doctors' ", de: "Begleitung: Arzttermine" },
+    title: { en: "Accompanying to doctors'", de: "Arzttermine" },
   },
 ];


### PR DESCRIPTION
Closes #456

In the German dashboard, accompanying opportunity cards were showing activity labels with a redundant "Begleitung:" prefix (e.g. "Begleitung: Arzttermine") even though the green badge already identifies the card as "Begleitung" type. Some labels also had a trailing asterisk and whitespace.

Changes:
- Added cleanActivityTitle() helper in helpers.ts that strips the "Begleitung:" prefix and trailing asterisk/whitespace from any activity title at display time, covering both API data and fallback data
- Updated activitiesFallback.ts to remove the "Begleitung:" prefix from all accompanying activity entries and remove trailing gender asterisks from regular activity entries

How to test:
1. Open the dashboard in German (de locale)
2. Navigate to Opportunities
3. Open an Accompanying (Begleitung) opportunity card that has activities
4. Confirm activity tags no longer show "Begleitung: " prefix or trailing asterisks
5. Confirm Regular opportunity cards are unaffected