### PR TITLE
Fix: Volunteers dashboard: selecting "Temporarily Unavailable" in the Engagement filter returns 0 results #430

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -355,7 +355,7 @@
           "inactive": "Inaktiv",
           "new": "Neu",
           "available": "Verfügbar",
-          "temporarilyUnavailable": "Vorübergehend nicht verfügbar",
+          "temp-unavailable": "Vorübergehend nicht verfügbar",
           "unresponsive": "Reagiert nicht"
         },
         "preferredAv": {

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -351,12 +351,12 @@
         "activities": "Aktivitäten",
         "engagement": {
           "header": "Engagement",
-          "active": "Aktiv",
-          "inactive": "Inaktiv",
-          "new": "Neu",
-          "available": "Verfügbar",
-          "temp-unavailable": "Vorübergehend nicht verfügbar",
-          "unresponsive": "Reagiert nicht"
+          "vol-active": "Aktiv",
+          "vol-inactive": "Inaktiv",
+          "vol-new": "Neu",
+          "vol-available": "Verfügbar",
+          "vol-temp-unavailable": "Vorübergehend nicht verfügbar",
+          "vol-unresponsive": "Reagiert nicht"
         },
         "preferredAv": {
           "header": "Bevorzugte Verfügbarkeit",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -355,7 +355,7 @@
           "inactive": "Inactive",
           "new": "New",
           "available": "Available",
-          "temporarilyUnavailable": "Temporarily Unavailable",
+          "temp-unavailable": "Temporarily Unavailable",
           "unresponsive": "Unresponsive"
         },
         "preferredAv": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -351,12 +351,12 @@
         "activities": "Activities",
         "engagement": {
           "header": "Engagement",
-          "active": "Active",
-          "inactive": "Inactive",
-          "new": "New",
-          "available": "Available",
-          "temp-unavailable": "Temporarily Unavailable",
-          "unresponsive": "Unresponsive"
+          "vol-active": "Active",
+          "vol-inactive": "Inactive",
+          "vol-new": "New",
+          "vol-available": "Available",
+          "vol-temp-unavailable": "Temporarily Unavailable",
+          "vol-unresponsive": "Unresponsive"
         },
         "preferredAv": {
           "header": "Preferred Availability",

--- a/src/components/Dashboard/Volunteers/Filters/constants.tsx
+++ b/src/components/Dashboard/Volunteers/Filters/constants.tsx
@@ -1,4 +1,4 @@
-import { ByDay, OccasionalType, QueryParamsKeys, TimeSlot } from "need4deed-sdk";
+import { ByDay, OccasionalType, QueryParamsKeys, TimeSlot, VolunteerStateEngagementType } from "need4deed-sdk";
 import { CardsFilter } from "./types";
 
 export const defaultVolunteerCardsFilter: CardsFilter = {
@@ -7,12 +7,12 @@ export const defaultVolunteerCardsFilter: CardsFilter = {
   [QueryParamsKeys.DISTRICT]: {},
   [QueryParamsKeys.LANGUAGE]: {},
   [QueryParamsKeys.ENGAGEMENT]: {
-    new: false,
-    active: false,
-    available: false,
-    "temp-unavailable": false,
-    inactive: false,
-    unresponsive: false,
+    [VolunteerStateEngagementType.NEW]: false,
+    [VolunteerStateEngagementType.ACTIVE]: false,
+    [VolunteerStateEngagementType.AVAILABLE]: false,
+    [VolunteerStateEngagementType.TEMP_UNAVAILABLE]: false,
+    [VolunteerStateEngagementType.INACTIVE]: false,
+    [VolunteerStateEngagementType.UNRESPONSIVE]: false,
   },
   [QueryParamsKeys.AVAILABILITY]: {
     times: {

--- a/src/components/Dashboard/Volunteers/Filters/constants.tsx
+++ b/src/components/Dashboard/Volunteers/Filters/constants.tsx
@@ -10,7 +10,7 @@ export const defaultVolunteerCardsFilter: CardsFilter = {
     new: false,
     active: false,
     available: false,
-    temporarilyUnavailable: false,
+    "temp-unavailable": false,
     inactive: false,
     unresponsive: false,
   },

--- a/src/components/Dashboard/Volunteers/VolunteerCardList.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerCardList.tsx
@@ -17,6 +17,8 @@ interface VolunteerCardListProps {
 const VolunteerCardListContainer = styled.div`
   display: flex;
   justify-content: left;
+  flex: 1;
+  min-width: 0;
 `;
 
 export function VolunteerCardList({

--- a/src/components/Dashboard/Volunteers/helpers.ts
+++ b/src/components/Dashboard/Volunteers/helpers.ts
@@ -107,10 +107,11 @@ export function serializeFilters(
   });
 
   // 2. Clear all existing 'engagement' params
+  // Strip the "vol-" prefix because the backend's engagementWorkaround re-adds it
   params.delete(QueryParamsKeys.ENGAGEMENT);
   Object.entries(filter.engagement).forEach(([key, value]) => {
     if (value === true) {
-      params.append(QueryParamsKeys.ENGAGEMENT, key);
+      params.append(QueryParamsKeys.ENGAGEMENT, key.replace(/^vol-/, ""));
     }
   });
 


### PR DESCRIPTION

Fix: Volunteers dashboard: selecting "Temporarily Unavailable" in the Engagement filter returns 0 results #430

## Description
The "Temporarily Unavailable" engagement filter was sending temporarilyUnavailable to the API. The backend has a workaround that prepends vol- to all engagement filter values before querying the database, so it was looking for vol-temporarilyUnavailable which doesn't exist, returning 0 results. The fix aligns the filter key with what the backend expects.

## Related Issues
Closes #430 

## Changes
- Fix `temporarilyUnavailable` filter key to `temp-unavailable` so the backend correctly resolves it to `vol-temp-unavailable`
- Update EN and DE translation keys accordingly
- Fix layout shift in the volunteer cards list during loading by adding `flex: 1` to `VolunteerCardListContainer`

## Screenshots / Demos
<img width="494" height="240" alt="image" src="https://github.com/user-attachments/assets/f47dc0c8-9760-4760-aedc-62b3a8ddd1ea" />

## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

