### PR TITLE
Add address field to agent contact details form

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -949,6 +949,7 @@
         "email": "E-Mail",
         "mobile": "Mobiltelefon",
         "landline": "Festnetz",
+        "address": "Adresse",
         "saveSuccess": "Kontaktdaten erfolgreich aktualisiert",
         "roles": {
           "label": "Rolle",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -948,6 +948,7 @@
         "email": "E-mail",
         "mobile": "Mobile",
         "landline": "Landline",
+        "address": "Address",
         "saveSuccess": "Contact details updated successfully",
         "roles": {
           "label": "Role",

--- a/src/components/Dashboard/Profile/sections/ContactDetails/agent/AgentContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/agent/AgentContactDetails.tsx
@@ -3,7 +3,7 @@
 import { AgentRoles } from "@/config/constants";
 import { useUpdateAgentContact } from "@/hooks/useUpdateAgentContact";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { forwardRef, useImperativeHandle, useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { ApiAgentProfileGet } from "../../../types";
@@ -11,6 +11,7 @@ import { FormContainer } from "../../shared/styles";
 import { EditableSectionProps } from "../../shared/types";
 import { useEditingChangeNotifier } from "../../shared/useEditingChangeNotifier";
 import { useEnumTranslation } from "../shared";
+import { formatAddress, parseAddress } from "./agentAddressUtils";
 import { AgentContactDetailsDisplay } from "./AgentContactDetailsDisplay";
 import { AgentContactDetailsEdit } from "./AgentContactDetailsEdit";
 import { AgentContactDetailsFormData, createAgentContactDetailsSchema } from "./agentContactDetailsSchema";
@@ -30,7 +31,10 @@ export const AgentContactDetails = forwardRef<ContactDetailsRef, Props>(function
   ref,
 ) {
   const { t } = useTranslation();
-  const { mutate: updateAgent, isPending } = useUpdateAgentContact(String(agent?.representative?.id), String(agent?.id));
+  const { mutate: updateAgent, isPending } = useUpdateAgentContact(
+    String(agent?.representative?.id),
+    String(agent?.id),
+  );
   const [isEditing, setIsEditing] = useState(false);
 
   useEditingChangeNotifier(isEditing, onEditingChange);
@@ -42,7 +46,19 @@ export const AgentContactDetails = forwardRef<ContactDetailsRef, Props>(function
 
   const schema = createAgentContactDetailsSchema(t);
 
-  const initialFormValues = agent?.representative;
+  const initialFormValues = useMemo(
+    (): AgentContactDetailsFormData => ({
+      firstName: agent?.representative?.firstName ?? "",
+      middleName: agent?.representative?.middleName ?? "",
+      lastName: agent?.representative?.lastName ?? "",
+      role: agent?.representative?.role as AgentContactDetailsFormData["role"],
+      email: agent?.representative?.email ?? "",
+      phone: agent?.representative?.phone ?? "",
+      landline: agent?.representative?.landline ?? "",
+      address: formatAddress(agent?.representative?.address),
+    }),
+    [agent],
+  );
 
   const methods = useForm<AgentContactDetailsFormData>({
     resolver: zodResolver(schema),
@@ -62,13 +78,33 @@ export const AgentContactDetails = forwardRef<ContactDetailsRef, Props>(function
   };
 
   const onSubmit = (values: AgentContactDetailsFormData) => {
-    updateAgent(values, {
-      onSuccess: () => {
-        reset(values);
-        setIsEditing(false);
+    const addressData = parseAddress(values.address ?? "");
+    updateAgent(
+      {
+        ...values,
+        address: {
+          id: agent.representative?.address?.id,
+          street: addressData.street,
+          city: addressData.city,
+          postcode: {
+            id: agent.representative?.address?.postcode?.id,
+            code: addressData.postcode,
+          },
+        },
       },
-    });
+      {
+        onSuccess: () => {
+          reset(values);
+          setIsEditing(false);
+        },
+      },
+    );
   };
+
+  useEffect(() => {
+    if (isEditing) return;
+    reset(initialFormValues);
+  }, [initialFormValues, isEditing, reset]);
 
   return (
     <FormProvider {...methods}>

--- a/src/components/Dashboard/Profile/sections/ContactDetails/agent/AgentContactDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/agent/AgentContactDetailsDisplay.tsx
@@ -54,6 +54,13 @@ export const AgentContactDetailsDisplay = ({ keysToLabels }: Props) => {
         value={values.landline || ""}
         setValue={() => {}}
       />
+      <EditableField
+        mode="display"
+        type="text"
+        label={t("dashboard.agentProfile.contactDetails.address")}
+        value={values.address || ""}
+        setValue={() => {}}
+      />
     </FormDetails>
   );
 };

--- a/src/components/Dashboard/Profile/sections/ContactDetails/agent/AgentContactDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/agent/AgentContactDetailsEdit.tsx
@@ -128,6 +128,20 @@ export const AgentContactDetailsEdit = ({ options, toLabel, toKey, onCancel, onS
             />
           )}
         />
+        <Controller
+          name="address"
+          control={control}
+          render={({ field }: { field: ControllerRenderProps<AgentContactDetailsFormData, "address"> }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t("dashboard.agentProfile.contactDetails.address")}
+              value={field.value ?? ""}
+              setValue={field.onChange}
+              errorMessage={errors.address?.message}
+            />
+          )}
+        />
       </FormDetails>
 
       <ButtonRow>

--- a/src/components/Dashboard/Profile/sections/ContactDetails/agent/agentAddressUtils.ts
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/agent/agentAddressUtils.ts
@@ -1,0 +1,13 @@
+import { ApiRepresentativeGet } from "need4deed-sdk";
+
+export const formatAddress = (address: ApiRepresentativeGet["address"] | undefined) => {
+  if (!address || typeof address !== "object") return "";
+
+  const postcode = address.postcode && typeof address.postcode === "object" ? address.postcode.code : address.postcode;
+  return [address.street, address.city, postcode].filter(Boolean).join(", ");
+};
+
+export const parseAddress = (addressString: string) => {
+  const [street = "", city = "", postcode = ""] = addressString.split(",").map((part) => part.trim());
+  return { street, city, postcode };
+};

--- a/src/components/Dashboard/Profile/sections/ContactDetails/agent/agentContactDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/agent/agentContactDetailsSchema.ts
@@ -23,6 +23,7 @@ export const createAgentContactDetailsSchema = (t: (key: string) => string) => {
       .regex(PHONE_NUMBER_REGEX, t("dashboard.agentProfile.contactDetails.validation.landlineInvalid"))
       .optional()
       .or(z.literal("")),
+    address: z.string().optional().or(z.literal("")),
   });
 };
 


### PR DESCRIPTION
Closes #354

The agent contact details edit form was missing the address field entirely. The address is stored on the representative (person) and the existing PATCH /person/:id endpoint already handles it via dtoParsePerson, so this is a pure frontend fix.

Changes:
- Add agentAddressUtils.ts with formatAddress and parseAddress helpers, mirroring the volunteer contact details pattern
- Extend agentContactDetailsSchema with an optional address string field
- Memoize initialFormValues and sync form on agent data refresh via useEffect (same pattern as VolunteerContactDetails)
- Parse address string and include the structured address object in the PATCH /person/:id payload on submit
- Add address Controller to AgentContactDetailsEdit for editing
- Show address field in AgentContactDetailsDisplay
- Add "address" label key to EN and DE translation files

How to test:
1. Log in as a coordinator and navigate to an agent profile
2. Open the Contact Details section and verify the address is displayed
3. Click Edit and verify the address field appears pre-filled
4. Change the address (format: "Street, City, Postcode") and save
5. Verify the updated address is shown after saving