### PR TITLE
Show district in agent profile header

### DIFF
--- a/src/components/Dashboard/Profile/sections/ProfileHeader/agent/AgentHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/agent/AgentHeader.tsx
@@ -2,7 +2,6 @@
 import { EMPTY_PLACEHOLDER_VALUE } from "@/config/constants";
 import { formatDateTime } from "@/utils";
 import { HouseIcon } from "@phosphor-icons/react";
-import { Lang } from "need4deed-sdk";
 import { useTranslation } from "react-i18next";
 import { useUpdateAgentStatus } from "@/hooks";
 import { AgentTrustLevel, ApiAgentProfileGet } from "../../../types/agent";
@@ -12,6 +11,7 @@ import {
   createEngagementStatusLabelMap,
   createTrustLevelLabelMap,
   createVolunteerSearchLabelMap,
+  getDistrictLabel,
   TRUST_LEVEL_OPTIONS,
 } from "./constants";
 import { TrustLevelDropdown } from "./TrustLevelDropdown";
@@ -23,6 +23,7 @@ type Props = {
 
 export const AgentHeader = ({ agent }: Props) => {
   const { t, i18n } = useTranslation();
+  const districtLabel = getDistrictLabel(agent.district, i18n.language);
   const dialog = useAgentEngagementStatusDialog(agent);
   const { mutate: patchAgent } = useUpdateAgentStatus(agent.id);
 
@@ -74,17 +75,7 @@ export const AgentHeader = ({ agent }: Props) => {
         }
       />
 
-      <StatusRowField
-        title={t("dashboard.agentProfile.district")}
-        showIcon={false}
-        extra={
-          agent.district?.title ? (
-            <span>
-              {agent.district.title[i18n.language as Lang] ?? agent.district.title.en ?? EMPTY_PLACEHOLDER_VALUE}
-            </span>
-          ) : undefined
-        }
-      />
+      <StatusRowField title={t("dashboard.agentProfile.district")} showIcon={false} extra={districtLabel} />
     </HeaderCard>
   );
 };

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/agent/AgentHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/agent/AgentHeader.tsx
@@ -2,6 +2,7 @@
 import { EMPTY_PLACEHOLDER_VALUE } from "@/config/constants";
 import { formatDateTime } from "@/utils";
 import { HouseIcon } from "@phosphor-icons/react";
+import { Lang } from "need4deed-sdk";
 import { useTranslation } from "react-i18next";
 import { useUpdateAgentStatus } from "@/hooks";
 import { AgentTrustLevel, ApiAgentProfileGet } from "../../../types/agent";
@@ -21,7 +22,7 @@ type Props = {
 };
 
 export const AgentHeader = ({ agent }: Props) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const dialog = useAgentEngagementStatusDialog(agent);
   const { mutate: patchAgent } = useUpdateAgentStatus(agent.id);
 
@@ -70,6 +71,18 @@ export const AgentHeader = ({ agent }: Props) => {
             labels={trustLevelLabels}
             onChange={handleTrustLevelChange}
           />
+        }
+      />
+
+      <StatusRowField
+        title={t("dashboard.agentProfile.district")}
+        showIcon={false}
+        extra={
+          agent.district?.title ? (
+            <span>
+              {agent.district.title[i18n.language as Lang] ?? agent.district.title.en ?? EMPTY_PLACEHOLDER_VALUE}
+            </span>
+          ) : undefined
         }
       />
     </HeaderCard>

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/agent/constants.ts
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/agent/constants.ts
@@ -1,5 +1,7 @@
+import { EMPTY_PLACEHOLDER_VALUE } from "@/config/constants";
 import { TFunction } from "i18next";
-import { AgentEngagementStatus, AgentTrustLevel, AgentVolunteerSearch } from "../../../types/agent";
+import { Lang } from "need4deed-sdk";
+import { AgentEngagementStatus, AgentTrustLevel, AgentVolunteerSearch, ApiAgentProfileGet } from "../../../types/agent";
 
 export const createEngagementStatusLabelMap = (t: TFunction): Record<AgentEngagementStatus, string> => ({
   [AgentEngagementStatus.NEW]: t("dashboard.agentProfile.status.engagement.new"),
@@ -37,3 +39,8 @@ export const createTrustLevelLabelMap = (t: TFunction): Record<AgentTrustLevel, 
   [AgentTrustLevel.LOW]: t("dashboard.agentProfile.status.trustLevel.low"),
   [AgentTrustLevel.HIGH]: t("dashboard.agentProfile.status.trustLevel.high"),
 });
+
+export const getDistrictLabel = (district: ApiAgentProfileGet["district"], language: string): string => {
+  const { title } = district || {};
+  return title?.[language as Lang] ?? title?.en ?? EMPTY_PLACEHOLDER_VALUE;
+};

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/constants.ts
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/constants.ts
@@ -1,6 +1,8 @@
 import { TFunction } from "i18next";
 import { OpportunityMatchStatusType, OpportunityStatusType } from "need4deed-sdk";
 
+export type { OpportunityMatchStatusType };
+
 export enum OpportunityManualStatusType {
   NEW = "opp-new",
   SEARCHING = "opp-searching",

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/volunteer/constants.ts
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/volunteer/constants.ts
@@ -1,8 +1,5 @@
 import { TFunction } from "i18next";
-import {
-  VolunteerStateEngagementType,
-  VolunteerStateMatchType,
-} from "need4deed-sdk";
+import { VolunteerStateEngagementType, VolunteerStateMatchType } from "need4deed-sdk";
 
 export const ENGAGEMENT_DESCRIPTION_KEYS: Record<VolunteerStateEngagementType, string> = {
   [VolunteerStateEngagementType.NEW]: "new_description",
@@ -13,12 +10,8 @@ export const ENGAGEMENT_DESCRIPTION_KEYS: Record<VolunteerStateEngagementType, s
   [VolunteerStateEngagementType.UNRESPONSIVE]: "unresponsive_description",
 };
 
-export const createEngagementLabelMap = (
-  t: TFunction,
-): Record<VolunteerStateEngagementType, string> => ({
-  [VolunteerStateEngagementType.NEW]: t(
-    "dashboard.volunteerProfile.volunteerHeader.engagementStatus_options.new",
-  ),
+export const createEngagementLabelMap = (t: TFunction): Record<VolunteerStateEngagementType, string> => ({
+  [VolunteerStateEngagementType.NEW]: t("dashboard.volunteerProfile.volunteerHeader.engagementStatus_options.new"),
   [VolunteerStateEngagementType.ACTIVE]: t(
     "dashboard.volunteerProfile.volunteerHeader.engagementStatus_options.active",
   ),
@@ -36,18 +29,12 @@ export const createEngagementLabelMap = (
   ),
 });
 
-export const createMatchLabelMap = (
-  t: TFunction,
-): Record<VolunteerStateMatchType, string> => ({
-  [VolunteerStateMatchType.NO_MATCHES]: t(
-    "dashboard.volunteerProfile.volunteerHeader.matchStatus_options.noMatches",
-  ),
+export const createMatchLabelMap = (t: TFunction): Record<VolunteerStateMatchType, string> => ({
+  [VolunteerStateMatchType.NO_MATCHES]: t("dashboard.volunteerProfile.volunteerHeader.matchStatus_options.noMatches"),
   [VolunteerStateMatchType.PENDING_MATCH]: t(
     "dashboard.volunteerProfile.volunteerHeader.matchStatus_options.pendingMatch",
   ),
-  [VolunteerStateMatchType.MATCHED]: t(
-    "dashboard.volunteerProfile.volunteerHeader.matchStatus_options.matched",
-  ),
+  [VolunteerStateMatchType.MATCHED]: t("dashboard.volunteerProfile.volunteerHeader.matchStatus_options.matched"),
   [VolunteerStateMatchType.NEEDS_REMATCH]: t(
     "dashboard.volunteerProfile.volunteerHeader.matchStatus_options.needsRematch",
   ),


### PR DESCRIPTION
Closes #458

Agent profiles were not displaying the district field anywhere on the page. The district is available on the API response (agent.district) but was never rendered in the UI, making it impossible to see which area an agent serves.

Note: address visibility is covered by PR #480 (AgentContactDetailsDisplay now shows the address field).

Changes:
- Add a District row to AgentHeader using StatusRowField, rendering the title in the current UI language with EN fallback
- Import Lang type from need4deed-sdk for type-safe language key access

How to test:
1. Log in as a coordinator and navigate to an agent profile that has a district assigned
2. Verify the District row appears in the header section below Trust Level
3. Switch the UI language between EN and DE and verify the district title updates accordingly
4. Navigate to an agent profile with no district set and verify the row shows the empty placeholder