### PR TITLE
chore: add missing translation keys for SDK v0.0.81 match statuses

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -526,7 +526,8 @@
           "noMatches": "Keine Zuweisungen",
           "pendingMatch": "Zuweisung ausstehend",
           "matched": "Zugewiesen",
-          "needsRematch": "Neu-Zuweisung erforderlich"
+          "needsRematch": "Neu-Zuweisung erforderlich",
+          "past": "Abgeschlossen"
         },
         "communication_title": "Kommunikation",
         "communication_options": {
@@ -1021,7 +1022,10 @@
       "matchStatus": {
         "matched": "Gematcht",
         "needRematch": "Neues Matching erforderlich",
-        "unmatched": "Nicht gematcht"
+        "unmatched": "Nicht gematcht",
+        "noMatches": "Keine Zuweisungen",
+        "pendingMatch": "Zuweisung ausstehend",
+        "past": "Abgeschlossen"
       },
       "statusUpdateSuccess": "Status der Möglichkeit erfolgreich aktualisiert",
       "change_status": "Status ändern",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -527,7 +527,7 @@
           "pendingMatch": "Zuweisung ausstehend",
           "matched": "Zugewiesen",
           "needsRematch": "Neu-Zuweisung erforderlich",
-          "past": "Abgeschlossen"
+          "past": "Vergangen"
         },
         "communication_title": "Kommunikation",
         "communication_options": {
@@ -1025,7 +1025,7 @@
         "unmatched": "Nicht gematcht",
         "noMatches": "Keine Zuweisungen",
         "pendingMatch": "Zuweisung ausstehend",
-        "past": "Abgeschlossen"
+        "past": "Vergangen"
       },
       "statusUpdateSuccess": "Status der Möglichkeit erfolgreich aktualisiert",
       "change_status": "Status ändern",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -525,7 +525,8 @@
           "noMatches": "No matches",
           "pendingMatch": "Pending match",
           "matched": "Matched",
-          "needsRematch": "Needs rematch"
+          "needsRematch": "Needs rematch",
+          "past": "Past"
         },
         "communication_title": "Communication",
         "communication_options": {
@@ -1020,7 +1021,10 @@
       "matchStatus": {
         "matched": "Matched",
         "needRematch": "Need rematch",
-        "unmatched": "Unmatched"
+        "unmatched": "Unmatched",
+        "noMatches": "No matches",
+        "pendingMatch": "Pending match",
+        "past": "Past"
       },
       "statusUpdateSuccess": "Opportunity status updated successfully",
       "change_status": "Change status",


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/need4deed-org/fe/pull/483 — adds the 4 translation keys that were missing when the SDK bump PR was merged.

## Keys added

**EN + DE:**
- `dashboard.volunteerProfile.volunteerHeader.matchStatus_options.past` — new `VolunteerStateMatchType.PAST` value
- `dashboard.opportunityProfile.matchStatus.noMatches` — new `OpportunityMatchStatusType.NO_MATCHES`
- `dashboard.opportunityProfile.matchStatus.pendingMatch` — new `OpportunityMatchStatusType.PENDING_MATCH`
- `dashboard.opportunityProfile.matchStatus.past` — new `OpportunityMatchStatusType.PAST`

Without these keys i18next falls back to displaying the raw key string in the UI.