### PR TITLE
Fix: filter and sort accompanying opportunities by appointment date #460

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -421,7 +421,9 @@
     "sortBy": {
       "sortBy": "Sortieren nach",
       "newToOld": "Neueste zuerst",
-      "oldToNew": "Älteste zuerst"
+      "oldToNew": "Älteste zuerst",
+      "appointmentProximal": "Event: Nächste zuerst",
+      "appointmentDistant": "Event: Späteste zuerst"
     },
     "heroSection": {
       "heroText": "Bedarfsorientierte freiwillige Unterstützung für Geflüchtete in Berlin",
@@ -526,7 +528,8 @@
           "noMatches": "Keine Zuweisungen",
           "pendingMatch": "Zuweisung ausstehend",
           "matched": "Zugewiesen",
-          "needsRematch": "Neu-Zuweisung erforderlich"
+          "needsRematch": "Neu-Zuweisung erforderlich",
+          "past": "Vergangen"
         },
         "communication_title": "Kommunikation",
         "communication_options": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -421,7 +421,9 @@
     "sortBy": {
       "sortBy": "SortBy",
       "newToOld": "Newest to Oldest",
-      "oldToNew": "Oldest to Newest"
+      "oldToNew": "Oldest to Newest",
+      "appointmentProximal": "Event: Soonest First",
+      "appointmentDistant": "Event: Latest First"
     },
     "heroSection": {
       "heroText": "Need-based voluntary support for refugees in Berlin",
@@ -525,7 +527,8 @@
           "noMatches": "No matches",
           "pendingMatch": "Pending match",
           "matched": "Matched",
-          "needsRematch": "Needs rematch"
+          "needsRematch": "Needs rematch",
+          "past": "Past"
         },
         "communication_title": "Communication",
         "communication_options": {

--- a/src/components/Dashboard/Agents/Agents.tsx
+++ b/src/components/Dashboard/Agents/Agents.tsx
@@ -35,8 +35,8 @@ export const Agents = () => {
     handleFilterUpdate((prev) => ({ ...prev, search: searchInput }));
   };
 
-  const handleSortChange = (order: SortOrder) => {
-    setSortOrder(order);
+  const handleSortChange = (order: string) => {
+    setSortOrder(order as SortOrder);
   };
 
   const handleFilterUpdate = (newFilter: AgentCardsFilter | ((prev: AgentCardsFilter) => AgentCardsFilter)) => {

--- a/src/components/Dashboard/Opportunities/Opportunities.tsx
+++ b/src/components/Dashboard/Opportunities/Opportunities.tsx
@@ -23,7 +23,7 @@ export function Opportunities() {
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const [isFiltersOpen, setIsFiltersOpen] = useState(false);
   const [numOfOpps, setNumOfOpps] = useState(0);
-  const [sortOrder, setSortOrder] = useState(SortOrder.NewToOld);
+  const [sortOrder, setSortOrder] = useState<string>(SortOrder.NewToOld);
   const [cardsFilter, setCardsFilter] = useState(defaultOpportunityCardsFilter);
   const { data: apiFilterOptions } = useGetQuery<ApiOptionLists>({ queryKey: ["options"], apiPath: apiPathOption });
   const searchParams = useSearchParams();
@@ -42,9 +42,14 @@ export function Opportunities() {
     handleFilterUpdate((prev) => ({ ...prev, search: searchInput }));
   };
 
-  const handleSortChange = (order: SortOrder) => {
+  const handleSortChange = (order: string) => {
     setSortOrder(order);
   };
+
+  const extraSortOptions = [
+    { value: "appointment-proximal", label: t("dashboard.sortBy.appointmentProximal") },
+    { value: "appointment-distant", label: t("dashboard.sortBy.appointmentDistant") },
+  ];
 
   const handleFilterUpdate = (
     newFilter: OpportunityCardsFilter | ((prev: OpportunityCardsFilter) => OpportunityCardsFilter),
@@ -98,6 +103,7 @@ export function Opportunities() {
           searchPlaceholder={t("dashboard.opportunities.card.search")}
           sortOrder={sortOrder}
           onSortOrderChange={handleSortChange}
+          extraSortOptions={extraSortOptions}
           activeFilters={activeFilters}
           onClearAllFilters={handleClearAllFilters}
           entityFilter={volunteerFilter ? { ...volunteerFilter, onRemove: handleRemoveVolunteerFilter } : undefined}

--- a/src/components/Dashboard/Opportunities/OpportunityListController.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityListController.tsx
@@ -10,9 +10,33 @@ const columns = 3;
 const rows = 3;
 const limit = columns * rows;
 
+const APPOINTMENT_SORT_VALUES = ["appointment-proximal", "appointment-distant"] as const;
+type AppointmentSort = (typeof APPOINTMENT_SORT_VALUES)[number];
+
+function isAppointmentSort(sort: string): sort is AppointmentSort {
+  return (APPOINTMENT_SORT_VALUES as readonly string[]).includes(sort);
+}
+
+function sortByAppointmentDate(
+  opportunities: ApiVolunteerOpportunityGetList[],
+  sort: AppointmentSort,
+): ApiVolunteerOpportunityGetList[] {
+  return [...opportunities].sort((a, b) => {
+    const dateA = a.accompanyingDetails?.appointmentDate;
+    const dateB = b.accompanyingDetails?.appointmentDate;
+
+    if (!dateA && !dateB) return 0;
+    if (!dateA) return 1;
+    if (!dateB) return -1;
+
+    const diff = new Date(dateA).getTime() - new Date(dateB).getTime();
+    return sort === "appointment-proximal" ? diff : -diff;
+  });
+}
+
 type Props = {
   setNumOfOpps: (num: number) => void;
-  sortOrder: SortOrder;
+  sortOrder: string;
   isFiltersOpen: boolean;
   filter: OpportunityCardsFilter;
   apiFilterOptions?: ApiOptionLists;
@@ -38,19 +62,24 @@ export function OpportunityListController({
     serializedFilter.set("volunteer", volunteerId);
   }
 
+  const backendSortOrder = isAppointmentSort(sortOrder) ? SortOrder.NewToOld : (sortOrder as SortOrder);
+
   const { data, count } = useGetQuery<ApiVolunteerOpportunityGetList[]>({
     queryKey: ["opportunities"],
     apiPath: `${apiPathOpportunity}/`,
     params: {
       limit,
       page: currentPage,
-      sortOrder,
+      sortOrder: backendSortOrder,
       filter: serializedFilter,
     },
     staleTime: cacheTTL,
   });
 
-  const opportunities: ApiVolunteerOpportunityGetList[] = data || [];
+  const rawOpportunities: ApiVolunteerOpportunityGetList[] = data || [];
+  const opportunities = isAppointmentSort(sortOrder)
+    ? sortByAppointmentDate(rawOpportunities, sortOrder)
+    : rawOpportunities;
 
   useEffect(() => {
     setNumOfOpps(count);

--- a/src/components/Dashboard/Volunteers/Volunteers.tsx
+++ b/src/components/Dashboard/Volunteers/Volunteers.tsx
@@ -42,8 +42,8 @@ export function Volunteers() {
     handleFilterUpdate((prev) => ({ ...prev, [QueryParamsKeys.SEARCH]: searchInput }));
   };
 
-  const handleSortChange = (sortOrder: SortOrder) => {
-    setSortOrder(sortOrder);
+  const handleSortChange = (sortOrder: string) => {
+    setSortOrder(sortOrder as SortOrder);
   };
 
   const handleFilterUpdate = (newFilter: CardsFilter | ((prev: CardsFilter) => CardsFilter)) => {

--- a/src/components/Dashboard/common/CardsHeader/CardsHeader.tsx
+++ b/src/components/Dashboard/common/CardsHeader/CardsHeader.tsx
@@ -4,8 +4,7 @@ import { Paragraph } from "../../../styled/text";
 import { Search } from "../../../core/common";
 import FiltersButton from "./FiltersButton";
 import Results from "./Results";
-import SortBy, { OnChangeSortOrder } from "./SortBy";
-import { SortOrder } from "need4deed-sdk";
+import SortBy, { OnChangeSortOrder, SortOption } from "./SortBy";
 import { XIcon } from "@phosphor-icons/react";
 import { FilterItem } from "../CardsFilter/types";
 import { EntityFilterChip } from "./EntityFilterChip";
@@ -40,8 +39,9 @@ type Props = {
   selectedTabIndex: number;
   setSelectedTabIndex: (index: number) => void;
   setIsFiltersOpen: (isOpen: boolean) => void;
-  sortOrder: SortOrder;
+  sortOrder: string;
   onSortOrderChange?: OnChangeSortOrder;
+  extraSortOptions?: SortOption[];
   activeFilters: FilterItem[];
   onClearAllFilters?: () => void;
   entityFilter?: EntityFilter;
@@ -60,6 +60,7 @@ export default function CardsHeader({
   setIsFiltersOpen,
   sortOrder,
   onSortOrderChange,
+  extraSortOptions,
   activeFilters,
   onClearAllFilters,
   entityFilter,
@@ -79,7 +80,7 @@ export default function CardsHeader({
               </TabHeading>
             ))}
           </Tabs>
-          <SortBy sortOrder={sortOrder} onChange={onSortOrderChange} />
+          <SortBy sortOrder={sortOrder} onChange={onSortOrderChange} extraOptions={extraSortOptions} />
         </TabsSectionContainer>
 
         <SearchBarSectionContainer>

--- a/src/components/Dashboard/common/CardsHeader/SortBy.tsx
+++ b/src/components/Dashboard/common/CardsHeader/SortBy.tsx
@@ -42,23 +42,27 @@ const OptionButton = styled.button`
   cursor: pointer;
 `;
 
+export type SortOption = { value: string; label: string };
+
 interface Props {
-  sortOrder: SortOrder;
+  sortOrder: string;
   onChange?: OnChangeSortOrder;
+  extraOptions?: SortOption[];
 }
 
-export type OnChangeSortOrder = (value: SortOrder) => void;
+export type OnChangeSortOrder = (value: string) => void;
 
-export default function SortBy({ onChange, sortOrder }: Props) {
+export default function SortBy({ onChange, sortOrder, extraOptions }: Props) {
   const { t } = useTranslation();
   const [isOptionsVisible, setIsOptionsVisible] = useState(false);
 
-  const sortByOptions = [
+  const sortByOptions: SortOption[] = [
     { value: SortOrder.NewToOld, label: t("dashboard.sortBy.newToOld") },
     { value: SortOrder.OldToNew, label: t("dashboard.sortBy.oldToNew") },
+    ...(extraOptions ?? []),
   ];
 
-  const handleChange = (value: SortOrder) => {
+  const handleChange = (value: string) => {
     setIsOptionsVisible(false);
     if (onChange) onChange(value);
   };


### PR DESCRIPTION
Fix: filter and sort accompanying opportunities by appointment date #460

## Description
Adds two new sort options to the opportunities dashboard so agents can sort accompanying opportunities by their event date.


## Related Issues
Closes #460

## Changes
Added "Event: Soonest First" and "Event: Latest First" options to the sort dropdown
SortBy and CardsHeader components now accept extra sort options as a prop
OpportunityListController sorts opportunities client-side by accompanyingDetails.appointmentDate when an event sort is selected
Added EN and DE translations for the new sort labels

## Screenshots / Demos
<img width="636" height="394" alt="image" src="https://github.com/user-attachments/assets/8a7ba701-67e3-4051-865a-ae68f9938460" />



## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

