### PR TITLE
Fix: dashboard link is wrong

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -80,7 +80,7 @@ export function Header({
       )}
 
       {user && (
-        <Link href={`/${i18n.language}/dashboard/home`} style={{ textDecoration: "none" }}>
+        <Link href={`/${i18n.language}/dashboard`} style={{ textDecoration: "none" }}>
           <MenuItem text={t("dashboard.header.button.dashboard")} color={menuItemColor} />
         </Link>
       )}


### PR DESCRIPTION
## Description
The dashboard button in the header was navigating to /dashboard/home instead of /dashboard.

## Related Issues
Closes #494 

## Changes
Fixed dashboard link in Header.tsx to point to /dashboard instead of /dashboard/home


## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

