### PR TITLE
Fix: bug: dashboard list pagination resets to page 1 when returning from a profile #487

### DIFF
--- a/src/components/Dashboard/Agents/AgentListController.tsx
+++ b/src/components/Dashboard/Agents/AgentListController.tsx
@@ -1,7 +1,7 @@
 import { ApiAgentGetList, ApiOptionLists, SortOrder } from "need4deed-sdk";
 import { AgentCardList } from "./AgentCardList";
-import { useEffect, useState } from "react";
-import { useGetQuery } from "@/hooks";
+import { useEffect } from "react";
+import { useGetQuery, usePageParam } from "@/hooks";
 import { apiPathAgent, cacheTTL } from "@/config/constants";
 import { serializeAgentFilters } from "./helpers";
 import { AgentCardsFilter } from "./Filters/types";
@@ -20,7 +20,7 @@ type Props = {
 };
 
 export const AgentListController = ({ setNumOfAgents, sortOrder, isFiltersOpen, filter, apiFilterOptions }: Props) => {
-  const [currentPage, setCurrentPage] = useState(1);
+  const { currentPage, setCurrentPage } = usePageParam();
 
   const serializedFilter = new URLSearchParams(
     serializeAgentFilters(filter, undefined, false, {

--- a/src/components/Dashboard/Agents/helpers.ts
+++ b/src/components/Dashboard/Agents/helpers.ts
@@ -47,6 +47,7 @@ export function serializeAgentFilters(
   options?: SerializeFiltersOptions,
 ) {
   const params = new URLSearchParams(searchParams);
+  params.delete("page");
 
   if (filter.search) params.set(QueryParamsKeys.SEARCH, filter.search);
   else params.delete(QueryParamsKeys.SEARCH);

--- a/src/components/Dashboard/Opportunities/OpportunityListController.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityListController.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { apiPathOpportunity, cacheTTL } from "@/config/constants";
-import { useGetQuery } from "@/hooks";
+import { useGetQuery, usePageParam } from "@/hooks";
 import { ApiVolunteerOpportunityGetList, ApiOptionLists, SortOrder } from "need4deed-sdk";
 import { OpportunityCardsFilter } from "./Filters/types";
 import { serializeOpportunityFilters } from "./helpers";
@@ -27,7 +27,7 @@ export function OpportunityListController({
   apiFilterOptions,
   volunteerId,
 }: Props) {
-  const [currentPage, setCurrentPage] = useState(1);
+  const { currentPage, setCurrentPage } = usePageParam();
 
   const serializedFilter = serializeOpportunityFilters(filter, undefined, false, {
     serializeToIDs: true,

--- a/src/components/Dashboard/Opportunities/helpers.ts
+++ b/src/components/Dashboard/Opportunities/helpers.ts
@@ -23,6 +23,7 @@ export function serializeOpportunityFilters(
   options?: SerializeFiltersOptions,
 ) {
   const params = new URLSearchParams(searchParams);
+  params.delete("page");
 
   if (filter.search) params.set(QueryParamsKeys.SEARCH, filter.search);
   else params.delete(QueryParamsKeys.SEARCH);

--- a/src/components/Dashboard/Profile/ProfilePage.tsx
+++ b/src/components/Dashboard/Profile/ProfilePage.tsx
@@ -1,21 +1,23 @@
 import { Heading2 } from "@/components/styled/text";
 import { useProfileSections } from "@/hooks/useProfileSections";
 import { ArrowLeftIcon } from "@phosphor-icons/react";
+import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { SectionCard } from "./common/SectionCard";
-import { BackLink, PageContainer } from "./styles";
+import { BackButton, PageContainer } from "./styles";
 import { ProfileEntityProps } from "./types";
 
 const ProfilePage = (props: ProfileEntityProps) => {
   const { t } = useTranslation();
+  const router = useRouter();
   const { sections, heading, header } = useProfileSections(props);
 
   return (
     <PageContainer>
-      <BackLink href=".">
+      <BackButton onClick={() => router.back()}>
         <ArrowLeftIcon size={24} />
         {t("dashboard.volunteerProfile.backToDashboard")}
-      </BackLink>
+      </BackButton>
 
       <Heading2>{heading}</Heading2>
 

--- a/src/components/Dashboard/Profile/styles.tsx
+++ b/src/components/Dashboard/Profile/styles.tsx
@@ -9,7 +9,7 @@ export const PageContainer = styled.div`
   gap: var(--volunteer-profile-container-gap);
 `;
 
-export const BackLink = styled(Link)`
+const backNavStyles = `
   display: inline-flex;
   align-items: center;
   gap: var(--volunteer-profile-back-link-gap);
@@ -17,4 +17,16 @@ export const BackLink = styled(Link)`
   color: var(--color-midnight);
   text-decoration: none;
   transition: var(--volunteer-profile-back-link-transition);
+`;
+
+export const BackLink = styled(Link)`
+  ${backNavStyles}
+`;
+
+export const BackButton = styled.button`
+  ${backNavStyles}
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
 `;

--- a/src/components/Dashboard/Volunteers/VolunteerListController.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerListController.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { apiPathVolunteer, cacheTTL } from "@/config/constants";
-import { useGetQuery } from "@/hooks";
+import { useGetQuery, usePageParam } from "@/hooks";
 import { ApiOptionLists, ApiVolunteerGetList, SortOrder } from "need4deed-sdk";
 import { CardsFilter } from "./Filters/types";
 import { serializeFilters } from "./helpers";
@@ -28,7 +28,7 @@ export function VolunteerListController({
   apiFilterOptions,
   opportunityId,
 }: VolunteerListControllerProps) {
-  const [currentPage, setCurrentPage] = useState(1);
+  const { currentPage, setCurrentPage } = usePageParam();
   const serializedFilter = serializeFilters(filter, undefined, false, {
     serializeToIDs: true,
     apiFilterOptions,

--- a/src/components/Dashboard/Volunteers/helpers.ts
+++ b/src/components/Dashboard/Volunteers/helpers.ts
@@ -69,6 +69,7 @@ export function serializeFilters(
   options?: SerializeFiltersOptions,
 ) {
   const params = new URLSearchParams(searchParams);
+  params.delete("page");
 
   if (filter.search) params.set(QueryParamsKeys.SEARCH, filter.search);
   else params.delete(QueryParamsKeys.SEARCH);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from "./useClickOutside";
+export * from "./usePageParam";
 export * from "./useGetOpportunity";
 export * from "./useGetVolunteer";
 export * from "./useGetQuery";

--- a/src/hooks/usePageParam.ts
+++ b/src/hooks/usePageParam.ts
@@ -1,0 +1,27 @@
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+/**
+ * Persists the current page number in the URL as `?page=X`.
+ * Reading the URL means navigating back restores the previous page.
+ */
+export function usePageParam() {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const currentPage = Number(searchParams.get("page") ?? "1");
+
+  const setCurrentPage = useCallback(
+    (page: number) => {
+      const params = new URLSearchParams(searchParams);
+      if (page <= 1) params.delete("page");
+      else params.set("page", String(page));
+      const qs = params.toString();
+      router.push(pathname + (qs ? "?" + qs : ""));
+    },
+    [searchParams, pathname, router],
+  );
+
+  return { currentPage, setCurrentPage };
+}


### PR DESCRIPTION

Fix: bug: dashboard list pagination resets to page 1 when returning from a profile #487

## Description
Page number was stored in component state, so navigating to a profile and returning always reset the list to page 1. Page is now persisted in the URL (?page=X), so both the browser back button and the in-app "Back to Dashboard" button restore the correct page.

## Related Issues
Closes #487 

## Changes
Added usePageParam hook to read/write the current page as a URL search param

Replaced useState(1) with usePageParam() in OpportunityListController, VolunteerListController, and AgentListController

Added params.delete("page") to the three filter serializers so changing filters always resets to page 1

Changed "Back to Dashboard" to use router.back() instead of href="." so it restores the full previous URL including the page param

## Screenshots / Demos
If UI-related, add before/after or GIFs.

## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

