### PR TITLE
Fix: skill field required when volunteer has no skill #485

### DIFF
--- a/src/components/Dashboard/Profile/sections/VolunteerProfile/volunteerProfileSchema.ts
+++ b/src/components/Dashboard/Profile/sections/VolunteerProfile/volunteerProfileSchema.ts
@@ -54,7 +54,7 @@ export const createVolunteerProfileSchema = (t: (key: string) => string) => {
     activities: z
       .array(z.string())
       .min(1, t("dashboard.volunteerProfile.profileSection.validation.activitiesRequired")),
-    skills: z.array(z.string()).min(1, t("dashboard.volunteerProfile.profileSection.validation.skillsRequired")),
+    skills: z.array(z.string()),
   });
 };
 


### PR DESCRIPTION
Closes #485

The `skills` field in the volunteer profile form had a `min(1)` Zod validation, making it required. This blocked coordinators from saving any profile section when the volunteer had no skill set, even though the skill attribute is optional.

Removing the `min(1)` constraint allows the form to submit with an empty skills array.

Changes:
- Remove `min(1)` from the `skills` field in `volunteerProfileSchema.ts`
How to test:
1. Open a volunteer profile that has no skill set
2. Enter edit mode for the profile section
3. Attempt to save without selecting a skill
4. Confirm the form submits successfully