### PR TITLE
Fix: dashboard list pagination resets to page 1 when returning from profile #487

### DIFF
--- a/src/components/Dashboard/Agents/AgentListController.tsx
+++ b/src/components/Dashboard/Agents/AgentListController.tsx
@@ -1,8 +1,9 @@
 import { ApiAgentGetList, ApiOptionLists, SortOrder } from "need4deed-sdk";
 import { AgentCardList } from "./AgentCardList";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { useGetQuery } from "@/hooks";
 import { apiPathAgent, cacheTTL } from "@/config/constants";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { serializeAgentFilters } from "./helpers";
 import { AgentCardsFilter } from "./Filters/types";
 
@@ -20,7 +21,20 @@ type Props = {
 };
 
 export const AgentListController = ({ setNumOfAgents, sortOrder, isFiltersOpen, filter, apiFilterOptions }: Props) => {
-  const [currentPage, setCurrentPage] = useState(1);
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const currentPage = Number(searchParams.get("page")) || 1;
+
+  const setCurrentPage = useCallback(
+    (page: number) => {
+      const params = new URLSearchParams(searchParams);
+      params.set("page", String(page));
+      router.replace(pathname + "?" + params.toString());
+    },
+    [router, pathname, searchParams],
+  );
 
   const serializedFilter = new URLSearchParams(
     serializeAgentFilters(filter, undefined, false, {

--- a/src/components/Dashboard/Agents/helpers.ts
+++ b/src/components/Dashboard/Agents/helpers.ts
@@ -47,6 +47,7 @@ export function serializeAgentFilters(
   options?: SerializeFiltersOptions,
 ) {
   const params = new URLSearchParams(searchParams);
+  params.delete("page");
 
   if (filter.search) params.set(QueryParamsKeys.SEARCH, filter.search);
   else params.delete(QueryParamsKeys.SEARCH);

--- a/src/components/Dashboard/Opportunities/OpportunityListController.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityListController.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { apiPathOpportunity, cacheTTL } from "@/config/constants";
 import { useGetQuery } from "@/hooks";
 import { ApiVolunteerOpportunityGetList, ApiOptionLists, SortOrder } from "need4deed-sdk";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { OpportunityCardsFilter } from "./Filters/types";
 import { serializeOpportunityFilters } from "./helpers";
 import { OpportunityCardList } from "./OpportunityCardList";
@@ -27,7 +28,20 @@ export function OpportunityListController({
   apiFilterOptions,
   volunteerId,
 }: Props) {
-  const [currentPage, setCurrentPage] = useState(1);
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const currentPage = Number(searchParams.get("page")) || 1;
+
+  const setCurrentPage = useCallback(
+    (page: number) => {
+      const params = new URLSearchParams(searchParams);
+      params.set("page", String(page));
+      router.replace(pathname + "?" + params.toString());
+    },
+    [router, pathname, searchParams],
+  );
 
   const serializedFilter = serializeOpportunityFilters(filter, undefined, false, {
     serializeToIDs: true,

--- a/src/components/Dashboard/Opportunities/helpers.ts
+++ b/src/components/Dashboard/Opportunities/helpers.ts
@@ -23,6 +23,7 @@ export function serializeOpportunityFilters(
   options?: SerializeFiltersOptions,
 ) {
   const params = new URLSearchParams(searchParams);
+  params.delete("page");
 
   if (filter.search) params.set(QueryParamsKeys.SEARCH, filter.search);
   else params.delete(QueryParamsKeys.SEARCH);

--- a/src/components/Dashboard/Volunteers/VolunteerListController.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerListController.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 
 import { apiPathVolunteer, cacheTTL } from "@/config/constants";
 import { useGetQuery } from "@/hooks";
 import { ApiOptionLists, ApiVolunteerGetList, SortOrder } from "need4deed-sdk";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { CardsFilter } from "./Filters/types";
 import { serializeFilters } from "./helpers";
 import { VolunteerCardList } from "./VolunteerCardList"; // We will modify this component
@@ -28,7 +29,21 @@ export function VolunteerListController({
   apiFilterOptions,
   opportunityId,
 }: VolunteerListControllerProps) {
-  const [currentPage, setCurrentPage] = useState(1);
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const currentPage = Number(searchParams.get("page")) || 1;
+
+  const setCurrentPage = useCallback(
+    (page: number) => {
+      const params = new URLSearchParams(searchParams);
+      params.set("page", String(page));
+      router.replace(pathname + "?" + params.toString());
+    },
+    [router, pathname, searchParams],
+  );
+
   const serializedFilter = serializeFilters(filter, undefined, false, {
     serializeToIDs: true,
     apiFilterOptions,

--- a/src/components/Dashboard/Volunteers/helpers.ts
+++ b/src/components/Dashboard/Volunteers/helpers.ts
@@ -69,6 +69,7 @@ export function serializeFilters(
   options?: SerializeFiltersOptions,
 ) {
   const params = new URLSearchParams(searchParams);
+  params.delete("page");
 
   if (filter.search) params.set(QueryParamsKeys.SEARCH, filter.search);
   else params.delete(QueryParamsKeys.SEARCH);


### PR DESCRIPTION
Closes #487

All three list controllers (volunteers, opportunities, agents) stored the current page in local component state. When navigating to a profile the component unmounted, discarding the page, so returning always landed on page 1.

Replace `useState(1)` with URL search params: page changes write to the URL via `router.replace` (no extra history entry), so the browser back button naturally restores the correct page. Filter changes delete the page param so applying a filter always resets to page 1.

Changes:
- `VolunteerListController`: read/write `page` from URL search params
- `OpportunityListController`: read/write `page` from URL search params
- `AgentListController`: read/write `page` from URL search params
- Volunteer, opportunity and agent filter serializers: delete `page` param on filter update
How to test:
1. Go to any list (volunteers, opportunities, agents)
2. Press the browser back button
3. Confirm the list returns to the page you were on.
4. Navigate to page 2 or higher
5. Open any item profile
