### PR TITLE
feat: volunteers list view (flat table) #476

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -342,9 +342,18 @@
     },
     "volunteers": {
       "header": "Freiwilligenverzeichnis",
+      "table": {
+        "name": "Name",
+        "type": "Typ",
+        "engagementStatus": "Engagementstatus",
+        "matchingStatus": "Matching-Status",
+        "language": "Sprache",
+        "district": "Bezirk",
+        "email": "E-Mail"
+      },
       "tabs": {
-        "tab1": "TABELLE",
-        "tab2": "KARTE"
+        "tab1": "Liste",
+        "tab2": "Karten"
       },
       "filters": {
         "accompanying": "Begleitung",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -368,7 +368,13 @@
           "vol-new": "Neu",
           "vol-available": "Verfügbar",
           "vol-temp-unavailable": "Vorübergehend nicht verfügbar",
-          "vol-unresponsive": "Reagiert nicht"
+          "vol-unresponsive": "Reagiert nicht",
+          "active": "Aktiv",
+          "inactive": "Inaktiv",
+          "new": "Neu",
+          "available": "Verfügbar",
+          "temporarilyUnavailable": "Vorübergehend nicht verfügbar",
+          "unresponsive": "Reagiert nicht"
         },
         "preferredAv": {
           "header": "Bevorzugte Verfügbarkeit",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -368,7 +368,13 @@
           "vol-new": "New",
           "vol-available": "Available",
           "vol-temp-unavailable": "Temporarily Unavailable",
-          "vol-unresponsive": "Unresponsive"
+          "vol-unresponsive": "Unresponsive",
+          "active": "Active",
+          "inactive": "Inactive",
+          "new": "New",
+          "available": "Available",
+          "temporarilyUnavailable": "Temporarily Unavailable",
+          "unresponsive": "Unresponsive"
         },
         "preferredAv": {
           "header": "Preferred Availability",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -342,9 +342,18 @@
     },
     "volunteers": {
       "header": "Volunteer Directory",
+      "table": {
+        "name": "Name",
+        "type": "Type",
+        "engagementStatus": "Engagement Status",
+        "matchingStatus": "Matching Status",
+        "language": "Language",
+        "district": "District",
+        "email": "Email"
+      },
       "tabs": {
-        "tab1": "TABLE VIEW",
-        "tab2": "MAP VIEW"
+        "tab1": "List",
+        "tab2": "Cards"
       },
       "filters": {
         "accompanying": "Accompanying",

--- a/src/components/Dashboard/Profile/sections/VolunteerAgents/types.ts
+++ b/src/components/Dashboard/Profile/sections/VolunteerAgents/types.ts
@@ -12,12 +12,12 @@ export type MappedVolunteerAgent = ApiVolunteerGetList & {
 };
 
 export const createEngagementStatusLabelMap = (t: TFunction): Record<VolunteerStateEngagementType, string> => ({
-  [VolunteerStateEngagementType.NEW]: t("dashboard.volunteers.filters.engagement.new"),
-  [VolunteerStateEngagementType.ACTIVE]: t("dashboard.volunteers.filters.engagement.active"),
-  [VolunteerStateEngagementType.UNRESPONSIVE]: t("dashboard.volunteers.filters.engagement.unresponsive"),
-  [VolunteerStateEngagementType.INACTIVE]: t("dashboard.volunteers.filters.engagement.inactive"),
-  [VolunteerStateEngagementType.TEMP_UNAVAILABLE]: t("dashboard.volunteers.filters.engagement.temporarilyUnavailable"),
-  [VolunteerStateEngagementType.AVAILABLE]: t("dashboard.volunteers.filters.engagement.available"),
+  [VolunteerStateEngagementType.NEW]: t("dashboard.volunteers.filters.engagement.vol-new"),
+  [VolunteerStateEngagementType.ACTIVE]: t("dashboard.volunteers.filters.engagement.vol-active"),
+  [VolunteerStateEngagementType.UNRESPONSIVE]: t("dashboard.volunteers.filters.engagement.vol-unresponsive"),
+  [VolunteerStateEngagementType.INACTIVE]: t("dashboard.volunteers.filters.engagement.vol-inactive"),
+  [VolunteerStateEngagementType.TEMP_UNAVAILABLE]: t("dashboard.volunteers.filters.engagement.vol-temp-unavailable"),
+  [VolunteerStateEngagementType.AVAILABLE]: t("dashboard.volunteers.filters.engagement.vol-available"),
 });
 
 export const createStatusLabelMap = (t: TFunction): Record<VolunteerStateTypeType, string> => ({

--- a/src/components/Dashboard/Profile/sections/VolunteerAgents/types.ts
+++ b/src/components/Dashboard/Profile/sections/VolunteerAgents/types.ts
@@ -12,12 +12,12 @@ export type MappedVolunteerAgent = ApiVolunteerGetList & {
 };
 
 export const createEngagementStatusLabelMap = (t: TFunction): Record<VolunteerStateEngagementType, string> => ({
-  [VolunteerStateEngagementType.NEW]: t("dashboard.volunteers.filters.engagement.vol-new"),
-  [VolunteerStateEngagementType.ACTIVE]: t("dashboard.volunteers.filters.engagement.vol-active"),
-  [VolunteerStateEngagementType.UNRESPONSIVE]: t("dashboard.volunteers.filters.engagement.vol-unresponsive"),
-  [VolunteerStateEngagementType.INACTIVE]: t("dashboard.volunteers.filters.engagement.vol-inactive"),
-  [VolunteerStateEngagementType.TEMP_UNAVAILABLE]: t("dashboard.volunteers.filters.engagement.vol-temp-unavailable"),
-  [VolunteerStateEngagementType.AVAILABLE]: t("dashboard.volunteers.filters.engagement.vol-available"),
+  [VolunteerStateEngagementType.NEW]: t("dashboard.volunteers.filters.engagement.new"),
+  [VolunteerStateEngagementType.ACTIVE]: t("dashboard.volunteers.filters.engagement.active"),
+  [VolunteerStateEngagementType.UNRESPONSIVE]: t("dashboard.volunteers.filters.engagement.unresponsive"),
+  [VolunteerStateEngagementType.INACTIVE]: t("dashboard.volunteers.filters.engagement.inactive"),
+  [VolunteerStateEngagementType.TEMP_UNAVAILABLE]: t("dashboard.volunteers.filters.engagement.temporarilyUnavailable"),
+  [VolunteerStateEngagementType.AVAILABLE]: t("dashboard.volunteers.filters.engagement.available"),
 });
 
 export const createStatusLabelMap = (t: TFunction): Record<VolunteerStateTypeType, string> => ({

--- a/src/components/Dashboard/Volunteers/VolunteerListController.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerListController.tsx
@@ -6,10 +6,12 @@ import { ApiOptionLists, ApiVolunteerGetList, SortOrder } from "need4deed-sdk";
 import { CardsFilter } from "./Filters/types";
 import { serializeFilters } from "./helpers";
 import { VolunteerCardList } from "./VolunteerCardList"; // We will modify this component
+import { VolunteerTableList } from "./VolunteerTableList";
 
 const columns = 3;
 const rows = 3;
 const limit = columns * rows;
+const LIST_TAB_INDEX = 0;
 
 interface VolunteerListControllerProps {
   setNumOfVols: (numOfVols: number) => void;
@@ -18,6 +20,7 @@ interface VolunteerListControllerProps {
   filter: CardsFilter;
   apiFilterOptions?: ApiOptionLists;
   opportunityId?: string;
+  selectedTabIndex: number;
 }
 
 export function VolunteerListController({
@@ -27,6 +30,7 @@ export function VolunteerListController({
   filter,
   apiFilterOptions,
   opportunityId,
+  selectedTabIndex,
 }: VolunteerListControllerProps) {
   const { currentPage, setCurrentPage } = usePageParam();
   const serializedFilter = serializeFilters(filter, undefined, false, {
@@ -51,9 +55,24 @@ export function VolunteerListController({
   });
   const volunteers = data || [];
 
+  const isListView = selectedTabIndex === LIST_TAB_INDEX;
+
   useEffect(() => {
     setNumOfVols(count);
   }, [count, setNumOfVols]);
+
+  if (isListView) {
+    return (
+      <VolunteerTableList
+        volunteers={volunteers}
+        count={count}
+        itemsPerPage={limit}
+        currentPage={currentPage}
+        setCurrentPage={setCurrentPage}
+        opportunityId={opportunityId}
+      />
+    );
+  }
 
   return (
     <VolunteerCardList

--- a/src/components/Dashboard/Volunteers/VolunteerListController.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerListController.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-import { apiPathVolunteer, cacheTTL } from "@/config/constants";
+import { apiPathVolunteer, cacheTTL, TABLE_LIMIT } from "@/config/constants";
 import { useGetQuery, usePageParam } from "@/hooks";
 import { ApiOptionLists, ApiVolunteerGetList, SortOrder } from "need4deed-sdk";
 import { CardsFilter } from "./Filters/types";
@@ -8,9 +8,9 @@ import { serializeFilters } from "./helpers";
 import { VolunteerCardList } from "./VolunteerCardList"; // We will modify this component
 import { VolunteerTableList } from "./VolunteerTableList";
 
-const columns = 3;
-const rows = 3;
-const limit = columns * rows;
+const CARD_COLUMNS = 3;
+const CARD_ROWS = 3;
+const CARD_LIMIT = CARD_COLUMNS * CARD_ROWS;
 const LIST_TAB_INDEX = 0;
 
 interface VolunteerListControllerProps {
@@ -32,6 +32,8 @@ export function VolunteerListController({
   opportunityId,
   selectedTabIndex,
 }: VolunteerListControllerProps) {
+  const isListView = selectedTabIndex === LIST_TAB_INDEX;
+  const limit = isListView ? TABLE_LIMIT : CARD_LIMIT;
   const { currentPage, setCurrentPage } = usePageParam();
   const serializedFilter = serializeFilters(filter, undefined, false, {
     serializeToIDs: true,
@@ -42,7 +44,7 @@ export function VolunteerListController({
     serializedFilter.set("opportunity", opportunityId);
   }
   const params = {
-    limit: limit,
+    limit,
     page: currentPage,
     sortOrder,
     filter: serializedFilter,
@@ -54,8 +56,6 @@ export function VolunteerListController({
     staleTime: cacheTTL,
   });
   const volunteers = data || [];
-
-  const isListView = selectedTabIndex === LIST_TAB_INDEX;
 
   useEffect(() => {
     setNumOfVols(count);
@@ -78,8 +78,8 @@ export function VolunteerListController({
     <VolunteerCardList
       volunteers={volunteers}
       count={count}
-      columns={columns - (isFiltersOpen ? 1 : 0)}
-      rows={rows + (isFiltersOpen ? 1 : 0)}
+      columns={CARD_COLUMNS - (isFiltersOpen ? 1 : 0)}
+      rows={CARD_ROWS + (isFiltersOpen ? 1 : 0)}
       currentPage={currentPage}
       setCurrentPage={setCurrentPage}
       opportunityId={opportunityId}

--- a/src/components/Dashboard/Volunteers/VolunteerTableList.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerTableList.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { ApiVolunteerGetList } from "need4deed-sdk";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+import {
+  createEngagementStatusLabelMap,
+  createStatusLabelMap,
+} from "@/components/Dashboard/Profile/sections/VolunteerAgents/types";
+import { Table, TableBody, TableContainer, TableHeader, TableHeaderCell } from "@/components/core/common/Table";
+import PaginationNumbers from "@/components/core/paginatedGrid/PaginationNumbers";
+import { VolunteerTableRow } from "./VolunteerTableRow";
+
+interface TableListProps {
+  volunteers: ApiVolunteerGetList[];
+  count: number;
+  itemsPerPage: number;
+  currentPage: number;
+  setCurrentPage: (page: number) => void;
+  opportunityId?: string;
+}
+
+export function VolunteerTableList({
+  volunteers,
+  count,
+  itemsPerPage,
+  currentPage,
+  setCurrentPage,
+  opportunityId,
+}: TableListProps) {
+  const { t } = useTranslation();
+  const totalPages = Math.ceil(count / itemsPerPage);
+
+  const engagementLabels = useMemo(() => createEngagementStatusLabelMap(t), [t]);
+  const typeLabels = useMemo(() => createStatusLabelMap(t), [t]);
+
+  const goToPage = (page: number) => {
+    if (page > 0 && page <= totalPages) setCurrentPage(page);
+  };
+
+  return (
+    <Wrapper data-testid="volunteers-table">
+      <TableContainer>
+        <Table>
+          <TableHeader>
+            <TableHeaderCell>{t("dashboard.volunteers.table.name")}</TableHeaderCell>
+            <TableHeaderCell $width="180px">{t("dashboard.volunteers.table.type")}</TableHeaderCell>
+            <TableHeaderCell $width="200px">{t("dashboard.volunteers.table.engagementStatus")}</TableHeaderCell>
+            <TableHeaderCell $width="140px">{t("dashboard.volunteers.table.matchingStatus")}</TableHeaderCell>
+            <TableHeaderCell $width="180px">{t("dashboard.volunteers.table.language")}</TableHeaderCell>
+            <TableHeaderCell $width="200px">{t("dashboard.volunteers.table.district")}</TableHeaderCell>
+            <TableHeaderCell>{t("dashboard.volunteers.table.email")}</TableHeaderCell>
+          </TableHeader>
+          <TableBody>
+            {volunteers.map((volunteer, index) => (
+              <VolunteerTableRow
+                key={volunteer.id}
+                volunteer={volunteer}
+                isLast={index === volunteers.length - 1}
+                engagementLabels={engagementLabels}
+                typeLabels={typeLabels}
+                opportunityId={opportunityId}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <PaginationNumbers currentPage={currentPage} goToPage={goToPage} totalPages={totalPages} />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--opportunities-container-gap);
+  width: 100%;
+`;

--- a/src/components/Dashboard/Volunteers/VolunteerTableRow.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerTableRow.tsx
@@ -4,8 +4,7 @@ import { ApiVolunteerGetList } from "need4deed-sdk";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
-
-import {
+import type {
   createEngagementStatusLabelMap,
   createStatusLabelMap,
 } from "@/components/Dashboard/Profile/sections/VolunteerAgents/types";
@@ -35,7 +34,7 @@ export function VolunteerTableRow({ volunteer, isLast, engagementLabels, typeLab
       .join(", ") || "—";
   const districtText =
     locations
-      .map((location) => location.title)
+      .map((location) => (typeof location === "string" ? location : location?.title))
       .filter(Boolean)
       .join(", ") || "—";
 

--- a/src/components/Dashboard/Volunteers/VolunteerTableRow.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerTableRow.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { ApiVolunteerGetList } from "need4deed-sdk";
+import { useRouter } from "next/navigation";
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+
+import {
+  createEngagementStatusLabelMap,
+  createStatusLabelMap,
+} from "@/components/Dashboard/Profile/sections/VolunteerAgents/types";
+import { TableCell, TableRow } from "@/components/core/common/Table";
+import { CirclePic } from "@/components/styled/img";
+import { defaultAvatarURL } from "@/config/constants";
+import { getImageUrl } from "@/utils";
+
+interface TableRowProps {
+  volunteer: ApiVolunteerGetList;
+  isLast: boolean;
+  engagementLabels: ReturnType<typeof createEngagementStatusLabelMap>;
+  typeLabels: ReturnType<typeof createStatusLabelMap>;
+  opportunityId?: string;
+}
+
+export function VolunteerTableRow({ volunteer, isLast, engagementLabels, typeLabels, opportunityId }: TableRowProps) {
+  const { i18n } = useTranslation();
+  const router = useRouter();
+
+  const { id, name, avatarUrl, statusEngagement, statusType, languages, locations } = volunteer;
+
+  const languageText =
+    languages
+      .map((language) => language.title)
+      .filter(Boolean)
+      .join(", ") || "—";
+  const districtText =
+    locations
+      .map((location) => location.title)
+      .filter(Boolean)
+      .join(", ") || "—";
+
+  const handleGoToProfile = () => {
+    if (!id) return;
+    const params = opportunityId ? `?opportunity=${opportunityId}` : "";
+    router.push(`/${i18n.language}/dashboard/volunteers/${id}${params}`);
+  };
+
+  return (
+    <ClickableRow $isLast={isLast} onClick={handleGoToProfile} data-testid={`volunteer-row-${id}`}>
+      <NameCell data-testid={`volunteer-name-${id}`}>
+        <CirclePic src={getImageUrl(avatarUrl || defaultAvatarURL)} size="32px" />
+        <NameText>{name}</NameText>
+      </NameCell>
+      <TableCell $width="180px" data-testid={`volunteer-type-${id}`}>
+        {statusType ? typeLabels[statusType] : "—"}
+      </TableCell>
+      <TableCell $width="200px" data-testid={`volunteer-engagement-${id}`}>
+        {statusEngagement ? engagementLabels[statusEngagement] : "—"}
+      </TableCell>
+      <TableCell $width="140px" data-testid={`volunteer-match-${id}`}>
+        —
+      </TableCell>
+      <TableCell $width="180px" data-testid={`volunteer-language-${id}`}>
+        {languageText}
+      </TableCell>
+      <TableCell $width="200px" data-testid={`volunteer-district-${id}`}>
+        {districtText}
+      </TableCell>
+      <TableCell data-testid={`volunteer-email-${id}`}>—</TableCell>
+    </ClickableRow>
+  );
+}
+
+const ClickableRow = styled(TableRow)`
+  cursor: pointer;
+
+  &:hover {
+    background: var(--color-pink-50);
+  }
+`;
+
+const NameCell = styled(TableCell)`
+  overflow: hidden;
+`;
+
+const NameText = styled.span`
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;

--- a/src/components/Dashboard/Volunteers/Volunteers.tsx
+++ b/src/components/Dashboard/Volunteers/Volunteers.tsx
@@ -110,6 +110,7 @@ export function Volunteers() {
             filter={cardsFilter}
             apiFilterOptions={apiFilterOptions}
             opportunityId={opportunityId}
+            selectedTabIndex={selectedTabIndex}
           />
           <Filters
             isFiltersOpen={isFiltersOpen}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -20,6 +20,7 @@ export const apiPathPerson = `/${apiPrefix}/person/`;
 export const apiPathOrganization = `/${apiPrefix}/organization/`;
 export const cloudfrontDataURL = process.env.NEXT_PUBLIC_CLOUDFRONT_DATA_URL;
 export const cacheTTL = 1000 * 60 * 5; // 5 minutes
+export const TABLE_LIMIT = 20;
 
 export enum ScreenTypes {
   MOBILE = "mobile",


### PR DESCRIPTION
## Description
Adds the flat table list view for the volunteers search page (`/dashboard/volunteers`).
Reuses the team's shared `core/common/Table` primitives, same pattern as `CommunicationTracker.tsx`. 

## Related Issues
Closes #476 

## Changes

- New `VolunteerTableList.tsx` and `VolunteerTableRow.tsx` ,  uses `core/common/Table`
- 7 columns: Name, Type, Engagement, Matching, Language, District, Email
- `VolunteerListController.tsx` : renders `VolunteerTableList` for the List tab
- Tab labels fixed in `Volunteers.tsx`: "TABLE VIEW"/"MAP VIEW"  to "List"/"Cards" (EN + DE)
- New translation keys for the column headers 
- Match + Email show "—" since they're not on `ApiVolunteerGetList`
- Also updated `createEngagementStatusLabelMap`  keys were out of sync after #475 PR



## Screenshots / Demos
<img width="1356" height="696" alt="Screenshot from 2026-05-07 09-21-00" src="https://github.com/user-attachments/assets/357aad39-ed1e-4110-b9a0-9c42de3df80d" />


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

