### PR TITLE
501: modify TextArea for user tags

### DIFF
--- a/src/app/[lang]/globals.css
+++ b/src/app/[lang]/globals.css
@@ -197,7 +197,6 @@ html {
   --comments-menu-item-danger-font-weight: var(--font-weight-semi-bold);
 
   /* user tags */
-  --tag-shadow: 0 0 0 2px var(--color-violet-100);
   --tag-text-stroke: 0.5px var(--color-midnight);
 
   /* icon */

--- a/src/app/[lang]/globals.css
+++ b/src/app/[lang]/globals.css
@@ -196,6 +196,10 @@ html {
   --comments-menu-item-font-weight: var(--font-weight-regular);
   --comments-menu-item-danger-font-weight: var(--font-weight-semi-bold);
 
+  /* user tags */
+  --tag-shadow: 0 0 0 2px var(--color-violet-100);
+  --tag-text-stroke: 0.5px var(--color-midnight);
+
   /* icon */
   --icon-color: var(--color-papaya);
   --icon-size-24: 24px;

--- a/src/components/Dashboard/Profile/sections/Comments/common/CommentDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/Comments/common/CommentDisplay.tsx
@@ -2,6 +2,7 @@ import { DotsThreeOutline } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
 import { CommentActionMenu } from "./CommentActionMenu";
 import { CommentText, MenuAction } from "./styles";
+import { useCommentTag } from "./hooks/useCommentTag";
 
 type MenuState = {
   isOpen: boolean;
@@ -21,10 +22,11 @@ type Props = {
 
 export function CommentDisplay({ commentId, content, menu }: Props) {
   const { t } = useTranslation();
+  const { renderHighlightedText } = useCommentTag();
 
   return (
     <>
-      <CommentText>{content}</CommentText>
+      <CommentText>{renderHighlightedText(content)}</CommentText>
       <MenuAction
         ref={menu.buttonRef}
         onClick={menu.onToggle}

--- a/src/components/Dashboard/Profile/sections/Comments/common/EntityComments.tsx
+++ b/src/components/Dashboard/Profile/sections/Comments/common/EntityComments.tsx
@@ -11,7 +11,8 @@ import { DeleteCommentDialog } from "./DeleteCommentDialog";
 import { useCommentDelete } from "./hooks/useCommentDelete";
 import { useCommentEdit } from "./hooks/useCommentEdit";
 import { useCommentMenu } from "./hooks/useCommentMenu";
-import { AddCommentButton, Container, NewCommentSection, TextArea } from "./styles";
+import { AddCommentButton, Container, NewCommentSection, TagOverlay, TextArea } from "./styles";
+import { useCommentTag } from "./hooks/useCommentTag";
 
 type Props = {
   entityId: Id;
@@ -28,6 +29,7 @@ export function EntityComments({ entityId, entityType, comments, testId }: Props
   const edit = useCommentEdit();
   const deleteState = useCommentDelete();
   const menu = useCommentMenu();
+  const { renderHighlightedText } = useCommentTag();
 
   const { mutate: updateComment, isPending: isUpdating } = useUpdateComment(
     entityId,
@@ -124,6 +126,7 @@ export function EntityComments({ entityId, entityType, comments, testId }: Props
       ))}
 
       <NewCommentSection>
+        <TagOverlay>{renderHighlightedText(newCommentText)}</TagOverlay>
         <TextArea
           placeholder={t("dashboard.commentsSection.placeholder")}
           value={newCommentText}

--- a/src/components/Dashboard/Profile/sections/Comments/common/EntityComments.tsx
+++ b/src/components/Dashboard/Profile/sections/Comments/common/EntityComments.tsx
@@ -4,7 +4,7 @@ import { useCreateComment } from "@/hooks/useCreateComment";
 import { useDeleteComment } from "@/hooks/useDeleteComment";
 import { useUpdateComment } from "@/hooks/useUpdateComment";
 import { Id, TimedText } from "need4deed-sdk";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Comment } from "./Comment";
 import { DeleteCommentDialog } from "./DeleteCommentDialog";
@@ -25,6 +25,8 @@ export function EntityComments({ entityId, entityType, comments, testId }: Props
   const { t } = useTranslation();
   const { mutate: createComment, isPending: isCreating } = useCreateComment(entityId, entityType);
   const [newCommentText, setNewCommentText] = useState("");
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
 
   const edit = useCommentEdit();
   const deleteState = useCommentDelete();
@@ -61,6 +63,11 @@ export function EntityComments({ entityId, entityType, comments, testId }: Props
       e.preventDefault();
       handleAddComment();
     }
+  };
+
+  const handleScroll = () => {
+    if (!textAreaRef?.current || !overlayRef?.current) return;
+    overlayRef.current.style.transform = `translateY(-${textAreaRef.current.scrollTop}px)`;
   };
 
   const handleSaveEdit = () => {
@@ -126,23 +133,24 @@ export function EntityComments({ entityId, entityType, comments, testId }: Props
       ))}
 
       <NewCommentSection>
-        <TagOverlay>{renderHighlightedText(newCommentText)}</TagOverlay>
+        <TagOverlay ref={overlayRef}>{renderHighlightedText(newCommentText)}</TagOverlay>
         <TextArea
+          ref={textAreaRef}
           placeholder={t("dashboard.commentsSection.placeholder")}
           value={newCommentText}
           onChange={(e) => setNewCommentText(e.target.value)}
           onKeyPress={handleKeyPress}
           data-testid="comment-textarea"
+          onScroll={handleScroll}
         />
-        <AddCommentButton
-          onClick={handleAddComment}
-          disabled={!newCommentText.trim() || isCreating}
-          data-testid="add-comment-button"
-        >
-          {t("dashboard.commentsSection.addComment")}
-        </AddCommentButton>
       </NewCommentSection>
-
+      <AddCommentButton
+        onClick={handleAddComment}
+        disabled={!newCommentText.trim() || isCreating}
+        data-testid="add-comment-button"
+      >
+        {t("dashboard.commentsSection.addComment")}
+      </AddCommentButton>
       <DeleteCommentDialog
         isOpen={deleteState.deleteDialogOpen}
         authorName={deleteState.deleteAuthorName}

--- a/src/components/Dashboard/Profile/sections/Comments/common/hooks/useCommentTag.tsx
+++ b/src/components/Dashboard/Profile/sections/Comments/common/hooks/useCommentTag.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+
+export function useCommentTag() {
+  const renderHighlightedText = (value: string) => {
+    const parts = value.split(/((?<=^|\s)@\w+)/g);
+    return parts.map((value, idx) => {
+      if (value.startsWith("@")) {
+        // TODO run logic here to find userId for url
+        // TODO add condition, if user valid pass return Link, else fail return value
+        return (
+          // TODO add userId to path
+          <Link href={`/volunteers/:userId`} key={`${value}${idx}`} className="tag">
+            {value}
+          </Link>
+        );
+      } else {
+        return value;
+      }
+    });
+  };
+
+  return { renderHighlightedText };
+}

--- a/src/components/Dashboard/Profile/sections/Comments/common/styles.ts
+++ b/src/components/Dashboard/Profile/sections/Comments/common/styles.ts
@@ -143,13 +143,11 @@ export const TextArea = styled.textarea`
 `;
 
 export const AddCommentButton = styled.button`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  align-self: end;
   padding: var(--spacing-16) var(--spacing-24);
   gap: var(--spacing-8);
   height: 56px;
+  aspect-ratio: 4/1;
   background: var(--color-aubergine);
   border-radius: var(--button-border-radius);
   border: none;

--- a/src/components/Dashboard/Profile/sections/Comments/common/styles.ts
+++ b/src/components/Dashboard/Profile/sections/Comments/common/styles.ts
@@ -64,6 +64,18 @@ export const CommentText = styled.div`
   color: var(--color-midnight);
   align-self: stretch;
   white-space: pre-wrap;
+
+  .tag {
+    color: var(--color-midnight);
+    font-weight: bold;
+    background: var(--color-violet-100);
+    text-decoration: none;
+    box-shadow: var(--tag-shadow);
+    border-radius: var(--border-radius-xs);
+    &:hover {
+      opacity: 0.8;
+    }
+  }
 `;
 
 export const MenuAction = styled.button`
@@ -84,6 +96,7 @@ export const MenuAction = styled.button`
 `;
 
 export const NewCommentSection = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -94,7 +107,7 @@ export const NewCommentSection = styled.div`
 `;
 
 export const TextArea = styled.textarea`
-  box-sizing: border-box;
+  position: relative;
   display: flex;
   flex-direction: row;
   align-items: flex-start;
@@ -102,7 +115,9 @@ export const TextArea = styled.textarea`
   gap: var(--spacing-8);
   width: 100%;
   min-height: 112px;
-  background: var(--color-white);
+  background: transparent;
+  color: transparent;
+  caret-color: var(--color-midnight);
   border: var(--border-width-thin) solid var(--color-grey-200);
   border-radius: var(--border-radius-small);
   font-style: normal;
@@ -110,9 +125,9 @@ export const TextArea = styled.textarea`
   font-size: var(--text-p-font-size);
   line-height: var(--text-p-line-height);
   letter-spacing: var(--letter-spacing-tight);
-  color: var(--color-midnight);
   resize: vertical;
   align-self: stretch;
+  z-index: 2;
 
   &::placeholder {
     color: var(--color-grey-500);
@@ -223,5 +238,35 @@ export const EditSaveButton = styled.button`
 
   &:hover:not(:disabled) {
     background: var(--color-aubergine-light);
+  }
+`;
+
+export const TagOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: var(--spacing-16);
+  font-size: var(--text-p-font-size);
+  line-height: var(--text-p-line-height);
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  color: var(--color-midnight);
+  z-index: 1;
+  pointer-events: none;
+  user-selects: none;
+  font-style: normal;
+  font-weight: var(--font-weight-regular);
+  letter-spacing: var(--letter-spacing-tight);
+
+  .tag {
+    color: var(--color-midnight);
+    background: var(--color-violet-100);
+    text-decoration: none;
+    padding: 0;
+    margin: 0;
+    border: none;
+    -webkit-text-stroke: var(--tag-text-stroke);
+    box-shadow: var(--tag-shadow);
+    border-radius: var(--border-radius-xs);
   }
 `;

--- a/src/components/Dashboard/Profile/sections/Comments/common/styles.ts
+++ b/src/components/Dashboard/Profile/sections/Comments/common/styles.ts
@@ -68,9 +68,7 @@ export const CommentText = styled.div`
   .tag {
     color: var(--color-midnight);
     font-weight: bold;
-    background: var(--color-violet-100);
     text-decoration: none;
-    box-shadow: var(--tag-shadow);
     border-radius: var(--border-radius-xs);
     &:hover {
       opacity: 0.8;
@@ -267,13 +265,11 @@ export const TagOverlay = styled.div`
   overflow-y: hidden;
   .tag {
     color: var(--color-midnight);
-    background: var(--color-violet-100);
     text-decoration: none;
     padding: 0;
     margin: 0;
     border: none;
     -webkit-text-stroke: var(--tag-text-stroke);
-    box-shadow: var(--tag-shadow);
     border-radius: var(--border-radius-xs);
   }
 `;

--- a/src/components/Dashboard/Profile/sections/Comments/common/styles.ts
+++ b/src/components/Dashboard/Profile/sections/Comments/common/styles.ts
@@ -99,35 +99,39 @@ export const NewCommentSection = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
   padding: 0;
   gap: var(--spacing-16);
   width: 100%;
+  height: 112px;
+  overflow-y: hidden;
   align-self: stretch;
+  border: var(--border-width-thin) solid var(--color-grey-200);
+  border-radius: var(--border-radius-small);
 `;
 
 export const TextArea = styled.textarea`
-  position: relative;
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
+  position: absolute;
   padding: var(--spacing-16);
-  gap: var(--spacing-8);
+  margin: 0;
   width: 100%;
-  min-height: 112px;
+  height: 100%;
+  top: 0;
+  left: 0;
   background: transparent;
   color: transparent;
   caret-color: var(--color-midnight);
-  border: var(--border-width-thin) solid var(--color-grey-200);
-  border-radius: var(--border-radius-small);
-  font-style: normal;
-  font-weight: var(--font-weight-regular);
+  font-family: inherit;
   font-size: var(--text-p-font-size);
   line-height: var(--text-p-line-height);
   letter-spacing: var(--letter-spacing-tight);
-  resize: vertical;
-  align-self: stretch;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  box-sizing: border-box;
   z-index: 2;
+  resize: none;
+  overflow-y: scroll;
+  border: none;
+  scrollbar-gutter: stable;
 
   &::placeholder {
     color: var(--color-grey-500);
@@ -135,7 +139,6 @@ export const TextArea = styled.textarea`
 
   &:focus {
     outline: none;
-    border-color: var(--color-midnight);
   }
 `;
 
@@ -245,19 +248,25 @@ export const TagOverlay = styled.div`
   position: absolute;
   top: 0;
   left: 0;
+  width: 100%;
   padding: var(--spacing-16);
+  margin: 0;
+  font-family: inherit;
   font-size: var(--text-p-font-size);
   line-height: var(--text-p-line-height);
+  letter-spacing: var(--letter-spacing-tight);
   white-space: pre-wrap;
   word-wrap: break-word;
+  box-sizing: border-box;
   color: var(--color-midnight);
   z-index: 1;
   pointer-events: none;
   user-selects: none;
   font-style: normal;
   font-weight: var(--font-weight-regular);
-  letter-spacing: var(--letter-spacing-tight);
-
+  will-change: transform;
+  scrollbar-gutter: stable;
+  overflow-y: hidden;
   .tag {
     color: var(--color-midnight);
     background: var(--color-violet-100);


### PR DESCRIPTION
## Description
Changes TextArea so that it accepts user tags with `@` character as well as display comments, so that tags look different from usual text

## Related Issues
Closes #501 

## Changes
- Bullet list of meaningful changes (optional)

## Screenshots / Demos
<img width="1889" height="908" alt="image" src="https://github.com/user-attachments/assets/1c9d9955-20b3-4c37-9c1c-2ea2e8a6299a" />


## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

