### PR TITLE
fix: enforce email validation on form submit in opportunity creation

### DIFF
--- a/src/components/forms/AddOpportunity/AddOpportunity.tsx
+++ b/src/components/forms/AddOpportunity/AddOpportunity.tsx
@@ -146,17 +146,28 @@ export default function AddOpportunity() {
             name="email"
             FieldTag={formOpportunity.Field}
             label={t("form.addOpportunity.fields.contactGroup.email.label")}
-            onChangeValidator={({ value }) => {
-              if (!value) {
-                return t("form.error.required");
-              }
-              if (!validateEmail(value as string)) {
-                return t("form.error.email");
-              }
-              return undefined;
-            }}
-            onChangeAsyncValidator={({ value }) => {
-              return validateRACEmail(value as string, t("form.error.badEmail"));
+            validators={{
+              onChange: ({ value }) => {
+                if (!value) {
+                  return t("form.error.required");
+                }
+                if (!validateEmail(value as string)) {
+                  return t("form.error.email");
+                }
+                return undefined;
+              },
+              onChangeAsync: ({ value }) => {
+                return validateRACEmail(value as string, t("form.error.badEmail"));
+              },
+              onSubmit: ({ value }) => {
+                if (!value) {
+                  return t("form.error.required");
+                }
+                if (!validateEmail(value as string)) {
+                  return t("form.error.email");
+                }
+                return undefined;
+              },
             }}
           />
           <SimpleInputField<OpportunityData>


### PR DESCRIPTION
Closes #421

The email field in the Add Opportunity form only validated onChange and onChangeAsync. If a user submitted the form without ever interacting with the email field, the validation was skipped and the form could be submitted with an empty or invalid email.

Changes:
- Switched email field from individual validator props to the unified `validators` object on SimpleInputField
- Added an `onSubmit` validator that enforces required + format checks at submission time
- Preserved existing `onChange` and `onChangeAsync` validators for real-time feedback
How to test:
1. Go to Add Opportunity form
2. Fill all fields except email
3. Click submit without touching the email field
4. Verify that a validation error appears on the email field
5. Enter a valid RAC email and verify the form submits correctly