### PR TITLE
fix: display operator name in agent organisation details

### DIFF
--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
@@ -35,6 +35,7 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
 
   const initialFormValues = {
     ...details,
+    operator: details?.operator || agent.operator || "",
     clientLanguages: apiLanguagesToFormValues(details?.clientLanguages),
   };
 


### PR DESCRIPTION
Closes #490

The API returns the operator name at two levels: `agent.operator` (root) and `agent.agentDetails.operator` (nested). When the nested field is empty the OrganisationDetails form showed a blank value because it only read from `agentDetails`. Now the form initializer falls back to the root-level operator.

Changes:
- Added fallback chain `details?.operator || agent.operator || ""` in OrganisationDetails form initial values
How to test:
1. Open an agent profile where the operator name is set at root level but not in agentDetails
2. Verify the operator field shows the correct value in the Organisation Details section
3. Verify editing and saving still works correctly