### PR TITLE
fix: invalidate complementary cache on volunteer-opportunity matching

### DIFF
--- a/src/hooks/useUpdateOpportunityVolunteerStatus.ts
+++ b/src/hooks/useUpdateOpportunityVolunteerStatus.ts
@@ -1,6 +1,7 @@
 import { apiPathOpportunityVolunteer } from "@/config/constants";
 import { useMutationQuery } from "@/hooks";
 import { OpportunityVolunteerStatusType } from "need4deed-sdk";
+import { useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 
 type StatusUpdatePayload = {
@@ -10,7 +11,13 @@ type StatusUpdatePayload = {
 
 type DeletePayload = { m2mId: number };
 
+function getComplementaryPrefix(queryKey: string[]): string {
+  return queryKey[0] === "opportunity-volunteers" ? "volunteer-opportunities" : "opportunity-volunteers";
+}
+
 export const useUpdateOpportunityVolunteerStatus = (queryKeyToInvalidate: string[]) => {
+  const queryClient = useQueryClient();
+
   return useMutationQuery<StatusUpdatePayload, unknown>({
     mutationFn: async ({ m2mId, status }: StatusUpdatePayload) => {
       const response = await axios.patch(`${apiPathOpportunityVolunteer}/${m2mId}`, { status });
@@ -18,10 +25,15 @@ export const useUpdateOpportunityVolunteerStatus = (queryKeyToInvalidate: string
     },
     successMessage: "dashboard.opportunityProfile.volunteersSec.statusUpdateSuccess",
     queryKeyToInvalidate,
+    onSuccessCallback: () => {
+      queryClient.invalidateQueries({ queryKey: [getComplementaryPrefix(queryKeyToInvalidate)] });
+    },
   });
 };
 
 export const useDeleteOpportunityVolunteer = (queryKeyToInvalidate: string[]) => {
+  const queryClient = useQueryClient();
+
   return useMutationQuery<DeletePayload, unknown>({
     mutationFn: async ({ m2mId }: DeletePayload) => {
       const response = await axios.delete(`${apiPathOpportunityVolunteer}/${m2mId}`);
@@ -29,5 +41,8 @@ export const useDeleteOpportunityVolunteer = (queryKeyToInvalidate: string[]) =>
     },
     successMessage: "dashboard.opportunityProfile.volunteersSec.removeSuccess",
     queryKeyToInvalidate,
+    onSuccessCallback: () => {
+      queryClient.invalidateQueries({ queryKey: [getComplementaryPrefix(queryKeyToInvalidate)] });
+    },
   });
 };


### PR DESCRIPTION
Closes #300

When matching a volunteer from the volunteer profile page, only the volunteer-opportunities cache was invalidated. The opportunity-volunteers cache stayed stale, so navigating to the opportunity profile still showed the volunteer as pending until a manual page refresh.

Changes:
- After a successful status update or delete in the matching hooks, also invalidate the complementary query prefix (opportunity-volunteers when called from volunteer view, and vice versa)
- Added `getComplementaryPrefix()` helper to determine the other cache key
- Both `useUpdateOpportunityVolunteerStatus` and `useDeleteOpportunityVolunteer` now invalidate both sides
How to test:
1. Open a volunteer profile with a pending opportunity match
2. Click Match on an opportunity
3. Navigate to the opportunity profile without refreshing
4. Verify the volunteer now shows as matched (no refresh needed)
5. Repeat from the opportunity side: match a volunteer, then check the volunteer profile