### PR TITLE
feat: wire document section checkboxes to volunteer PATCH with status dates

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -804,7 +804,7 @@
       "title": "Dokumente",
       "typeOfDocument": "Dokumenttyp",
       "status": "Status",
-      "uploadedOn": "Hochgeladen am",
+      "uploadedOn": "Aktualisiert am",
       "received": "Erhalten",
       "receivedOn": "Erhalten am",
       "actions": "Aktionen",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -631,7 +631,7 @@
       "title": "Documents",
       "typeOfDocument": "Type of document",
       "status": "Status",
-      "uploadedOn": "Uploaded on",
+      "uploadedOn": "Updated on",
       "received": "Received",
       "receivedOn": "Received on",
       "actions": "Actions",

--- a/src/components/Dashboard/Profile/sections/VolunteerProfileDocument/VolunteerProfileDocument.tsx
+++ b/src/components/Dashboard/Profile/sections/VolunteerProfileDocument/VolunteerProfileDocument.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useVolunteerDocuments } from "@/hooks/useVolunteerDocuments";
-import { ApiVolunteerGet, DocumentType } from "need4deed-sdk";
+import { ApiVolunteerGet, DocumentStatusType, DocumentType } from "need4deed-sdk";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
@@ -11,7 +11,7 @@ import { DocumentTableRow } from "./DocumentTableRow";
 import { ACTION_COLUMN_WIDTH, DocumentTableContainer, HeaderCell, Table, TableHeader } from "./styles";
 import { UploadDocumentDialog } from "./UploadDocumentDialog";
 import { useDialogState } from "./useDialogState";
-import { useDeleteDocument, useMarkDocumentReceived, useUploadDocument } from "./useDocumentOperations";
+import { useDeleteDocument, useUpdateVolunteerDocStatus, useUploadDocument } from "./useDocumentOperations";
 import { DocumentRow, enrichDocuments, extractDocumentUrl } from "./utils";
 
 type Props = {
@@ -32,21 +32,51 @@ export function VolunteerProfileDocument({ volunteer }: Props) {
   } = useDialogState();
 
   const [documentUrl, setDocumentUrl] = useState<string | null>(null);
+  const [passportReceived, setPassportReceived] = useState(false);
+  const [passportReceivedAt, setPassportReceivedAt] = useState<Date | null>(null);
 
   const { data: fetchedDocuments, isLoading, isError } = useVolunteerDocuments(volunteer.id);
 
-  const documentRows = useMemo(() => (fetchedDocuments ? enrichDocuments(fetchedDocuments) : []), [fetchedDocuments]);
-
-  const handleToggleReceived = (type: DocumentType, currentIsReceived: boolean) => {
-    receivedMutation.mutate({ volunteerId: volunteer.id, documentType: type, received: !currentIsReceived });
-  };
+  const documentRows = useMemo(
+    () => (fetchedDocuments ? enrichDocuments(fetchedDocuments, volunteer, passportReceived, passportReceivedAt) : []),
+    [fetchedDocuments, volunteer, passportReceived, passportReceivedAt],
+  );
 
   const uploadMutation = useUploadDocument(volunteer.id, () => closeDialog("upload"));
   const deleteMutation = useDeleteDocument(volunteer.id, () => {
     closeDialog("delete");
     closeDialog("preview");
   });
-  const receivedMutation = useMarkDocumentReceived(volunteer.id);
+  const docStatusMutation = useUpdateVolunteerDocStatus(volunteer.id);
+
+  const handleToggleReceived = (type: DocumentType, currentIsReceived: boolean) => {
+    switch (type) {
+      case DocumentType.MEASLES_VACCINATION:
+        docStatusMutation.mutate({
+          measlesVaccination: currentIsReceived ? DocumentStatusType.NO : DocumentStatusType.YES,
+        });
+        break;
+      case DocumentType.CGC:
+        docStatusMutation.mutate({
+          goodConductCertificate: currentIsReceived ? DocumentStatusType.NO : DocumentStatusType.YES,
+        });
+        break;
+      case DocumentType.CGC_APPLICATION:
+        // If the cert itself is already confirmed (YES), the application stage is superseded — ignore
+        if (volunteer.goodConductCertificate === DocumentStatusType.YES) return;
+        docStatusMutation.mutate({
+          goodConductCertificate: currentIsReceived ? DocumentStatusType.NO : DocumentStatusType.APPLIED_N4D,
+        });
+        break;
+      case DocumentType.PASSPORT_ID:
+        setPassportReceived((prev) => {
+          const next = !prev;
+          setPassportReceivedAt(next ? new Date() : null);
+          return next;
+        });
+        break;
+    }
+  };
 
   const handleConfirmDelete = () => {
     if (deleteDialogDocument) {

--- a/src/components/Dashboard/Profile/sections/VolunteerProfileDocument/useDocumentOperations.ts
+++ b/src/components/Dashboard/Profile/sections/VolunteerProfileDocument/useDocumentOperations.ts
@@ -1,7 +1,7 @@
 import { apiPathVolunteer } from "@/config/constants";
 import { useMutationQuery } from "@/hooks/useMutationQuery";
 import axios from "axios";
-import { DocumentType } from "need4deed-sdk";
+import { ApiVolunteerGet, DocumentStatusType, DocumentType } from "need4deed-sdk";
 import { useTranslation } from "react-i18next";
 
 type UploadMetaResponse = {
@@ -48,18 +48,9 @@ const deleteDocumentApi = async (volunteerId: number, documentType: DocumentType
   await axios.delete(`${apiPathVolunteer}/${volunteerId}/doc/${documentType}`);
 };
 
-type MarkReceivedPayload = {
-  volunteerId: number;
-  documentType: DocumentType;
-  received: boolean;
-};
-
-const markDocumentReceivedApi = async (
-  volunteerId: number,
-  documentType: DocumentType,
-  received: boolean,
-): Promise<void> => {
-  await axios.patch(`${apiPathVolunteer}/${volunteerId}/doc/${documentType}`, { received });
+type DocStatusPayload = {
+  goodConductCertificate?: DocumentStatusType;
+  measlesVaccination?: DocumentStatusType;
 };
 
 export const useUploadDocument = (volunteerId: number, onSuccess?: () => void) => {
@@ -89,9 +80,10 @@ export const useDeleteDocument = (volunteerId: number, onSuccess?: () => void) =
   });
 };
 
-export const useMarkDocumentReceived = (volunteerId: number) => {
-  return useMutationQuery<MarkReceivedPayload, void>({
-    mutationFn: ({ documentType, received }) => markDocumentReceivedApi(volunteerId, documentType, received),
-    queryKeyToInvalidate: ["volunteerDocuments", volunteerId.toString()],
+export const useUpdateVolunteerDocStatus = (volunteerId: number) => {
+  return useMutationQuery<DocStatusPayload, { message: string; data: ApiVolunteerGet }>({
+    apiPath: `${apiPathVolunteer}/${volunteerId}`,
+    method: "patch",
+    queryKeyToInvalidate: ["volunteer", String(volunteerId)],
   });
 };

--- a/src/components/Dashboard/Profile/sections/VolunteerProfileDocument/utils.ts
+++ b/src/components/Dashboard/Profile/sections/VolunteerProfileDocument/utils.ts
@@ -1,21 +1,17 @@
-import { ApiDocumentGet, DocumentType } from "need4deed-sdk";
+import { ApiDocumentGet, DocumentStatusType, DocumentType } from "need4deed-sdk";
 
-// TODO: remove cast once SDK is updated to include received and receivedOn (added by BE PR #417)
-export type ApiDocumentGetWithReceived = ApiDocumentGet & {
-  received?: boolean;
-  receivedOn?: string;
-};
-
-export type EnrichedDocument = ApiDocumentGetWithReceived & {
-  nameKey: string;
-  isUploaded: boolean;
+// TODO: remove once SDK >= 0.0.82 is published (BE issue need4deed-org/be#481)
+type ApiVolunteerGet = import("need4deed-sdk").ApiVolunteerGet & {
+  statusVaccinationDate?: Date | null;
+  statusCGCApplicationDate?: Date | null;
+  statusCGCDate?: Date | null;
 };
 
 export type DocumentRow = {
   type: DocumentType;
   nameKey: string;
   isUploaded: boolean;
-  document?: ApiDocumentGetWithReceived;
+  document?: ApiDocumentGet;
   isReceived: boolean;
   receivedAt: Date | null;
 };
@@ -48,19 +44,56 @@ export const extractDocumentUrl = (url: string): string | null => {
   }
 };
 
-export const enrichDocuments = (fetchedDocuments: ApiDocumentGet[]): DocumentRow[] => {
+export const enrichDocuments = (
+  fetchedDocuments: ApiDocumentGet[],
+  volunteer: ApiVolunteerGet,
+  passportReceived: boolean,
+  passportReceivedAt: Date | null,
+): DocumentRow[] => {
   const allTypes = Object.keys(DOCUMENT_NAME_KEYS) as DocumentType[];
 
   return allTypes.map((type) => {
-    // TODO: remove cast once SDK is updated to include received and receivedOn (added by BE PR #417)
-    const document = fetchedDocuments.find((doc) => doc.type === type) as ApiDocumentGetWithReceived | undefined;
+    const document = fetchedDocuments.find((doc) => doc.type === type);
+
+    let isReceived = false;
+    switch (type) {
+      case DocumentType.MEASLES_VACCINATION:
+        isReceived = volunteer.measlesVaccination === DocumentStatusType.YES;
+        break;
+      case DocumentType.CGC:
+        isReceived = volunteer.goodConductCertificate === DocumentStatusType.YES;
+        break;
+      case DocumentType.CGC_APPLICATION:
+        isReceived = volunteer.goodConductCertificate === DocumentStatusType.APPLIED_N4D;
+        break;
+      case DocumentType.PASSPORT_ID:
+        isReceived = passportReceived;
+        break;
+    }
+
+    let receivedAt: Date | null = null;
+    switch (type) {
+      case DocumentType.MEASLES_VACCINATION:
+        receivedAt = volunteer.statusVaccinationDate ? new Date(volunteer.statusVaccinationDate) : null;
+        break;
+      case DocumentType.CGC:
+        receivedAt = volunteer.statusCGCDate ? new Date(volunteer.statusCGCDate) : null;
+        break;
+      case DocumentType.CGC_APPLICATION:
+        receivedAt = volunteer.statusCGCApplicationDate ? new Date(volunteer.statusCGCApplicationDate) : null;
+        break;
+      case DocumentType.PASSPORT_ID:
+        receivedAt = passportReceivedAt;
+        break;
+    }
+
     return {
       type,
       nameKey: DOCUMENT_NAME_KEYS[type],
       isUploaded: !!document,
       document,
-      isReceived: document?.received ?? false,
-      receivedAt: document?.receivedOn ? new Date(document.receivedOn) : null,
+      isReceived,
+      receivedAt,
     };
   });
 };


### PR DESCRIPTION
## Summary

- Replaces broken `PATCH /volunteer/:id/doc/:type` calls with the existing `PATCH /volunteer/:id` endpoint
- Checkboxes map to `DocumentStatusType` values on `statusVaccination` / `statusCGC`
- **CGC-application** checkbox sets `goodConductCertificate = APPLIED_N4D` (blocked if already `YES`)
- **Good-conduct-cert** checkbox sets `goodConductCertificate = YES`, overwriting `APPLIED_N4D`
- **Passport copy** is local session state only — no BE call
- "Updated on" column now shows the status date per row — persisted via BE
- Column header renamed "Uploaded on" → "Updated on" (EN + DE)
- Removes dead `useMarkDocumentReceived` hook and `ApiDocumentGetWithReceived` type

## Dependencies

- Requires BE PR https://github.com/need4deed-org/be/pull/482 (date columns)
- Requires SDK PR https://github.com/need4deed-org/sdk/pull/92 (type update) — FE uses local type extension until SDK is published

## Test plan

- [ ] Tick measles-vacc-cert → `statusVaccination = YES`, date appears in Updated on column
- [ ] Untick measles-vacc-cert → `statusVaccination = NO`, date cleared
- [ ] Tick CGC-application → `goodConductCertificate = APPLIED_N4D`, application date shown
- [ ] Tick good-conduct-cert → `goodConductCertificate = YES`, cert date shown, application date still shown on CGC-application row
- [ ] CGC-application checkbox is unclickable when good-conduct-cert is ticked
- [ ] Untick good-conduct-cert → both CGC dates cleared
- [ ] Passport copy toggles locally, shows tick time in session, resets on page reload
- [ ] No 404 errors in console when toggling any checkbox

Closes https://github.com/need4deed-org/fe/issues/508

🤖 Generated with [Claude Code](https://claude.com/claude-code)