### PR TITLE
fix: display single district on opportunity card (#507)

### DIFF
--- a/src/components/Dashboard/Home/NewestOpportunities.tsx
+++ b/src/components/Dashboard/Home/NewestOpportunities.tsx
@@ -20,12 +20,13 @@ export function NewestOpportunities() {
     staleTime: cacheTTL,
   });
   const activitiesList = apiFilterOptions?.activity;
+  const districtsList = apiFilterOptions?.district;
 
   if (isLoading) {
     return <Heading4>{t("dashboard.home.content.loading")}</Heading4>;
   }
 
   return opportunities?.map((opp) => (
-    <OpportunityCard key={opp.id} opportunity={opp} volunteerId={undefined} activitiesList={activitiesList} />
+    <OpportunityCard key={opp.id} opportunity={opp} volunteerId={undefined} activitiesList={activitiesList} districtsList={districtsList} />
   ));
 }

--- a/src/components/Dashboard/Opportunities/OpportunityCard.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityCard.tsx
@@ -7,7 +7,7 @@ import { Paragraph } from "@/components/styled/text";
 import CardDetail from "../Volunteers/CardDetail";
 import { CardParagraph } from "../Volunteers/VolunteerCard";
 import { IconName } from "../Volunteers/icon";
-import { getActivityTitles, getLanguagesByPurpose, getOptionTitles } from "./helpers";
+import { getActivityTitles, getLanguagesByPurpose } from "./helpers";
 import {
   formatAccompanyingDate,
   formatAvailability,
@@ -23,9 +23,10 @@ type Props = {
   opportunity: ApiVolunteerOpportunityGetList;
   volunteerId?: string;
   activitiesList?: OptionItem[];
+  districtsList?: OptionItem[];
 };
 
-export function OpportunityCard({ opportunity, volunteerId, activitiesList }: Props) {
+export function OpportunityCard({ opportunity, volunteerId, activitiesList, districtsList }: Props) {
   const { t, i18n } = useTranslation();
   const router = useRouter();
 
@@ -36,19 +37,22 @@ export function OpportunityCard({ opportunity, volunteerId, activitiesList }: Pr
     statusOpportunity,
     languages,
     activities,
-    location,
     availability,
     accompanyingDetails,
     statusMatch,
+    district,
   } = opportunity as ApiVolunteerOpportunityGetList & {
     accompanyingDetails?: { appointmentDate?: string; appointmentTime?: string };
     statusMatch?: string;
+    district?: { id: number };
   };
 
   const mainCommunication = getLanguagesByPurpose(languages, LangPurpose.GENERAL);
   const recipientLanguage = getLanguagesByPurpose(languages, LangPurpose.RECIPIENT);
-  const locationTitles = getOptionTitles(location);
   const activityTitles = getActivityTitles(activities, activitiesList);
+  const districtTitle = district?.id
+    ? (districtsList?.find((d) => d.id === district.id)?.title ?? null)
+    : null;
 
   const isAccompanying = volunteerType === ProfileVolunteeringType.ACCOMPANYING;
   const scheduleText = isAccompanying
@@ -134,7 +138,7 @@ export function OpportunityCard({ opportunity, volunteerId, activitiesList }: Pr
       </CardDetail>
 
       <CardDetail header={t("dashboard.opportunities.district")} iconName={IconName.MapPin}>
-        {locationTitles.length > 0 && <CardParagraph text={locationTitles.join(", ")} />}
+        {districtTitle && <CardParagraph text={districtTitle} />}
       </CardDetail>
     </Card>
   );

--- a/src/components/Dashboard/Opportunities/OpportunityCardList.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityCardList.tsx
@@ -5,6 +5,7 @@ import { OpportunityCardListContainer } from "./styles";
 
 type Props = {
   activitiesList?: OptionItem[];
+  districtsList?: OptionItem[];
   opportunities: ApiVolunteerOpportunityGetList[];
   count: number;
   columns: number;
@@ -23,9 +24,10 @@ export function OpportunityCardList({
   setCurrentPage,
   volunteerId,
   activitiesList,
+  districtsList,
 }: Props) {
   const items = opportunities.map((opp) => (
-    <OpportunityCard key={opp.id} opportunity={opp} volunteerId={volunteerId} activitiesList={activitiesList} />
+    <OpportunityCard key={opp.id} opportunity={opp} volunteerId={volunteerId} activitiesList={activitiesList} districtsList={districtsList} />
   ));
 
   return (

--- a/src/components/Dashboard/Opportunities/OpportunityListController.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityListController.tsx
@@ -88,6 +88,7 @@ export function OpportunityListController({
   return (
     <OpportunityCardList
       activitiesList={apiFilterOptions?.activity}
+      districtsList={apiFilterOptions?.district}
       opportunities={opportunities}
       count={count}
       columns={columns - (isFiltersOpen ? 1 : 0)}


### PR DESCRIPTION
Closes https://github.com/need4deed-org/fe/issues/507

## Summary

- Reads `district.id` from the opportunity response (added to the BE DTO in https://github.com/need4deed-org/be/pull/473)
- Looks up the district title from the already-fetched `apiFilterOptions.district` list (14 options: 12 districts + Remote + Berlin)
- Threads `districtsList` prop through `OpportunityCardList` → `OpportunityCard` and adds it to `NewestOpportunities`
- Removes the old `locationTitles` / `getOptionTitles(location)` approach that was always blank

No backend changes needed — the options list the filter panel already fetches has all district titles.

> **Note:** `district` is not yet typed on `ApiVolunteerOpportunityGetList` in the SDK. A type cast is used until SDK PR https://github.com/need4deed-org/sdk/pull/91 is merged.

## Test plan

- [ ] Open the opportunities list — district name shows on cards that have one assigned
- [ ] Cards with no district assigned show a blank district row (same as before)
- [ ] Newest opportunities on the home page also display the district correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)