### PR TITLE
fix: remove district selector from accompanying opportunity form

### DIFF
--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetails.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useApiDistricts, useApiLanguages } from "@/components/Dashboard/Profile/sections/VolunteerProfile/hooks";
+import { useApiLanguages } from "@/components/Dashboard/Profile/sections/VolunteerProfile/hooks";
 import { useUpdateOpportunityAccompanyingDetails } from "@/hooks/useUpdateOpportunityAccompanyingDetails";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { de, enUS } from "date-fns/locale";
@@ -31,7 +31,6 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
 
   useEditingChangeNotifier(isEditing, onEditingChange);
   const { data: apiLanguages } = useApiLanguages();
-  const { data: apiDistricts } = useApiDistricts();
   const showFullDetails = isAccompanyingType(opportunity.volunteerType);
   const minAppointmentDate = useMemo(() => getMinAppointmentDate(), []);
 
@@ -53,14 +52,6 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
     appointmentLanguageLabelToKey[label] = key;
   });
   const appointmentLanguageOptions = appointmentLanguageKeys.map((key) => appointmentLanguageKeyToLabel[key]);
-
-  const districtKeyToLabel: Record<string, string> = {};
-  const districtLabelToKey: Record<string, string> = {};
-  apiDistricts.forEach((district) => {
-    districtKeyToLabel[String(district.id)] = district.title;
-    districtLabelToKey[district.title] = String(district.id);
-  });
-  const districtOptions = apiDistricts.map((district) => district.title);
 
   const initialFormValues = getInitialFormValues(opportunity.accompanyingDetails);
 
@@ -94,7 +85,6 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
         accompanyingDetails: {
           appointmentAddress: values.appointmentAddress,
           appointmentPostcode: values.appointmentPostcode || undefined,
-          appointmentDistrict: values.appointmentDistrict || undefined,
           appointmentDate: values.appointmentDate ? values.appointmentDate.toISOString() : undefined,
           appointmentTime: values.appointmentTime || undefined,
           refugeeNumber: values.refugeeNumber,
@@ -132,8 +122,6 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
     .filter((lang) => lang.purpose === LangPurpose.RECIPIENT)
     .map((lang) => lang.title)
     .join(", ");
-  const districtLabel =
-    districtKeyToLabel[formValues.appointmentDistrict || ""] || formValues.appointmentDistrict || "";
 
   return (
     <FormProvider {...methods}>
@@ -147,16 +135,13 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
             appointmentLanguageOptions={appointmentLanguageOptions}
             appointmentLanguageKeyToLabel={appointmentLanguageKeyToLabel}
             appointmentLanguageLabelToKey={appointmentLanguageLabelToKey}
-            districtOptions={districtOptions}
-            districtKeyToLabel={districtKeyToLabel}
-            districtLabelToKey={districtLabelToKey}
             onCancel={handleCancel}
             onSubmit={handleSubmit(onSubmit)}
             isPending={isPending}
             minAppointmentDate={minAppointmentDate}
           />
         ) : (
-          <AccompanyingDetailsDisplay values={formValues} languageLabel={languageLabel} districtLabel={districtLabel} />
+          <AccompanyingDetailsDisplay values={formValues} languageLabel={languageLabel} />
         )}
       </Container>
     </FormProvider>

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsDisplay.tsx
@@ -9,10 +9,9 @@ import { DateFieldRow, Details } from "./styles";
 type Props = {
   values: AccompanyingDetailsFormData;
   languageLabel: string;
-  districtLabel: string;
 };
 
-export const AccompanyingDetailsDisplay = ({ values, languageLabel, districtLabel }: Props) => {
+export const AccompanyingDetailsDisplay = ({ values, languageLabel }: Props) => {
   const { t } = useTranslation();
 
   return (
@@ -31,15 +30,6 @@ export const AccompanyingDetailsDisplay = ({ values, languageLabel, districtLabe
         label={t("dashboard.opportunityProfile.accompanyingDetails.appointmentPostcode")}
         value={values.appointmentPostcode || ""}
         setValue={() => {}}
-      />
-
-      <EditableField
-        mode="display"
-        type="radio-list"
-        label={t("dashboard.opportunityProfile.accompanyingDetails.appointmentDistrict")}
-        value={districtLabel}
-        setValue={() => {}}
-        options={[]}
       />
 
       <DateFieldRow data-testid="appointment-date-field">

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsEdit.tsx
@@ -23,9 +23,6 @@ type Props = {
   appointmentLanguageOptions: string[];
   appointmentLanguageKeyToLabel: Record<string, string>;
   appointmentLanguageLabelToKey: Record<string, string>;
-  districtOptions: string[];
-  districtKeyToLabel: Record<string, string>;
-  districtLabelToKey: Record<string, string>;
   onCancel: () => void;
   onSubmit: () => void;
   isPending: boolean;
@@ -40,9 +37,6 @@ export const AccompanyingDetailsEdit = ({
   appointmentLanguageOptions,
   appointmentLanguageKeyToLabel,
   appointmentLanguageLabelToKey,
-  districtOptions,
-  districtKeyToLabel,
-  districtLabelToKey,
   onCancel,
   onSubmit,
   isPending,
@@ -83,25 +77,6 @@ export const AccompanyingDetailsEdit = ({
               value={field.value || ""}
               setValue={field.onChange}
               errorMessage={errors.appointmentPostcode?.message}
-            />
-          )}
-        />
-
-        <Controller
-          name="appointmentDistrict"
-          control={control}
-          render={({ field }: { field: ControllerRenderProps<AccompanyingDetailsFormData, "appointmentDistrict"> }) => (
-            <EditableField
-              mode="edit"
-              type="radio-list"
-              label={t("dashboard.opportunityProfile.accompanyingDetails.appointmentDistrict")}
-              value={districtKeyToLabel[field.value || ""] || field.value || ""}
-              setValue={(value) => {
-                const label = Array.isArray(value) ? value[0] : value;
-                field.onChange(districtLabelToKey[label] || label);
-              }}
-              options={districtOptions}
-              errorMessage={errors.appointmentDistrict?.message}
             />
           )}
         />

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/accompanyingDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/accompanyingDetailsSchema.ts
@@ -5,7 +5,6 @@ const timeRegex = /^([01]?[0-9]|2[0-3]):[0-5][0-9]$/;
 export const accompanyingDetailsSchema = z.object({
   appointmentAddress: z.string().optional(),
   appointmentPostcode: z.string().optional(),
-  appointmentDistrict: z.string().optional(),
   appointmentDate: z.date().nullable().optional(),
   appointmentTime: z
     .string()


### PR DESCRIPTION
## Summary

- Removed the `appointmentDistrict` field from the accompanying opportunity form (both edit and display modes)
- For accompanying opportunities, district is derived automatically on the BE from the appointment postcode — a manual selector is not needed
- Removed district fetching (`useApiDistricts`), mapping, and all related props from the component tree

## Closes

https://github.com/need4deed-org/fe/issues/517

🤖 Generated with [Claude Code](https://claude.com/claude-code)