### PR TITLE
feat: add video call as a contact method in communication tracker

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1234,7 +1234,8 @@
         "signal": "Signal",
         "email": "E-Mail",
         "sms": "SMS",
-        "voicenote": "Sprachnachricht"
+        "voicenote": "Sprachnachricht",
+        "videoCall": "Videoanruf"
       },
       "notesPlaceholder": "Fügen Sie Notizen zu dieser Kommunikation hinzu...",
       "cancel": "Abbrechen",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1233,7 +1233,8 @@
         "signal": "Signal",
         "email": "E-mail",
         "sms": "SMS",
-        "voicenote": "Voicenote"
+        "voicenote": "Voicenote",
+        "videoCall": "Video call"
       },
       "notesPlaceholder": "Add notes about this communication...",
       "cancel": "Cancel",

--- a/src/components/Dashboard/Profile/sections/CommunicationTracker/utils/options.ts
+++ b/src/components/Dashboard/Profile/sections/CommunicationTracker/utils/options.ts
@@ -30,6 +30,7 @@ export function getContactMethodOptions(t: TFunction, contactType: ContactType):
 
   return [
     ContactMethodType.PHONE,
+    ContactMethodType.VIDEO_CALL,
     ContactMethodType.TELEGRAM,
     ContactMethodType.WHATSAPP,
     ContactMethodType.SIGNAL,

--- a/src/components/Dashboard/Profile/sections/CommunicationTracker/utils/translations.ts
+++ b/src/components/Dashboard/Profile/sections/CommunicationTracker/utils/translations.ts
@@ -20,6 +20,7 @@ export function getContactMethodLabel(t: TFunction, contactMethod: ContactMethod
     [ContactMethodType.EMAIL]: "dashboard.communicationSection.platformOptions.email",
     [ContactMethodType.SMS]: "dashboard.communicationSection.platformOptions.sms",
     [ContactMethodType.VOICENOTE]: "dashboard.communicationSection.platformOptions.voicenote",
+    [ContactMethodType.VIDEO_CALL]: "dashboard.communicationSection.platformOptions.videoCall",
   };
   return t(map[contactMethod] || `dashboard.communicationSection.platformOptions.${contactMethod.toLowerCase()}`, { defaultValue: contactMethod });
 }


### PR DESCRIPTION
## Summary
- Adds "Video call" option to the contact method dropdown in the communication tracker
- Appears under call-type contacts (alongside Phone, Telegram, WhatsApp, Signal)
- Translations added for EN ("Video call") and DE ("Videoanruf")

## Related
- Closes https://github.com/need4deed-org/fe/issues/521
- SDK PR: https://github.com/need4deed-org/sdk/pull/97
- BE PR: https://github.com/need4deed-org/be/pull/new/feat/521-add-video-call-contact-method

## Test plan
- [ ] Open communication tracker on a volunteer or agent profile
- [ ] Click "Add communication", set contact type to "Called" — verify "Video call" appears as an option
- [ ] Log a briefing (Communication type = "Briefed") with video call method — saves successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)