### PR TITLE
fix: add SMS to preferred contact method options

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -602,7 +602,8 @@
           "email-sent": "E-Mail gesendet",
           "briefed": "Briefing erfolgt",
           "tried-call": "Versucht anzurufen",
-          "not-responding": "Keine Reaktion"
+          "not-responding": "Keine Reaktion",
+          "sms": "SMS"
         },
         "notProvided": "Nicht angegeben",
         "cancel": "Abbrechen",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -601,7 +601,8 @@
           "email-sent": "Email sent",
           "briefed": "Briefed",
           "tried-call": "Tried to call",
-          "not-responding": "Not responding"
+          "not-responding": "Not responding",
+          "sms": "SMS"
         },
         "notProvided": "Not provided",
         "cancel": "Cancel",


### PR DESCRIPTION
## Summary
Adds `"sms": "SMS"` translation key to the `preferredCommunicationType` section in EN and DE locales. The `SMS` value was already added to `PreferredCommunicationType` enum in SDK PR #97 — this is the FE translation needed to display it correctly.

## Related
- Closes https://github.com/need4deed-org/fe/issues/491
- SDK PR: https://github.com/need4deed-org/sdk/pull/97

🤖 Generated with [Claude Code](https://claude.com/claude-code)