### PR TITLE
feat(#488): add agent profile link to opportunity header

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1012,6 +1012,7 @@
       "postedOn": "Veröffentlicht am",
       "currentStatus": "Aktueller Status",
       "matchingStatus": "Matching-Status",
+      "agent": "Träger",
       "status": {
         "new": "Neu",
         "active": "Aktiv",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1011,6 +1011,7 @@
       "postedOn": "Posted on",
       "currentStatus": "Current status",
       "matchingStatus": "Matching status",
+      "agent": "Agent",
       "status": {
         "new": "New",
         "active": "Active",

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
@@ -3,7 +3,9 @@ import { EMPTY_PLACEHOLDER_VALUE } from "@/config/constants";
 import { formatDateTime } from "@/utils";
 import { ShootingStarIcon } from "@phosphor-icons/react";
 import { ApiOpportunityGet, VolunteerStateMatchType } from "need4deed-sdk";
+import Link from "next/link";
 import { useTranslation } from "react-i18next";
+import styled from "styled-components";
 import { createVolunteerTypeLabelMap, EditButton, HeaderCard, IconContainer, StatusRowField } from "../common";
 import { ChangeOpportunityStatusDialog } from "./ChangeOpportunityStatusDialog";
 import { createMatchLabelMap } from "../volunteer/constants";
@@ -16,8 +18,18 @@ type Props = {
   opportunity: OpportunityWithMatch;
 };
 
+const AgentLink = styled(Link)`
+  color: var(--color-blue-700);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
 export const OpportunityHeader = ({ opportunity }: Props) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const dialog = useOpportunityStatusDialog(opportunity);
   const statusLabelMap = createOpportunityStatusLabelMap(t);
   const volunteerTypeLabelMap = createVolunteerTypeLabelMap(t);
@@ -56,6 +68,17 @@ export const OpportunityHeader = ({ opportunity }: Props) => {
         status={opportunity.statusMatch}
         label={opportunity.statusMatch ? matchLabelMap[opportunity.statusMatch] : undefined}
       />
+
+      {opportunity.agent?.id && (
+        <StatusRowField
+          title={t("dashboard.opportunityProfile.agent")}
+          extra={
+            <AgentLink href={`/${i18n.language}/dashboard/agents/${opportunity.agent.id}`}>
+              {opportunity.agent.name}
+            </AgentLink>
+          }
+        />
+      )}
     </HeaderCard>
   );
 };

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
@@ -18,16 +18,6 @@ type Props = {
   opportunity: OpportunityWithMatch;
 };
 
-const AgentLink = styled(Link)`
-  color: var(--color-blue-700);
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
-  text-decoration: none;
-  &:hover {
-    text-decoration: underline;
-  }
-`;
-
 export const OpportunityHeader = ({ opportunity }: Props) => {
   const { t, i18n } = useTranslation();
   const dialog = useOpportunityStatusDialog(opportunity);
@@ -82,3 +72,13 @@ export const OpportunityHeader = ({ opportunity }: Props) => {
     </HeaderCard>
   );
 };
+
+const AgentLink = styled(Link)`
+  color: var(--color-blue-700);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+`;


### PR DESCRIPTION
## Summary
- Adds an "Agent" row to the opportunity profile header
- Agent name is a clickable link that navigates to `/dashboard/agents/{id}`
- Adds translation keys `dashboard.opportunityProfile.agent` (EN: "Agent", DE: "Träger")

Depends on: https://github.com/need4deed-org/be/pull/496 (BE exposes `id` in opportunity agent DTO)

Closes https://github.com/need4deed-org/fe/issues/488

## Test plan
- [ ] Open an opportunity profile — the header should show an "Agent" row with the agent's name as a link
- [ ] Click the link — should navigate to the agent's profile page
- [ ] Check both EN and DE locales show correct label

🤖 Generated with [Claude Code](https://claude.com/claude-code)