### PR TITLE
refactor: extract generic EntityTableList component

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "^0.0.81",
+    "need4deed-sdk": "^0.0.82",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/src/app/[lang]/globals.css
+++ b/src/app/[lang]/globals.css
@@ -503,6 +503,9 @@ html {
   --custom-px-17: 17px;
   --zero: 0px;
 
+  /* entity table */
+  --entity-table-gap: var(--spacing-16);
+
   /* volunteer header */
   --volunteer-header-label-width: 214px;
 }

--- a/src/components/Dashboard/Volunteers/VolunteerListController.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerListController.tsx
@@ -7,11 +7,11 @@ import { CardsFilter } from "./Filters/types";
 import { serializeFilters } from "./helpers";
 import { VolunteerCardList } from "./VolunteerCardList"; // We will modify this component
 import { VolunteerTableList } from "./VolunteerTableList";
+import { ViewMode } from "../common/types";
 
 const CARD_COLUMNS = 3;
 const CARD_ROWS = 3;
 const CARD_LIMIT = CARD_COLUMNS * CARD_ROWS;
-const LIST_TAB_INDEX = 0;
 
 interface VolunteerListControllerProps {
   setNumOfVols: (numOfVols: number) => void;
@@ -20,7 +20,7 @@ interface VolunteerListControllerProps {
   filter: CardsFilter;
   apiFilterOptions?: ApiOptionLists;
   opportunityId?: string;
-  selectedTabIndex: number;
+  viewMode: ViewMode;
 }
 
 export function VolunteerListController({
@@ -30,10 +30,9 @@ export function VolunteerListController({
   filter,
   apiFilterOptions,
   opportunityId,
-  selectedTabIndex,
+  viewMode,
 }: VolunteerListControllerProps) {
-  const isListView = selectedTabIndex === LIST_TAB_INDEX;
-  const limit = isListView ? TABLE_LIMIT : CARD_LIMIT;
+  const limit = viewMode === "list" ? TABLE_LIMIT : CARD_LIMIT;
   const { currentPage, setCurrentPage } = usePageParam();
   const serializedFilter = serializeFilters(filter, undefined, false, {
     serializeToIDs: true,
@@ -61,7 +60,7 @@ export function VolunteerListController({
     setNumOfVols(count);
   }, [count, setNumOfVols]);
 
-  if (isListView) {
+  if (viewMode === "list") {
     return (
       <VolunteerTableList
         volunteers={volunteers}

--- a/src/components/Dashboard/Volunteers/VolunteerListController.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerListController.tsx
@@ -32,7 +32,8 @@ export function VolunteerListController({
   opportunityId,
   viewMode,
 }: VolunteerListControllerProps) {
-  const limit = viewMode === "list" ? TABLE_LIMIT : CARD_LIMIT;
+  const isListView = viewMode === "list";
+  const limit = isListView ? TABLE_LIMIT : CARD_LIMIT;
   const { currentPage, setCurrentPage } = usePageParam();
   const serializedFilter = serializeFilters(filter, undefined, false, {
     serializeToIDs: true,
@@ -60,7 +61,7 @@ export function VolunteerListController({
     setNumOfVols(count);
   }, [count, setNumOfVols]);
 
-  if (viewMode === "list") {
+  if (isListView) {
     return (
       <VolunteerTableList
         volunteers={volunteers}

--- a/src/components/Dashboard/Volunteers/VolunteerListController.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerListController.tsx
@@ -33,7 +33,7 @@ export function VolunteerListController({
   opportunityId,
   viewMode,
 }: VolunteerListControllerProps) {
-  const isListView = viewMode === "list";
+  const isListView = viewMode === ViewMode.LIST;
   const limit = isListView ? TABLE_LIMIT : CARD_LIMIT;
   const { currentPage, setCurrentPage } = usePageParam();
   const serializedFilter = serializeFilters(filter, undefined, false, {

--- a/src/components/Dashboard/Volunteers/VolunteerTableList.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerTableList.tsx
@@ -1,16 +1,15 @@
 "use client";
 
-import { ApiVolunteerGetList } from "need4deed-sdk";
+import type { ApiVolunteerGetList } from "need4deed-sdk";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import styled from "styled-components";
 import {
   createEngagementStatusLabelMap,
   createStatusLabelMap,
 } from "@/components/Dashboard/Profile/sections/VolunteerAgents/types";
-import { Table, TableBody, TableContainer, TableHeader, TableHeaderCell } from "@/components/core/common/Table";
-import PaginationNumbers from "@/components/core/paginatedGrid/PaginationNumbers";
+import { createVolunteerTableColumns } from "./volunteerTableColumns";
 import { VolunteerTableRow } from "./VolunteerTableRow";
+import { EntityTableList } from "../common/EntityTableList";
 
 interface TableListProps {
   volunteers: ApiVolunteerGetList[];
@@ -30,50 +29,29 @@ export function VolunteerTableList({
   opportunityId,
 }: TableListProps) {
   const { t } = useTranslation();
-  const totalPages = Math.ceil(count / itemsPerPage);
-
   const engagementLabels = useMemo(() => createEngagementStatusLabelMap(t), [t]);
   const typeLabels = useMemo(() => createStatusLabelMap(t), [t]);
-
-  const goToPage = (page: number) => {
-    if (page > 0 && page <= totalPages) setCurrentPage(page);
-  };
+  const columns = useMemo(() => createVolunteerTableColumns(t), [t]);
 
   return (
-    <Wrapper data-testid="volunteers-table">
-      <TableContainer>
-        <Table>
-          <TableHeader>
-            <TableHeaderCell>{t("dashboard.volunteers.table.name")}</TableHeaderCell>
-            <TableHeaderCell $width="180px">{t("dashboard.volunteers.table.type")}</TableHeaderCell>
-            <TableHeaderCell $width="200px">{t("dashboard.volunteers.table.engagementStatus")}</TableHeaderCell>
-            <TableHeaderCell $width="140px">{t("dashboard.volunteers.table.matchingStatus")}</TableHeaderCell>
-            <TableHeaderCell $width="180px">{t("dashboard.volunteers.table.language")}</TableHeaderCell>
-            <TableHeaderCell $width="200px">{t("dashboard.volunteers.table.district")}</TableHeaderCell>
-            <TableHeaderCell>{t("dashboard.volunteers.table.email")}</TableHeaderCell>
-          </TableHeader>
-          <TableBody>
-            {volunteers.map((volunteer, index) => (
-              <VolunteerTableRow
-                key={volunteer.id}
-                volunteer={volunteer}
-                isLast={index === volunteers.length - 1}
-                engagementLabels={engagementLabels}
-                typeLabels={typeLabels}
-                opportunityId={opportunityId}
-              />
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-      <PaginationNumbers currentPage={currentPage} goToPage={goToPage} totalPages={totalPages} />
-    </Wrapper>
+    <EntityTableList
+      columns={columns}
+      data={volunteers}
+      renderRow={(volunteer, isLast) => (
+        <VolunteerTableRow
+          key={volunteer.id}
+          volunteer={volunteer}
+          isLast={isLast}
+          engagementLabels={engagementLabels}
+          typeLabels={typeLabels}
+          opportunityId={opportunityId}
+        />
+      )}
+      count={count}
+      itemsPerPage={itemsPerPage}
+      currentPage={currentPage}
+      setCurrentPage={setCurrentPage}
+      testIdPrefix="volunteers"
+    />
   );
 }
-
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: var(--opportunities-container-gap);
-  width: 100%;
-`;

--- a/src/components/Dashboard/Volunteers/VolunteerTableRow.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerTableRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ApiVolunteerGetList } from "need4deed-sdk";
+import type { ApiVolunteerGetList } from "need4deed-sdk";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";

--- a/src/components/Dashboard/Volunteers/VolunteerTableRow.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerTableRow.tsx
@@ -12,6 +12,7 @@ import { TableCell, TableRow } from "@/components/core/common/Table";
 import { CirclePic } from "@/components/styled/img";
 import { defaultAvatarURL } from "@/config/constants";
 import { getImageUrl } from "@/utils";
+import { VOLUNTEER_COL_WIDTHS } from "./volunteerTableColumns";
 
 interface TableRowProps {
   volunteer: ApiVolunteerGetList;
@@ -50,19 +51,19 @@ export function VolunteerTableRow({ volunteer, isLast, engagementLabels, typeLab
         <CirclePic src={getImageUrl(avatarUrl || defaultAvatarURL)} size="32px" />
         <NameText>{name}</NameText>
       </NameCell>
-      <TableCell $width="180px" data-testid={`volunteer-type-${id}`}>
+      <TableCell $width={VOLUNTEER_COL_WIDTHS.type} data-testid={`volunteer-type-${id}`}>
         {statusType ? typeLabels[statusType] : "—"}
       </TableCell>
-      <TableCell $width="200px" data-testid={`volunteer-engagement-${id}`}>
+      <TableCell $width={VOLUNTEER_COL_WIDTHS.engagement} data-testid={`volunteer-engagement-${id}`}>
         {statusEngagement ? engagementLabels[statusEngagement] : "—"}
       </TableCell>
-      <TableCell $width="140px" data-testid={`volunteer-match-${id}`}>
+      <TableCell $width={VOLUNTEER_COL_WIDTHS.matching} data-testid={`volunteer-match-${id}`}>
         —
       </TableCell>
-      <TableCell $width="180px" data-testid={`volunteer-language-${id}`}>
+      <TableCell $width={VOLUNTEER_COL_WIDTHS.language} data-testid={`volunteer-language-${id}`}>
         {languageText}
       </TableCell>
-      <TableCell $width="200px" data-testid={`volunteer-district-${id}`}>
+      <TableCell $width={VOLUNTEER_COL_WIDTHS.district} data-testid={`volunteer-district-${id}`}>
         {districtText}
       </TableCell>
       <TableCell data-testid={`volunteer-email-${id}`}>—</TableCell>

--- a/src/components/Dashboard/Volunteers/Volunteers.tsx
+++ b/src/components/Dashboard/Volunteers/Volunteers.tsx
@@ -21,6 +21,7 @@ import {
   serializeFilters,
 } from "./helpers";
 import { VolunteerListController } from "./VolunteerListController";
+import { ViewMode } from "../common/types";
 
 export function Volunteers() {
   const { t } = useTranslation();
@@ -34,7 +35,7 @@ export function Volunteers() {
   const pathname = usePathname();
   const router = useRouter();
   const tabs = [t("dashboard.volunteers.tabs.tab1"), t("dashboard.volunteers.tabs.tab2")];
-
+  const viewMode: ViewMode = selectedTabIndex === 0 ? "list" : "cards";
   const opportunityId = searchParams.get("opportunity") ?? undefined;
   const opportunityFilter = useGetOpportunity(opportunityId);
 
@@ -110,7 +111,7 @@ export function Volunteers() {
             filter={cardsFilter}
             apiFilterOptions={apiFilterOptions}
             opportunityId={opportunityId}
-            selectedTabIndex={selectedTabIndex}
+            viewMode={viewMode}
           />
           <Filters
             isFiltersOpen={isFiltersOpen}

--- a/src/components/Dashboard/Volunteers/Volunteers.tsx
+++ b/src/components/Dashboard/Volunteers/Volunteers.tsx
@@ -35,7 +35,7 @@ export function Volunteers() {
   const pathname = usePathname();
   const router = useRouter();
   const tabs = [t("dashboard.volunteers.tabs.tab1"), t("dashboard.volunteers.tabs.tab2")];
-  const viewMode: ViewMode = selectedTabIndex === 0 ? "list" : "cards";
+  const viewMode = Object.values(ViewMode)[selectedTabIndex];
   const opportunityId = searchParams.get("opportunity") ?? undefined;
   const opportunityFilter = useGetOpportunity(opportunityId);
 

--- a/src/components/Dashboard/Volunteers/volunteerTableColumns.ts
+++ b/src/components/Dashboard/Volunteers/volunteerTableColumns.ts
@@ -1,0 +1,12 @@
+import { TFunction } from "i18next";
+import { Column } from "../common/EntityTableList";
+
+export const createVolunteerTableColumns = (t: TFunction): Column[] => [
+  { key: "name", label: t("dashboard.volunteers.table.name") },
+  { key: "type", label: t("dashboard.volunteers.table.type"), width: "180px" },
+  { key: "engagement", label: t("dashboard.volunteers.table.engagementStatus"), width: "200px" },
+  { key: "matching", label: t("dashboard.volunteers.table.matchingStatus"), width: "140px" },
+  { key: "language", label: t("dashboard.volunteers.table.language"), width: "180px" },
+  { key: "district", label: t("dashboard.volunteers.table.district"), width: "200px" },
+  { key: "email", label: t("dashboard.volunteers.table.email") },
+];

--- a/src/components/Dashboard/Volunteers/volunteerTableColumns.ts
+++ b/src/components/Dashboard/Volunteers/volunteerTableColumns.ts
@@ -1,12 +1,24 @@
 import { TFunction } from "i18next";
 import { Column } from "../common/EntityTableList";
 
+export const VOLUNTEER_COL_WIDTHS = {
+  type: "180px",
+  engagement: "200px",
+  matching: "140px",
+  language: "180px",
+  district: "200px",
+};
+
 export const createVolunteerTableColumns = (t: TFunction): Column[] => [
   { key: "name", label: t("dashboard.volunteers.table.name") },
-  { key: "type", label: t("dashboard.volunteers.table.type"), width: "180px" },
-  { key: "engagement", label: t("dashboard.volunteers.table.engagementStatus"), width: "200px" },
-  { key: "matching", label: t("dashboard.volunteers.table.matchingStatus"), width: "140px" },
-  { key: "language", label: t("dashboard.volunteers.table.language"), width: "180px" },
-  { key: "district", label: t("dashboard.volunteers.table.district"), width: "200px" },
+  { key: "type", label: t("dashboard.volunteers.table.type"), width: VOLUNTEER_COL_WIDTHS.type },
+  {
+    key: "engagement",
+    label: t("dashboard.volunteers.table.engagementStatus"),
+    width: VOLUNTEER_COL_WIDTHS.engagement,
+  },
+  { key: "matching", label: t("dashboard.volunteers.table.matchingStatus"), width: VOLUNTEER_COL_WIDTHS.matching },
+  { key: "language", label: t("dashboard.volunteers.table.language"), width: VOLUNTEER_COL_WIDTHS.language },
+  { key: "district", label: t("dashboard.volunteers.table.district"), width: VOLUNTEER_COL_WIDTHS.district },
   { key: "email", label: t("dashboard.volunteers.table.email") },
 ];

--- a/src/components/Dashboard/common/EntityTableList/EntityTableList.tsx
+++ b/src/components/Dashboard/common/EntityTableList/EntityTableList.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Table, TableBody, TableContainer, TableHeader, TableHeaderCell } from "@/components/core/common/Table";
+import { Wrapper } from "./styles";
+import { EntityTableListProps } from "./types";
+import PaginationNumbers from "@/components/core/paginatedGrid/PaginationNumbers";
+
+export function EntityTableList<T extends { id: string | number }>({
+  columns,
+  data,
+  renderRow,
+  count,
+  itemsPerPage,
+  currentPage,
+  setCurrentPage,
+  testIdPrefix,
+}: EntityTableListProps<T>) {
+  const totalPages = Math.ceil(count / itemsPerPage);
+  const goToPage = (page: number) => {
+    if (page > 0 && page <= totalPages) setCurrentPage(page);
+  };
+
+  return (
+    <Wrapper data-testid={`${testIdPrefix}-table`}>
+      <TableContainer>
+        <Table>
+          <TableHeader>
+            {columns.map((col) => (
+              <TableHeaderCell key={col.key} $width={col.width}>
+                {col.label}
+              </TableHeaderCell>
+            ))}
+          </TableHeader>
+          <TableBody>{data.map((item, index) => renderRow(item, index === data.length - 1))}</TableBody>
+        </Table>
+      </TableContainer>
+      <PaginationNumbers currentPage={currentPage} goToPage={goToPage} totalPages={totalPages} />
+    </Wrapper>
+  );
+}

--- a/src/components/Dashboard/common/EntityTableList/index.ts
+++ b/src/components/Dashboard/common/EntityTableList/index.ts
@@ -1,0 +1,2 @@
+export * from "./EntityTableList";
+export type { Column, EntityTableListProps } from "./types";

--- a/src/components/Dashboard/common/EntityTableList/styles.ts
+++ b/src/components/Dashboard/common/EntityTableList/styles.ts
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--opportunities-container-gap);
+  width: 100%;
+`;

--- a/src/components/Dashboard/common/EntityTableList/styles.ts
+++ b/src/components/Dashboard/common/EntityTableList/styles.ts
@@ -3,6 +3,6 @@ import styled from "styled-components";
 export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: var(--opportunities-container-gap);
+  gap: var(--entity-table-gap);
   width: 100%;
 `;

--- a/src/components/Dashboard/common/EntityTableList/types.ts
+++ b/src/components/Dashboard/common/EntityTableList/types.ts
@@ -1,0 +1,18 @@
+import { ReactNode } from "react";
+
+export interface Column {
+  key: string;
+  label: string;
+  width?: string;
+}
+
+export interface EntityTableListProps<T extends { id: string | number }> {
+  columns: Column[];
+  data: T[];
+  renderRow: (item: T, isLast: boolean) => ReactNode;
+  count: number;
+  itemsPerPage: number;
+  currentPage: number;
+  setCurrentPage: (page: number) => void;
+  testIdPrefix: string;
+}

--- a/src/components/Dashboard/common/types.ts
+++ b/src/components/Dashboard/common/types.ts
@@ -1,0 +1,1 @@
+export type ViewMode = "cards" | "list" | "map";

--- a/src/components/Dashboard/common/types.ts
+++ b/src/components/Dashboard/common/types.ts
@@ -1,1 +1,5 @@
-export type ViewMode = "cards" | "list" | "map";
+export enum ViewMode {
+  LIST = "list",
+  CARDS = "cards",
+  MAP = "map",
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,10 +2407,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@^0.0.81:
-  version "0.0.81"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.81.tgz#30ae25f87898567ed3afdf7da93db09dc5eb8aec"
-  integrity sha512-rrjFSEavw4oSVCiIKKNwGwyagoDU6E4FG61RShz2trgnoDas7rZ9q7IzpkdSkSHTMSHPFz3W1mn4J15WBKOGnQ==
+need4deed-sdk@^0.0.82:
+  version "0.0.82"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.82.tgz#a1e85c26bc496fffc1d9fbdf3bef0ab211919ff5"
+  integrity sha512-Wqt/p62QY3AAzkGWAvE7NG/0XQ/lC8rrXKTI2OHRT7NIsrENtT01EQ+lKXnnQQOUQT82COTR62KAe16PQ8FqpA==
 
 next@15.3.8:
   version "15.3.8"


### PR DESCRIPTION
## Description
Extracts a generic `EntityTableList<T>` component to `Dashboard/common/EntityTableList/` so opportunities (#477) and agents (#478) list views can reuse it instead of duplicating the table/header/pagination boilerplate

Also: 
- Replaces `selectedTabIndex` prop on `VolunteerListController` with `viewMode: ViewMode` ,  controller no longer knows about tab indices
- Adds `VOLUNTEER_COL_WIDTHS` as single source of truth for column widths

**Layout note:** With filters open the filter panel overflows off screen (table takes full width). Tried `flex: 1` on the container  so filters sit side by side but some columns get clipped and also tried an overlay approach  neither is clean. Figma has no spec for this state. What's the preferred behavior?

## Related Issues
Closes #526 Part of #441

## Changes
- Add `EntityTableList<T>` to `Dashboard/common/EntityTableList/`
- Add `ViewMode` type to `Dashboard/common/types.ts`
- Add `volunteerTableColumns.ts` with `createVolunteerTableColumns(t)` 
- Migrate `VolunteerTableList` to use `EntityTableList`
- Replace `selectedTabIndex` with `viewMode: ViewMode` on `VolunteerListController`

## Screenshots / Demos
If UI-related, add before/after or GIFs.

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

