### PR TITLE
✨ upgrade SDK to 0.0.83 and update AccompanyingDetails section

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "^0.0.81",
+    "need4deed-sdk": "^0.0.83",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1122,10 +1122,9 @@
         "refugeeLanguage": "Flüchtlingssprache",
         "appointmentLanguage": "Terminsprache",
         "appointmentLanguageOptions": {
-          "german": "Deutsch",
-          "english": "Englisch",
-          "englishGerman": "Englisch/Deutsch",
-          "noTranslation": "Keine Übersetzung erforderlich"
+          "deutsche": "Deutsch",
+          "englishOk": "Deutsch, Englisch",
+          "noTranslation": "Keine Übersetzung"
         },
         "cancel": "Abbrechen",
         "saveChanges": "Änderungen speichern",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1118,7 +1118,6 @@
         "appointmentTime": "Terminzeit",
         "refugeeNumber": "Geflüchtetennummer",
         "refugeeName": "Name des Geflüchteten",
-        "languageToTranslate": "Zu übersetzende Sprache",
         "refugeeLanguage": "Flüchtlingssprache",
         "appointmentLanguage": "Terminsprache",
         "appointmentLanguageOptions": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1121,10 +1121,9 @@
         "refugeeLanguage": "Refugee language",
         "appointmentLanguage": "Appointment language",
         "appointmentLanguageOptions": {
-          "german": "German",
-          "english": "English",
-          "englishGerman": "English/German",
-          "noTranslation": "No translation needed"
+          "deutsche": "German",
+          "englishOk": "German, English",
+          "noTranslation": "No translation"
         },
         "cancel": "Cancel",
         "saveChanges": "Save changes",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1117,7 +1117,6 @@
         "appointmentTime": "Appointment time",
         "refugeeNumber": "Refugee number",
         "refugeeName": "Refugee name",
-        "languageToTranslate": "Language to translate",
         "refugeeLanguage": "Refugee language",
         "appointmentLanguage": "Appointment language",
         "appointmentLanguageOptions": {

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetails.tsx
@@ -3,7 +3,7 @@ import { useApiLanguages } from "@/components/Dashboard/Profile/sections/Volunte
 import { useUpdateOpportunityAccompanyingDetails } from "@/hooks/useUpdateOpportunityAccompanyingDetails";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { de, enUS } from "date-fns/locale";
-import { ApiOpportunityGet, LangPurpose } from "need4deed-sdk";
+import { ApiOpportunityGet, TranslatedIntoType } from "need4deed-sdk";
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -12,7 +12,6 @@ import { localHhmmToUtc } from "@/utils";
 import { useEditingChangeNotifier } from "../shared/useEditingChangeNotifier";
 import { AccompanyingDetailsDisplay } from "./AccompanyingDetailsDisplay";
 import { AccompanyingDetailsEdit } from "./AccompanyingDetailsEdit";
-import { AppointmentLanguages } from "@/config/constants";
 import { getInitialFormValues, getMinAppointmentDate, isAccompanyingType } from "./helpers";
 import { AccompanyingDetailsFormData, accompanyingDetailsSchema } from "./accompanyingDetailsSchema";
 import { Container, NotAccompanyingMessage } from "./styles";
@@ -44,7 +43,7 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
     labelToKey[lang.title] = String(lang.id);
   });
 
-  const appointmentLanguageKeys = Object.values(AppointmentLanguages);
+  const appointmentLanguageKeys = Object.values(TranslatedIntoType);
   const appointmentLanguageKeyToLabel: Record<string, string> = {};
   const appointmentLanguageLabelToKey: Record<string, string> = {};
   appointmentLanguageKeys.forEach((key) => {
@@ -90,7 +89,7 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
           appointmentTime: values.appointmentTime ? localHhmmToUtc(values.appointmentTime) : undefined,
           refugeeNumber: values.refugeeNumber,
           refugeeName: values.refugeeName,
-          languagesToTranslate: values.languagesToTranslate ?? [],
+          refugeeLanguage: (values.languagesToTranslate ?? []).map((id) => ({ id })),
           appointmentLanguage: values.appointmentLanguage || undefined,
         },
       },
@@ -118,10 +117,8 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
     );
   }
 
-  // Refugee language = the language the refugee speaks (LangPurpose.RECIPIENT on the opportunity)
-  const languageLabel = (opportunity.languages ?? [])
-    .filter((lang) => lang.purpose === LangPurpose.RECIPIENT)
-    .map((lang) => lang.title)
+  const languageLabel = (opportunity.accompanyingDetails?.refugeeLanguage ?? [])
+    .map((lang) => keyToLabel[String(lang.id)] || String(lang.id))
     .join(", ");
 
   return (

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetails.tsx
@@ -89,7 +89,7 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
           appointmentTime: values.appointmentTime ? localHhmmToUtc(values.appointmentTime) : undefined,
           refugeeNumber: values.refugeeNumber,
           refugeeName: values.refugeeName,
-          refugeeLanguage: (values.languagesToTranslate ?? []).map((id) => ({ id })),
+          refugeeLanguage: (values.refugeeLanguage ?? []).map((id) => ({ id })),
           appointmentLanguage: values.appointmentLanguage || undefined,
         },
       },

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsEdit.tsx
@@ -158,13 +158,9 @@ export const AccompanyingDetailsEdit = ({
         />
 
         <Controller
-          name="languagesToTranslate"
+          name="refugeeLanguage"
           control={control}
-          render={({
-            field,
-          }: {
-            field: ControllerRenderProps<AccompanyingDetailsFormData, "languagesToTranslate">;
-          }) => (
+          render={({ field }: { field: ControllerRenderProps<AccompanyingDetailsFormData, "refugeeLanguage"> }) => (
             <EditableField
               mode="edit"
               type="checkbox-list"
@@ -175,7 +171,7 @@ export const AccompanyingDetailsEdit = ({
                 field.onChange(labels.map((label) => labelToKey[label] || label));
               }}
               options={languageOptions}
-              errorMessage={errors.languagesToTranslate?.message}
+              errorMessage={errors.refugeeLanguage?.message}
             />
           )}
         />

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/accompanyingDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/accompanyingDetailsSchema.ts
@@ -1,3 +1,4 @@
+import { TranslatedIntoType } from "need4deed-sdk";
 import { z } from "zod";
 
 const timeRegex = /^([01]?[0-9]|2[0-3]):[0-5][0-9]$/;
@@ -14,8 +15,8 @@ export const accompanyingDetailsSchema = z.object({
     }),
   refugeeNumber: z.string().optional(),
   refugeeName: z.string().optional(),
-  languagesToTranslate: z.array(z.string()).optional(),
-  appointmentLanguage: z.string().optional(),
+  refugeeLanguage: z.array(z.string()).optional(),
+  appointmentLanguage: z.nativeEnum(TranslatedIntoType).optional(),
 });
 
 export type AccompanyingDetailsFormData = z.infer<typeof accompanyingDetailsSchema>;

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
@@ -48,6 +48,6 @@ export const getInitialFormValues = (
   appointmentTime: details?.appointmentTime ? utcHhmmToLocal(parseTime(details.appointmentTime)) : "",
   refugeeNumber: details?.refugeeNumber || "",
   refugeeName: details?.refugeeName || "",
-  languagesToTranslate: details?.refugeeLanguage?.map((lang) => String(lang.id)) ?? [],
-  appointmentLanguage: details?.appointmentLanguage || "",
+  refugeeLanguage: details?.refugeeLanguage?.map((lang) => String(lang.id)) ?? [],
+  appointmentLanguage: details?.appointmentLanguage ?? undefined,
 });

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
@@ -48,7 +48,6 @@ export const getInitialFormValues = (
   appointmentTime: details?.appointmentTime ? utcHhmmToLocal(parseTime(details.appointmentTime)) : "",
   refugeeNumber: details?.refugeeNumber || "",
   refugeeName: details?.refugeeName || "",
-  languagesToTranslate: details?.languageToTranslate !== undefined ? [details.languageToTranslate.toString()] : [],
-  appointmentLanguage:
-    (details as ApiOpportunityAccompanyingDetails & { appointmentLanguage?: string })?.appointmentLanguage || "",
+  languagesToTranslate: details?.refugeeLanguage?.map((lang) => String(lang.id)) ?? [],
+  appointmentLanguage: details?.appointmentLanguage || "",
 });

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -75,10 +75,3 @@ export const MAX_DESCRIPTION_LENGTH = 500;
 export const PHONE_NUMBER_REGEX = /^\+[0-9\s]+$/;
 
 export const LOGGED_IN_COOKIE = "is_logged_in=true; path=/; max-age=6000; SameSite=Lax; Secure";
-
-export enum AppointmentLanguages {
-  GERMAN = "german",
-  ENGLISH = "english",
-  ENGLISH_GERMAN = "englishGerman",
-  NO_TRANSLATION = "noTranslation",
-}

--- a/src/hooks/useUpdateOpportunityAccompanyingDetails.ts
+++ b/src/hooks/useUpdateOpportunityAccompanyingDetails.ts
@@ -1,6 +1,6 @@
 import { apiPathOpportunity } from "@/config/constants";
 import { useMutationQuery } from "@/hooks";
-import { ApiOpportunityGet } from "need4deed-sdk";
+import { ApiOpportunityGet, TranslatedIntoType } from "need4deed-sdk";
 
 export type OpportunityAccompanyingDetailsUpdateData = {
   accompanyingDetails: {
@@ -12,7 +12,7 @@ export type OpportunityAccompanyingDetailsUpdateData = {
     refugeeNumber?: string;
     refugeeName?: string;
     refugeeLanguage?: { id: string | number }[];
-    appointmentLanguage?: string;
+    appointmentLanguage?: TranslatedIntoType;
   };
 };
 

--- a/src/hooks/useUpdateOpportunityAccompanyingDetails.ts
+++ b/src/hooks/useUpdateOpportunityAccompanyingDetails.ts
@@ -11,7 +11,7 @@ export type OpportunityAccompanyingDetailsUpdateData = {
     appointmentTime?: string;
     refugeeNumber?: string;
     refugeeName?: string;
-    languagesToTranslate?: string[];
+    refugeeLanguage?: { id: string | number }[];
     appointmentLanguage?: string;
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,10 +2407,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@^0.0.81:
-  version "0.0.81"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.81.tgz#30ae25f87898567ed3afdf7da93db09dc5eb8aec"
-  integrity sha512-rrjFSEavw4oSVCiIKKNwGwyagoDU6E4FG61RShz2trgnoDas7rZ9q7IzpkdSkSHTMSHPFz3W1mn4J15WBKOGnQ==
+need4deed-sdk@^0.0.83:
+  version "0.0.83"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.83.tgz#6940f34ae33ba96c58f6e21a3b8ade58d17e5440"
+  integrity sha512-DvLFddWLj017c8HmZ79FWE/0LUuu/k1/orJUnl3eX/1ZH6mubKKegnKaU0Bew6366z5QOeC/SelCQevWRfrDsg==
 
 next@15.3.8:
   version "15.3.8"


### PR DESCRIPTION
## Summary

- Bumps `need4deed-sdk` `^0.0.81` → `^0.0.83` from npmjs.org
- Updates the **Accompanying details** section on `/dashboard/opportunities/[id]` to align with the new `ApiOpportunityAccompanyingDetails` shape

## SDK changes reflected

| Before | After |
|---|---|
| `languageToTranslate?: number` | `refugeeLanguage?: OptionById[]` |
| `appointmentLanguage` (cast hack) | `appointmentLanguage?: TranslatedIntoType` (typed) |

## FE changes

- **`helpers.ts`** — `getInitialFormValues` reads `refugeeLanguage` IDs instead of the removed `languageToTranslate`; drops the `appointmentLanguage` cast
- **`AccompanyingDetails.tsx`** — uses SDK `TranslatedIntoType` for appointment language options; derives refugee language label from `accompanyingDetails.refugeeLanguage` (via `keyToLabel` map) instead of filtering `opportunity.languages` by `LangPurpose.RECIPIENT`; submit payload sends `refugeeLanguage: [{id}]`
- **`useUpdateOpportunityAccompanyingDetails.ts`** — patch type updated: `languagesToTranslate` → `refugeeLanguage`
- **`constants.ts`** — removed local `AppointmentLanguages` enum (now covered by SDK `TranslatedIntoType`)
- **`locales/en` + `locales/de`** — `appointmentLanguageOptions` keys updated to `deutsche` / `englishOk` / `noTranslation` with correct labels per both languages

## Test plan

- [ ] Open an accompanying opportunity and verify the Accompanying details section displays appointment language options: "German", "German, English", "No translation" (EN) / "Deutsch", "Deutsch, Englisch", "Keine Übersetzung" (DE)
- [ ] Edit and save — confirm `refugeeLanguage` and `appointmentLanguage` round-trip correctly
- [ ] Verify refugee language label resolves from `accompanyingDetails.refugeeLanguage`, not from opportunity languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)