### PR TITLE
✨ upgrade SDK to 0.0.85 and drop appointmentPostcode cast hack

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "^0.0.83",
+    "need4deed-sdk": "^0.0.85",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
@@ -42,8 +42,7 @@ export const getInitialFormValues = (
   details: ApiOpportunityAccompanyingDetails | undefined,
 ): AccompanyingDetailsFormData => ({
   appointmentAddress: details?.appointmentAddress || "",
-  appointmentPostcode:
-    (details as ApiOpportunityAccompanyingDetails & { appointmentPostcode?: string })?.appointmentPostcode || "",
+  appointmentPostcode: details?.appointmentPostcode || "",
   appointmentDate: parseDate(details?.appointmentDate),
   appointmentTime: details?.appointmentTime ? utcHhmmToLocal(parseTime(details.appointmentTime)) : "",
   refugeeNumber: details?.refugeeNumber || "",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,10 +2407,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@^0.0.83:
-  version "0.0.83"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.83.tgz#6940f34ae33ba96c58f6e21a3b8ade58d17e5440"
-  integrity sha512-DvLFddWLj017c8HmZ79FWE/0LUuu/k1/orJUnl3eX/1ZH6mubKKegnKaU0Bew6366z5QOeC/SelCQevWRfrDsg==
+need4deed-sdk@^0.0.85:
+  version "0.0.85"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.85.tgz#297b455e3e20fd2a8724cdea78d0d2db2edd0509"
+  integrity sha512-yIKwEGvaKb0JsIeeZKbPs7aceSYA7HhINTZuoa2cUmw6LUDr7lczGjmB63z4585mprEoLyz/dKBg+L9Yk/9x9A==
 
 next@15.3.8:
   version "15.3.8"


### PR DESCRIPTION
## Summary
- Bump `need4deed-sdk` `^0.0.83` → `^0.0.85`
- `ApiOpportunityAccompanyingDetails.appointmentPostcode` is now typed natively as `string` in the SDK, so the prior `(details as ApiOpportunityAccompanyingDetails & { appointmentPostcode?: string })` cast in `getInitialFormValues` is no longer needed
- Removes a runtime error where the API was briefly returning `appointmentPostcode` as an object while the frontend expected a string

## Test plan
- [ ] `yarn typecheck` passes
- [ ] `yarn lint` passes
- [ ] Open an opportunity profile with `volunteerType` ACCOMPANYING / REGULAR_ACCOMPANYING — Accompanying Details section renders without error
- [ ] Edit and save `appointmentPostcode`; reload and confirm the value persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)