### PR TITLE
fix: render appointmentDistrict next to postcode and drop from PATCH payload

### DIFF
--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetails.tsx
@@ -1,9 +1,9 @@
 "use client";
-import { useApiDistricts, useApiLanguages } from "@/components/Dashboard/Profile/sections/VolunteerProfile/hooks";
+import { useApiLanguages } from "@/components/Dashboard/Profile/sections/VolunteerProfile/hooks";
 import { useUpdateOpportunityAccompanyingDetails } from "@/hooks/useUpdateOpportunityAccompanyingDetails";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { de, enUS } from "date-fns/locale";
-import { ApiOpportunityGet, LangPurpose } from "need4deed-sdk";
+import { ApiOpportunityAccompanyingDetails, ApiOpportunityGet, Lang, LangPurpose, Option } from "need4deed-sdk";
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -31,7 +31,6 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
 
   useEditingChangeNotifier(isEditing, onEditingChange);
   const { data: apiLanguages } = useApiLanguages();
-  const { data: apiDistricts } = useApiDistricts();
   const showFullDetails = isAccompanyingType(opportunity.volunteerType);
   const minAppointmentDate = useMemo(() => getMinAppointmentDate(), []);
 
@@ -53,14 +52,6 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
     appointmentLanguageLabelToKey[label] = key;
   });
   const appointmentLanguageOptions = appointmentLanguageKeys.map((key) => appointmentLanguageKeyToLabel[key]);
-
-  const districtKeyToLabel: Record<string, string> = {};
-  const districtLabelToKey: Record<string, string> = {};
-  apiDistricts.forEach((district) => {
-    districtKeyToLabel[String(district.id)] = district.title;
-    districtLabelToKey[district.title] = String(district.id);
-  });
-  const districtOptions = apiDistricts.map((district) => district.title);
 
   const initialFormValues = getInitialFormValues(opportunity.accompanyingDetails);
 
@@ -94,7 +85,6 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
         accompanyingDetails: {
           appointmentAddress: values.appointmentAddress,
           appointmentPostcode: values.appointmentPostcode || undefined,
-          appointmentDistrict: values.appointmentDistrict || undefined,
           appointmentDate: values.appointmentDate ? values.appointmentDate.toISOString() : undefined,
           appointmentTime: values.appointmentTime || undefined,
           refugeeNumber: values.refugeeNumber,
@@ -132,8 +122,17 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
     .filter((lang) => lang.purpose === LangPurpose.RECIPIENT)
     .map((lang) => lang.title)
     .join(", ");
-  const districtLabel =
-    districtKeyToLabel[formValues.appointmentDistrict || ""] || formValues.appointmentDistrict || "";
+
+  // appointmentDistrict is server-calculated from postcode — read from API response, never from form state
+  const rawDetails = opportunity.accompanyingDetails as ApiOpportunityAccompanyingDetails & {
+    appointmentPostcode?: string;
+    appointmentDistrict?: Option;
+  };
+  const lang = i18n.language as Lang;
+  const districtTitle =
+    rawDetails?.appointmentDistrict?.title?.[lang] ?? rawDetails?.appointmentDistrict?.title?.de ?? "";
+  const postcode = rawDetails?.appointmentPostcode || "";
+  const postcodeDisplay = postcode && districtTitle ? `${postcode}, ${districtTitle}` : postcode;
 
   return (
     <FormProvider {...methods}>
@@ -147,16 +146,17 @@ export const AccompanyingDetails = forwardRef<EditableSectionRef, Props>(functio
             appointmentLanguageOptions={appointmentLanguageOptions}
             appointmentLanguageKeyToLabel={appointmentLanguageKeyToLabel}
             appointmentLanguageLabelToKey={appointmentLanguageLabelToKey}
-            districtOptions={districtOptions}
-            districtKeyToLabel={districtKeyToLabel}
-            districtLabelToKey={districtLabelToKey}
             onCancel={handleCancel}
             onSubmit={handleSubmit(onSubmit)}
             isPending={isPending}
             minAppointmentDate={minAppointmentDate}
           />
         ) : (
-          <AccompanyingDetailsDisplay values={formValues} languageLabel={languageLabel} districtLabel={districtLabel} />
+          <AccompanyingDetailsDisplay
+            values={formValues}
+            languageLabel={languageLabel}
+            postcodeDisplay={postcodeDisplay}
+          />
         )}
       </Container>
     </FormProvider>

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsDisplay.tsx
@@ -9,10 +9,10 @@ import { DateFieldRow, Details } from "./styles";
 type Props = {
   values: AccompanyingDetailsFormData;
   languageLabel: string;
-  districtLabel: string;
+  postcodeDisplay: string;
 };
 
-export const AccompanyingDetailsDisplay = ({ values, languageLabel, districtLabel }: Props) => {
+export const AccompanyingDetailsDisplay = ({ values, languageLabel, postcodeDisplay }: Props) => {
   const { t } = useTranslation();
 
   return (
@@ -29,17 +29,8 @@ export const AccompanyingDetailsDisplay = ({ values, languageLabel, districtLabe
         mode="display"
         type="text"
         label={t("dashboard.opportunityProfile.accompanyingDetails.appointmentPostcode")}
-        value={values.appointmentPostcode || ""}
+        value={postcodeDisplay}
         setValue={() => {}}
-      />
-
-      <EditableField
-        mode="display"
-        type="radio-list"
-        label={t("dashboard.opportunityProfile.accompanyingDetails.appointmentDistrict")}
-        value={districtLabel}
-        setValue={() => {}}
-        options={[]}
       />
 
       <DateFieldRow data-testid="appointment-date-field">

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsEdit.tsx
@@ -23,9 +23,6 @@ type Props = {
   appointmentLanguageOptions: string[];
   appointmentLanguageKeyToLabel: Record<string, string>;
   appointmentLanguageLabelToKey: Record<string, string>;
-  districtOptions: string[];
-  districtKeyToLabel: Record<string, string>;
-  districtLabelToKey: Record<string, string>;
   onCancel: () => void;
   onSubmit: () => void;
   isPending: boolean;
@@ -40,9 +37,6 @@ export const AccompanyingDetailsEdit = ({
   appointmentLanguageOptions,
   appointmentLanguageKeyToLabel,
   appointmentLanguageLabelToKey,
-  districtOptions,
-  districtKeyToLabel,
-  districtLabelToKey,
   onCancel,
   onSubmit,
   isPending,
@@ -83,25 +77,6 @@ export const AccompanyingDetailsEdit = ({
               value={field.value || ""}
               setValue={field.onChange}
               errorMessage={errors.appointmentPostcode?.message}
-            />
-          )}
-        />
-
-        <Controller
-          name="appointmentDistrict"
-          control={control}
-          render={({ field }: { field: ControllerRenderProps<AccompanyingDetailsFormData, "appointmentDistrict"> }) => (
-            <EditableField
-              mode="edit"
-              type="radio-list"
-              label={t("dashboard.opportunityProfile.accompanyingDetails.appointmentDistrict")}
-              value={districtKeyToLabel[field.value || ""] || field.value || ""}
-              setValue={(value) => {
-                const label = Array.isArray(value) ? value[0] : value;
-                field.onChange(districtLabelToKey[label] || label);
-              }}
-              options={districtOptions}
-              errorMessage={errors.appointmentDistrict?.message}
             />
           )}
         />

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/accompanyingDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/accompanyingDetailsSchema.ts
@@ -5,7 +5,6 @@ const timeRegex = /^([01]?[0-9]|2[0-3]):[0-5][0-9]$/;
 export const accompanyingDetailsSchema = z.object({
   appointmentAddress: z.string().optional(),
   appointmentPostcode: z.string().optional(),
-  appointmentDistrict: z.string().optional(),
   appointmentDate: z.date().nullable().optional(),
   appointmentTime: z
     .string()

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
@@ -37,8 +37,7 @@ export const parseTime = (time: Date | string | undefined): string => {
 
 // Converts a UTC HH:mm string from the API to the browser's local time for display only.
 // Do NOT use this for form state — it would cause the time to shift on every save.
-export const formatTimeForDisplay = (time: string | undefined): string =>
-  time ? utcHhmmToLocal(time) : "";
+export const formatTimeForDisplay = (time: string | undefined): string => (time ? utcHhmmToLocal(time) : "");
 
 export const getInitialFormValues = (
   details: ApiOpportunityAccompanyingDetails | undefined,
@@ -46,8 +45,6 @@ export const getInitialFormValues = (
   appointmentAddress: details?.appointmentAddress || "",
   appointmentPostcode:
     (details as ApiOpportunityAccompanyingDetails & { appointmentPostcode?: string })?.appointmentPostcode || "",
-  appointmentDistrict:
-    (details as ApiOpportunityAccompanyingDetails & { appointmentDistrict?: string })?.appointmentDistrict || "",
   appointmentDate: parseDate(details?.appointmentDate),
   appointmentTime: parseTime(details?.appointmentTime),
   refugeeNumber: details?.refugeeNumber || "",

--- a/src/hooks/useUpdateOpportunityAccompanyingDetails.ts
+++ b/src/hooks/useUpdateOpportunityAccompanyingDetails.ts
@@ -6,7 +6,6 @@ export type OpportunityAccompanyingDetailsUpdateData = {
   accompanyingDetails: {
     appointmentAddress?: string;
     appointmentPostcode?: string;
-    appointmentDistrict?: string;
     appointmentDate?: string;
     appointmentTime?: string;
     refugeeNumber?: string;


### PR DESCRIPTION
Closes #533

appointmentDistrict is server-calculated from appointmentPostcode and is read-only on the client. The frontend was incorrectly treating it as an editable string, including it in the form schema and PATCH payload, and failing to display it. This fix reads the localized district title directly from the API response and renders it inline with the postcode as a single row, removes the district field from the edit form, and drops it from the PATCH payload.

Changes:
- useUpdateOpportunityAccompanyingDetails: remove appointmentDistrict from payload type
- accompanyingDetailsSchema: remove appointmentDistrict field
- helpers: remove appointmentDistrict from getInitialFormValues
- AccompanyingDetailsEdit: remove district Controller and district-related props
- AccompanyingDetails: derive postcodeDisplay from opportunity.accompanyingDetails using localized Option title with de fallback; drop appointmentDistrict from onSubmit
- AccompanyingDetailsDisplay: merge postcode and district into one row; remove separate district row