### PR TITLE
fix: contact details fall back to legacy comment when contact entity is empty

### DIFF
--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
@@ -49,6 +49,20 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
         ? [raw as PreferredCommunicationType]
         : [];
 
+    const hasContactData = !!(opportunity.contact.name || opportunity.contact.phone || opportunity.contact.email);
+
+    if (!hasContactData) {
+      const sorted = [...opportunity.comments].sort(
+        (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+      );
+      for (const comment of sorted) {
+        const parts = comment.content.split("<|>");
+        if (parts.length >= 5) {
+          return { name: parts[1] ?? "", phone: parts[4] ?? "", email: parts[0] ?? "", waysToContact: [] };
+        }
+      }
+    }
+
     // Fields are listed explicitly to stay in sync with OpportunityContactDetailsFormData.
     // If the schema adds or removes fields, update this object accordingly.
     return {
@@ -57,7 +71,7 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
       email: opportunity.contact.email ?? "",
       waysToContact,
     };
-  }, [opportunity.contact]);
+  }, [opportunity.contact, opportunity.comments]);
 
   const methods = useForm<OpportunityContactDetailsFormData>({
     resolver: zodResolver(schema),


### PR DESCRIPTION
Closes https://github.com/need4deed-org/fe/issues/539

## Problem

Legacy opportunities store contact info as the first coordinator comment in `email<|>name<|>address<|>postal<|>phone` format (written by the legacy form submission route). The `opportunity.contact` entity is populated from the agent's representative person, which is often empty for these legacy opportunities — leaving the Contact details section blank while the real data sits in the first comment.

## Fix

In `OpportunityContactDetails`, when `opportunity.contact` has no name/phone/email, sort comments by timestamp and look for the first one that matches the `<|>` format. Parse `email`, `name`, and `phone` from it and use them as the form's initial values.

The fallback is display-only: saving still writes to the proper contact entity via `useUpdateOpportunityContact`, so once saved the data is in the right place.