### PR TITLE
fix(#548): derive volunteer match status from live opportunities

### DIFF
--- a/src/components/Dashboard/Profile/sections/ProfileHeader/volunteer/VolunteerHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/volunteer/VolunteerHeader.tsx
@@ -55,13 +55,7 @@ export const VolunteerHeader = ({ volunteer }: Props) => {
     enabled: !!volunteer.id,
   });
 
-  // While opportunities are loading, fall back to the stored value to avoid
-  // a flash of "No matches". Once loaded, derive from live opportunity statuses
-  // so the badge stays in sync without requiring the BE to update statusMatch.
-  const matchStatus =
-    opportunitiesData !== undefined
-      ? deriveMatchStatus(opportunitiesData)
-      : (volunteer.statusMatch ?? VolunteerStateMatchType.NO_MATCHES);
+  const matchStatus = deriveMatchStatus(opportunitiesData ?? []);
 
   const engagementLabelMap = createEngagementLabelMap(t);
   const matchLabelMap = createMatchLabelMap(t);

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/volunteer/VolunteerHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/volunteer/VolunteerHeader.tsx
@@ -55,7 +55,13 @@ export const VolunteerHeader = ({ volunteer }: Props) => {
     enabled: !!volunteer.id,
   });
 
-  const matchStatus = deriveMatchStatus(opportunitiesData ?? []);
+  // While opportunities are loading, fall back to the stored value to avoid
+  // a flash of "No matches". Once loaded, derive from live opportunity statuses
+  // so the badge stays in sync without requiring the BE to update statusMatch.
+  const matchStatus =
+    opportunitiesData !== undefined
+      ? deriveMatchStatus(opportunitiesData)
+      : (volunteer.statusMatch ?? VolunteerStateMatchType.NO_MATCHES);
 
   const engagementLabelMap = createEngagementLabelMap(t);
   const matchLabelMap = createMatchLabelMap(t);

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/volunteer/VolunteerHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/volunteer/VolunteerHeader.tsx
@@ -1,8 +1,15 @@
 "use client";
-import { defaultAvatarVolunteerProfile, EMPTY_PLACEHOLDER_VALUE } from "@/config/constants";
+import { apiPathVolunteer, cacheTTL, defaultAvatarVolunteerProfile, EMPTY_PLACEHOLDER_VALUE } from "@/config/constants";
+import { useGetQuery } from "@/hooks/useGetQuery";
 import { formatDateTime, getImageUrl } from "@/utils";
 import { CheckCircleIcon } from "@phosphor-icons/react";
-import { ApiVolunteerGet, VolunteerStateEngagementType } from "need4deed-sdk";
+import {
+  ApiOpportunityVolunteerGet,
+  ApiVolunteerGet,
+  OpportunityVolunteerStatusType,
+  VolunteerStateEngagementType,
+  VolunteerStateMatchType,
+} from "need4deed-sdk";
 import Image from "next/image";
 import { useTranslation } from "react-i18next";
 import {
@@ -18,6 +25,21 @@ import { ChangeEngagementStatusDialog } from "./ChangeEngagementStatusDialog";
 import { createEngagementLabelMap, createMatchLabelMap } from "./constants";
 import { useEngagementStatusDialog } from "./useEngagementStatusDialog";
 
+function deriveMatchStatus(opportunities: ApiOpportunityVolunteerGet[]): VolunteerStateMatchType {
+  if (!opportunities.length) return VolunteerStateMatchType.NO_MATCHES;
+  const statuses = opportunities.map((o) => o.status);
+  if (statuses.some((s) => s === OpportunityVolunteerStatusType.MATCHED || s === OpportunityVolunteerStatusType.ACTIVE)) {
+    return VolunteerStateMatchType.MATCHED;
+  }
+  if (statuses.some((s) => s === OpportunityVolunteerStatusType.PENDING)) {
+    return VolunteerStateMatchType.PENDING_MATCH;
+  }
+  if (statuses.some((s) => s === OpportunityVolunteerStatusType.PAST)) {
+    return VolunteerStateMatchType.PAST;
+  }
+  return VolunteerStateMatchType.NO_MATCHES;
+}
+
 type Props = {
   volunteer: ApiVolunteerGet;
 };
@@ -25,6 +47,15 @@ type Props = {
 export const VolunteerHeader = ({ volunteer }: Props) => {
   const { t } = useTranslation();
   const dialog = useEngagementStatusDialog(volunteer);
+
+  const { data: opportunitiesData } = useGetQuery<ApiOpportunityVolunteerGet[]>({
+    queryKey: ["volunteer-opportunities", String(volunteer.id)],
+    apiPath: `${apiPathVolunteer}/${volunteer.id}/opportunity-linked`,
+    staleTime: cacheTTL,
+    enabled: !!volunteer.id,
+  });
+
+  const matchStatus = deriveMatchStatus(opportunitiesData ?? []);
 
   const engagementLabelMap = createEngagementLabelMap(t);
   const matchLabelMap = createMatchLabelMap(t);
@@ -68,8 +99,8 @@ export const VolunteerHeader = ({ volunteer }: Props) => {
 
       <StatusRowField
         title={t("dashboard.volunteerProfile.volunteerHeader.matchStatus_title")}
-        status={volunteer.statusMatch}
-        label={volunteer.statusMatch ? matchLabelMap[volunteer.statusMatch] : undefined}
+        status={matchStatus}
+        label={matchLabelMap[matchStatus]}
       />
 
       <StatusRowField


### PR DESCRIPTION
## Summary

- `VolunteerHeader` was reading `volunteer.statusMatch` — a stored DB field that the BE never updates when opportunity-volunteer statuses change
- Now derives match status directly from the `["volunteer-opportunities", volunteerId]` React Query cache, which `VolunteerOpportunities` already keeps up-to-date
- No extra network request: React Query deduplicates the identical query key

**Derivation rules (highest priority wins):**
| Opportunity status | Displayed match status |
|---|---|
| Any `MATCHED` or `ACTIVE` | Matched |
| Any `PENDING` | Pending match |
| Only `PAST` | Past |
| None | No matches |

Closes https://github.com/need4deed-org/fe/issues/548

## Test plan
- [ ] Volunteer with no opportunities → header shows "No matches"
- [ ] Volunteer with a pending opportunity → header shows "Pending match"
- [ ] Volunteer with a matched opportunity → header shows "Matched"
- [ ] Mark a pending opportunity as Matched → header updates immediately
- [ ] Mark active back to past → header updates to "Past" if no other active/matched opps
- [ ] Volunteer profile still loads and engagement status row still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)