### PR TITLE
Add agents list view (#478)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "^0.0.85",
+    "need4deed-sdk": "^0.0.90",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -662,7 +662,7 @@
         "title": "Name",
         "type": "Typ",
         "volunteerSearch": "Freiwilligensuche",
-        "district": "Stadtviertel",
+        "district": "Bezirk",
         "activeVolunteers": "Aktive Freiwillige",
         "numberOfOpportunities": "Anzahl der Möglichkeiten",
         "email": "E-Mail"

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -658,6 +658,15 @@
     },
     "agents": {
       "agents": "RAC-Verzeichnis",
+      "table": {
+        "title": "Name",
+        "type": "Typ",
+        "volunteerSearch": "Freiwilligensuche",
+        "district": "Stadtviertel",
+        "activeVolunteers": "Aktive Freiwillige",
+        "numberOfOpportunities": "Anzahl der Möglichkeiten",
+        "email": "E-Mail"
+      },
       "tabs": {
         "tab1": "Liste",
         "tab2": "Karten",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -701,6 +701,15 @@
     },
     "agents": {
       "agents": "RAC Directory",
+      "table": {
+        "title": "Name",
+        "type": "Type",
+        "volunteerSearch": "Volunteer Search",
+        "district": "District",
+        "activeVolunteers": "Active Volunteers",
+        "numberOfOpportunities": "Number of Opportunities",
+        "email": "Email"
+      },
       "tabs": {
         "tab1": "List",
         "tab2": "Cards",

--- a/src/components/Dashboard/Agents/AgentCard.tsx
+++ b/src/components/Dashboard/Agents/AgentCard.tsx
@@ -14,7 +14,7 @@ import { TrustLevelDropdown } from "@/components/Dashboard/Profile/sections/Prof
 import { Heading4, Paragraph } from "@/components/styled/text";
 import { useUpdateAgentStatus } from "@/hooks";
 import { getNormalizedAgent } from "./helpers";
-import { createAgentTypeMap, createServiceTypeMap, createVolunteerSearchMap } from "./icon";
+import { createAgentTypeMap, createServiceTypeMap, createVolunteerSearchMap } from "./constants";
 import { StatusBadge } from "../common/StatusBadge";
 import { Card, CardDetailsInfo, CardHeader, CardHeaderInfo, DistrictContainer, DistrictDiv } from "./styles";
 

--- a/src/components/Dashboard/Agents/AgentCard.tsx
+++ b/src/components/Dashboard/Agents/AgentCard.tsx
@@ -2,7 +2,7 @@
 
 import { MapPinIcon } from "@phosphor-icons/react";
 import { AgentTrustLevel } from "@/components/Dashboard/Profile/types/agent";
-import { ApiAgentGetList } from "need4deed-sdk";
+import type { ApiAgentGetList, OptionItem } from "need4deed-sdk";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { IconDiv } from "@/components/styled/container";
@@ -20,13 +20,15 @@ import { Card, CardDetailsInfo, CardHeader, CardHeaderInfo, DistrictContainer, D
 
 interface Props {
   agent: ApiAgentGetList;
+  districtsList?: OptionItem[];
 }
 
-export const AgentCard = ({ agent }: Props) => {
+export const AgentCard = ({ agent, districtsList }: Props) => {
   const { t, i18n } = useTranslation();
   const router = useRouter();
 
   const { id, title, district, volunteerSearch, serviceType, type, trustLevel } = getNormalizedAgent(agent);
+  const districtTitle = district?.id ? (districtsList?.find((d) => d.id === district.id)?.title ?? null) : null;
 
   const { mutate: patchAgent } = useUpdateAgentStatus(agent.id);
 
@@ -82,7 +84,7 @@ export const AgentCard = ({ agent }: Props) => {
           <IconDiv size="var(--dashboard-agents-card-detail-icon-size)">
             <MapPinIcon weight="fill" />
           </IconDiv>
-          <Paragraph>{district?.title?.[i18n.language as "en" | "de"]}</Paragraph>
+          <Paragraph>{districtTitle}</Paragraph>
         </DistrictDiv>
       </DistrictContainer>
     </Card>

--- a/src/components/Dashboard/Agents/AgentCardList.tsx
+++ b/src/components/Dashboard/Agents/AgentCardList.tsx
@@ -1,4 +1,4 @@
-import { ApiAgentGetList } from "need4deed-sdk";
+import type { ApiAgentGetList, OptionItem } from "need4deed-sdk";
 import { PaginatedGrid } from "@/components/core/paginatedGrid";
 import { AgentCard } from "./AgentCard";
 import { AgentCardListContainer } from "./styles";
@@ -10,10 +10,11 @@ type Props = {
   rows: number;
   currentPage: number;
   setCurrentPage: (page: number) => void;
+  districtsList?: OptionItem[];
 };
 
-export function AgentCardList({ agents, count, columns, rows, currentPage, setCurrentPage }: Props) {
-  const items = agents.map((agent) => <AgentCard key={agent.id} agent={agent} />);
+export function AgentCardList({ agents, count, columns, rows, currentPage, setCurrentPage, districtsList }: Props) {
+  const items = agents.map((agent) => <AgentCard key={agent.id} agent={agent} districtsList={districtsList} />);
 
   return (
     <AgentCardListContainer data-testid="agent-card-list">

--- a/src/components/Dashboard/Agents/AgentListController.tsx
+++ b/src/components/Dashboard/Agents/AgentListController.tsx
@@ -1,4 +1,4 @@
-import { ApiAgentGetList, ApiOptionLists, SortOrder } from "need4deed-sdk";
+import { type ApiAgentGetList, type ApiOptionLists, SortOrder } from "need4deed-sdk";
 import { AgentCardList } from "./AgentCardList";
 import { useEffect } from "react";
 import { DashboardListLoading } from "@/components/Dashboard/common/DashboardListLoading";
@@ -7,6 +7,7 @@ import { apiPathAgent, cacheTTL, TABLE_LIMIT } from "@/config/constants";
 import { serializeAgentFilters } from "./helpers";
 import { AgentCardsFilter } from "./Filters/types";
 import { ViewMode } from "../common/types";
+import { AgentTableList } from "./AgentTableList";
 
 const CARD_COLUMNS = 3;
 const CARD_ROWS = 3;
@@ -63,7 +64,15 @@ export const AgentListController = ({
   if (isLoading) return <DashboardListLoading />;
 
   if (isListView) {
-    return <h1>List</h1>;
+    return (
+      <AgentTableList
+        agents={agents}
+        count={count}
+        itemsPerPage={limit}
+        currentPage={currentPage}
+        setCurrentPage={setCurrentPage}
+      />
+    );
   }
 
   return (

--- a/src/components/Dashboard/Agents/AgentListController.tsx
+++ b/src/components/Dashboard/Agents/AgentListController.tsx
@@ -67,6 +67,7 @@ export const AgentListController = ({
         itemsPerPage={limit}
         currentPage={currentPage}
         setCurrentPage={setCurrentPage}
+        districtsList={apiFilterOptions?.district}
       />
     );
   }
@@ -79,6 +80,7 @@ export const AgentListController = ({
       rows={CARD_ROWS + (isFiltersOpen ? 1 : 0)}
       currentPage={currentPage}
       setCurrentPage={setCurrentPage}
+      districtsList={apiFilterOptions?.district}
     />
   );
 };

--- a/src/components/Dashboard/Agents/AgentListController.tsx
+++ b/src/components/Dashboard/Agents/AgentListController.tsx
@@ -3,13 +3,14 @@ import { AgentCardList } from "./AgentCardList";
 import { useEffect } from "react";
 import { DashboardListLoading } from "@/components/Dashboard/common/DashboardListLoading";
 import { useGetQuery, usePageParam } from "@/hooks";
-import { apiPathAgent, cacheTTL } from "@/config/constants";
+import { apiPathAgent, cacheTTL, TABLE_LIMIT } from "@/config/constants";
 import { serializeAgentFilters } from "./helpers";
 import { AgentCardsFilter } from "./Filters/types";
+import { ViewMode } from "../common/types";
 
-const columns = 3;
-const rows = 3;
-const limit = columns * rows;
+const CARD_COLUMNS = 3;
+const CARD_ROWS = 3;
+const CARD_LIMIT = CARD_COLUMNS * CARD_ROWS;
 
 type Props = {
   setNumOfAgents: (num: number) => void;
@@ -18,10 +19,20 @@ type Props = {
   filter: AgentCardsFilter;
   apiFilterOptions?: ApiOptionLists;
   volunteerId?: string;
+  viewMode: ViewMode;
 };
 
-export const AgentListController = ({ setNumOfAgents, sortOrder, isFiltersOpen, filter, apiFilterOptions }: Props) => {
+export const AgentListController = ({
+  setNumOfAgents,
+  sortOrder,
+  isFiltersOpen,
+  filter,
+  apiFilterOptions,
+  viewMode,
+}: Props) => {
   const { currentPage, setCurrentPage } = usePageParam();
+  const isListView = viewMode === ViewMode.LIST;
+  const limit = isListView ? TABLE_LIMIT : CARD_LIMIT;
 
   const serializedFilter = new URLSearchParams(
     serializeAgentFilters(filter, undefined, false, {
@@ -51,12 +62,16 @@ export const AgentListController = ({ setNumOfAgents, sortOrder, isFiltersOpen, 
 
   if (isLoading) return <DashboardListLoading />;
 
+  if (isListView) {
+    return <h1>List</h1>;
+  }
+
   return (
     <AgentCardList
       agents={agents}
       count={count}
-      columns={columns - (isFiltersOpen ? 1 : 0)}
-      rows={rows + (isFiltersOpen ? 1 : 0)}
+      columns={CARD_COLUMNS - (isFiltersOpen ? 1 : 0)}
+      rows={CARD_ROWS + (isFiltersOpen ? 1 : 0)}
       currentPage={currentPage}
       setCurrentPage={setCurrentPage}
     />

--- a/src/components/Dashboard/Agents/AgentListController.tsx
+++ b/src/components/Dashboard/Agents/AgentListController.tsx
@@ -67,7 +67,7 @@ export const AgentListController = ({
         itemsPerPage={limit}
         currentPage={currentPage}
         setCurrentPage={setCurrentPage}
-        districtsList={apiFilterOptions?.district}
+        districtsList={apiFilterOptions?.district ?? undefined}
       />
     );
   }

--- a/src/components/Dashboard/Agents/AgentListController.tsx
+++ b/src/components/Dashboard/Agents/AgentListController.tsx
@@ -3,15 +3,11 @@ import { AgentCardList } from "./AgentCardList";
 import { useEffect } from "react";
 import { DashboardListLoading } from "@/components/Dashboard/common/DashboardListLoading";
 import { useGetQuery, usePageParam } from "@/hooks";
-import { apiPathAgent, cacheTTL, TABLE_LIMIT } from "@/config/constants";
+import { apiPathAgent, cacheTTL, CARD_COLUMNS, CARD_LIMIT, CARD_ROWS, TABLE_LIMIT } from "@/config/constants";
 import { serializeAgentFilters } from "./helpers";
 import { AgentCardsFilter } from "./Filters/types";
 import { ViewMode } from "../common/types";
 import { AgentTableList } from "./AgentTableList";
-
-const CARD_COLUMNS = 3;
-const CARD_ROWS = 3;
-const CARD_LIMIT = CARD_COLUMNS * CARD_ROWS;
 
 type Props = {
   setNumOfAgents: (num: number) => void;

--- a/src/components/Dashboard/Agents/AgentTableList.tsx
+++ b/src/components/Dashboard/Agents/AgentTableList.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { createAgentTableColumns } from "./agentsTableColumns";
 import { useMemo } from "react";
 import { AgentTableRow } from "./AgentTableRow";
-import { createAgentTypeMap, createVolunteerSearchMap } from "./icon";
+import { createAgentTypeMap, createVolunteerSearchMap } from "./constants";
 
 interface TableListProps {
   agents: ApiAgentGetList[];

--- a/src/components/Dashboard/Agents/AgentTableList.tsx
+++ b/src/components/Dashboard/Agents/AgentTableList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ApiAgentGetList } from "need4deed-sdk";
+import type { ApiAgentGetList, OptionItem } from "need4deed-sdk";
 import { EntityTableList } from "../common/EntityTableList";
 import { useTranslation } from "react-i18next";
 import { createAgentTableColumns } from "./agentsTableColumns";
@@ -14,9 +14,17 @@ interface TableListProps {
   itemsPerPage: number;
   currentPage: number;
   setCurrentPage: (page: number) => void;
+  districtsList?: OptionItem[];
 }
 
-export function AgentTableList({ agents, count, itemsPerPage, currentPage, setCurrentPage }: TableListProps) {
+export function AgentTableList({
+  agents,
+  count,
+  itemsPerPage,
+  currentPage,
+  setCurrentPage,
+  districtsList,
+}: TableListProps) {
   const { t } = useTranslation();
 
   const columns = useMemo(() => createAgentTableColumns(t), [t]);
@@ -34,6 +42,7 @@ export function AgentTableList({ agents, count, itemsPerPage, currentPage, setCu
           isLast={isLast}
           typeLabels={typeLabels}
           searchLabels={searchLabels}
+          districtsList={districtsList}
         />
       )}
       count={count}

--- a/src/components/Dashboard/Agents/AgentTableList.tsx
+++ b/src/components/Dashboard/Agents/AgentTableList.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type { ApiAgentGetList } from "need4deed-sdk";
+import { EntityTableList } from "../common/EntityTableList";
+import { useTranslation } from "react-i18next";
+import { createAgentTableColumns } from "./agentsTableColumns";
+import { useMemo } from "react";
+import { AgentTableRow } from "./AgentTableRow";
+import { createAgentTypeMap, createVolunteerSearchMap } from "./icon";
+
+interface TableListProps {
+  agents: ApiAgentGetList[];
+  count: number;
+  itemsPerPage: number;
+  currentPage: number;
+  setCurrentPage: (page: number) => void;
+}
+
+export function AgentTableList({ agents, count, itemsPerPage, currentPage, setCurrentPage }: TableListProps) {
+  const { t } = useTranslation();
+
+  const columns = useMemo(() => createAgentTableColumns(t), [t]);
+  const typeLabels = useMemo(() => createAgentTypeMap(t), [t]);
+  const searchLabels = useMemo(() => createVolunteerSearchMap(t), [t]);
+
+  return (
+    <EntityTableList
+      columns={columns}
+      data={agents}
+      renderRow={(agent, isLast) => (
+        <AgentTableRow
+          key={agent.id}
+          agent={agent}
+          isLast={isLast}
+          typeLabels={typeLabels}
+          searchLabels={searchLabels}
+        />
+      )}
+      count={count}
+      itemsPerPage={itemsPerPage}
+      currentPage={currentPage}
+      setCurrentPage={setCurrentPage}
+      testIdPrefix="agents"
+    />
+  );
+}

--- a/src/components/Dashboard/Agents/AgentTableRow.tsx
+++ b/src/components/Dashboard/Agents/AgentTableRow.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import type { ApiAgentGetList } from "need4deed-sdk";
+import { useRouter } from "next/navigation";
+import { useTranslation } from "react-i18next";
+import { AGENT_COL_WIDTHS } from "./agentsTableColumns";
+import { TableCell, TableRow } from "@/components/core/common/Table";
+import styled from "styled-components";
+
+interface TableRowProps {
+  agent: ApiAgentGetList;
+  isLast: boolean;
+  typeLabels: Record<string, string>;
+  searchLabels: Record<string, string>;
+}
+
+export function AgentTableRow({ agent, isLast, typeLabels, searchLabels }: TableRowProps) {
+  const { i18n } = useTranslation();
+  const router = useRouter();
+
+  const { id, title, type, volunteerSearch, district, activeVolunteers } = agent;
+
+  const handleGoToProfile = () => {
+    if (!id) return;
+    router.push(`/${i18n.language}/dashboard/agents/${id}`);
+  };
+
+  return (
+    <ClickableRow $isLast={isLast} onClick={handleGoToProfile} data-testid={`agent-row-${id}`}>
+      <TableCell $width={AGENT_COL_WIDTHS.title} data-testid={`agent-title-${id}`}>
+        {title}
+      </TableCell>
+      <TableCell $width={AGENT_COL_WIDTHS.type} data-testid={`agent-type-${id}`}>
+        {typeLabels[type] || type}
+      </TableCell>
+      <TableCell $width={AGENT_COL_WIDTHS.volunteerSearch} data-testid={`agent-search-${id}`}>
+        {searchLabels[volunteerSearch] || volunteerSearch}
+      </TableCell>
+      <TableCell $width={AGENT_COL_WIDTHS.district} data-testid={`agent-district-${id}`}>
+        {district?.title?.[i18n.language as "en" | "de"] || "—"}
+      </TableCell>
+      <TableCell $width={AGENT_COL_WIDTHS.activeVolunteers} data-testid={`agent-active-volunteers-${id}`}>
+        {activeVolunteers}
+      </TableCell>
+      <TableCell $width={AGENT_COL_WIDTHS.numOpportunities} data-testid={`agent-opportunities-${id}`}>
+        —
+      </TableCell>
+      <TableCell data-testid={`agent-email-${id}`}>—</TableCell>
+    </ClickableRow>
+  );
+}
+
+const ClickableRow = styled(TableRow)`
+  cursor: pointer;
+
+  &:hover {
+    background: var(--color-pink-50);
+  }
+`;

--- a/src/components/Dashboard/Agents/AgentTableRow.tsx
+++ b/src/components/Dashboard/Agents/AgentTableRow.tsx
@@ -47,7 +47,7 @@ export function AgentTableRow({ agent, isLast, typeLabels, searchLabels, distric
         {activeVolunteers}
       </TableCell>
       <TableCell $width={AGENT_COL_WIDTHS.numOpportunities} data-testid={`agent-opportunities-${id}`}>
-        0
+        {"—"}
       </TableCell>
       <WrapAnywhereCell data-testid={`agent-email-${id}`}>{email || "—"}</WrapAnywhereCell>
     </ClickableRow>

--- a/src/components/Dashboard/Agents/AgentTableRow.tsx
+++ b/src/components/Dashboard/Agents/AgentTableRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ApiAgentGetList } from "need4deed-sdk";
+import type { ApiAgentGetList, OptionItem } from "need4deed-sdk";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { AGENT_COL_WIDTHS } from "./agentsTableColumns";
@@ -12,13 +12,15 @@ interface TableRowProps {
   isLast: boolean;
   typeLabels: Record<string, string>;
   searchLabels: Record<string, string>;
+  districtsList?: OptionItem[];
 }
 
-export function AgentTableRow({ agent, isLast, typeLabels, searchLabels }: TableRowProps) {
+export function AgentTableRow({ agent, isLast, typeLabels, searchLabels, districtsList }: TableRowProps) {
   const { i18n } = useTranslation();
   const router = useRouter();
 
   const { id, title, type, volunteerSearch, district, activeVolunteers } = agent;
+  const districtTitle = district?.id ? (districtsList?.find((d) => d.id === district.id)?.title ?? null) : null;
 
   const handleGoToProfile = () => {
     if (!id) return;
@@ -37,7 +39,7 @@ export function AgentTableRow({ agent, isLast, typeLabels, searchLabels }: Table
         {searchLabels[volunteerSearch] || volunteerSearch}
       </TableCell>
       <TableCell $width={AGENT_COL_WIDTHS.district} data-testid={`agent-district-${id}`}>
-        {district?.title?.[i18n.language as "en" | "de"] || "—"}
+        {districtTitle || "—"}
       </TableCell>
       <TableCell $width={AGENT_COL_WIDTHS.activeVolunteers} data-testid={`agent-active-volunteers-${id}`}>
         {activeVolunteers}

--- a/src/components/Dashboard/Agents/AgentTableRow.tsx
+++ b/src/components/Dashboard/Agents/AgentTableRow.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { AGENT_COL_WIDTHS } from "./agentsTableColumns";
 import { TableCell, TableRow } from "@/components/core/common/Table";
 import styled from "styled-components";
+import { WrapAnywhereCell } from "../common/EntityTableList/styles";
 
 interface TableRowProps {
   agent: ApiAgentGetList;
@@ -19,7 +20,10 @@ export function AgentTableRow({ agent, isLast, typeLabels, searchLabels, distric
   const { i18n } = useTranslation();
   const router = useRouter();
 
-  const { id, title, type, volunteerSearch, district, activeVolunteers } = agent;
+  // TODO: remove cast once codebase migrates to need4deed-sdk@0.0.91+
+  const { id, title, type, volunteerSearch, district, activeVolunteers, email } = agent as ApiAgentGetList & {
+    email?: string;
+  };
   const districtTitle = district?.id ? (districtsList?.find((d) => d.id === district.id)?.title ?? null) : null;
 
   const handleGoToProfile = () => {
@@ -44,12 +48,12 @@ export function AgentTableRow({ agent, isLast, typeLabels, searchLabels, distric
       <TableCell $width={AGENT_COL_WIDTHS.activeVolunteers} data-testid={`agent-active-volunteers-${id}`}>
         {activeVolunteers}
       </TableCell>
-      <TableCell $width={AGENT_COL_WIDTHS.email} data-testid={`agent-email-${id}`}>
-        —
-      </TableCell>
       <TableCell $width={AGENT_COL_WIDTHS.numOpportunities} data-testid={`agent-opportunities-${id}`}>
-        —
+        0
       </TableCell>
+      <WrapAnywhereCell $width={AGENT_COL_WIDTHS.email} data-testid={`agent-email-${id}`}>
+        {email || "—"}
+      </WrapAnywhereCell>
     </ClickableRow>
   );
 }

--- a/src/components/Dashboard/Agents/AgentTableRow.tsx
+++ b/src/components/Dashboard/Agents/AgentTableRow.tsx
@@ -42,10 +42,12 @@ export function AgentTableRow({ agent, isLast, typeLabels, searchLabels }: Table
       <TableCell $width={AGENT_COL_WIDTHS.activeVolunteers} data-testid={`agent-active-volunteers-${id}`}>
         {activeVolunteers}
       </TableCell>
+      <TableCell $width={AGENT_COL_WIDTHS.email} data-testid={`agent-email-${id}`}>
+        —
+      </TableCell>
       <TableCell $width={AGENT_COL_WIDTHS.numOpportunities} data-testid={`agent-opportunities-${id}`}>
         —
       </TableCell>
-      <TableCell data-testid={`agent-email-${id}`}>—</TableCell>
     </ClickableRow>
   );
 }

--- a/src/components/Dashboard/Agents/AgentTableRow.tsx
+++ b/src/components/Dashboard/Agents/AgentTableRow.tsx
@@ -33,9 +33,7 @@ export function AgentTableRow({ agent, isLast, typeLabels, searchLabels, distric
 
   return (
     <ClickableRow $isLast={isLast} onClick={handleGoToProfile} data-testid={`agent-row-${id}`}>
-      <TableCell $width={AGENT_COL_WIDTHS.title} data-testid={`agent-title-${id}`}>
-        {title}
-      </TableCell>
+      <TableCell data-testid={`agent-title-${id}`}>{title}</TableCell>
       <TableCell $width={AGENT_COL_WIDTHS.type} data-testid={`agent-type-${id}`}>
         {typeLabels[type] || type}
       </TableCell>
@@ -51,9 +49,7 @@ export function AgentTableRow({ agent, isLast, typeLabels, searchLabels, distric
       <TableCell $width={AGENT_COL_WIDTHS.numOpportunities} data-testid={`agent-opportunities-${id}`}>
         0
       </TableCell>
-      <WrapAnywhereCell $width={AGENT_COL_WIDTHS.email} data-testid={`agent-email-${id}`}>
-        {email || "—"}
-      </WrapAnywhereCell>
+      <WrapAnywhereCell data-testid={`agent-email-${id}`}>{email || "—"}</WrapAnywhereCell>
     </ClickableRow>
   );
 }

--- a/src/components/Dashboard/Agents/Agents.tsx
+++ b/src/components/Dashboard/Agents/Agents.tsx
@@ -31,7 +31,8 @@ export const Agents = () => {
   const pathname = usePathname();
   const router = useRouter();
   const tabs = [t("dashboard.agents.tabs.tab1"), t("dashboard.agents.tabs.tab2"), t("dashboard.agents.tabs.tab3")];
-  const viewMode = Object.values(ViewMode)[selectedTabIndex];
+  const VIEW_MODE_BY_TAB = [ViewMode.LIST, ViewMode.CARDS, ViewMode.MAP] as const;
+  const viewMode = VIEW_MODE_BY_TAB[selectedTabIndex] ?? ViewMode.LIST;
 
   const handleSearchInputChange = (searchInput: string) => {
     handleFilterUpdate((prev) => ({ ...prev, search: searchInput }));

--- a/src/components/Dashboard/Agents/Agents.tsx
+++ b/src/components/Dashboard/Agents/Agents.tsx
@@ -17,6 +17,7 @@ import { createFilterFromOption, getClearFilter } from "../common/CardsFilter/he
 import { deserializeAgentFilters, serializeAgentFilters } from "./helpers";
 import Filters from "../common/CardsFilter/Filters";
 import FiltersContent from "./Filters/FiltersContent";
+import { ViewMode } from "../common/types";
 
 export const Agents = () => {
   const { t } = useTranslation();
@@ -30,6 +31,7 @@ export const Agents = () => {
   const pathname = usePathname();
   const router = useRouter();
   const tabs = [t("dashboard.agents.tabs.tab1"), t("dashboard.agents.tabs.tab2"), t("dashboard.agents.tabs.tab3")];
+  const viewMode = Object.values(ViewMode)[selectedTabIndex];
 
   const handleSearchInputChange = (searchInput: string) => {
     handleFilterUpdate((prev) => ({ ...prev, search: searchInput }));
@@ -91,6 +93,7 @@ export const Agents = () => {
             isFiltersOpen={isFiltersOpen}
             filter={cardsFilter}
             apiFilterOptions={apiFilterOptions}
+            viewMode={viewMode}
           />
           <Filters
             isFiltersOpen={isFiltersOpen}

--- a/src/components/Dashboard/Agents/agentsTableColumns.ts
+++ b/src/components/Dashboard/Agents/agentsTableColumns.ts
@@ -2,11 +2,11 @@ import { TFunction } from "i18next";
 import { Column } from "../common/EntityTableList";
 
 export const AGENT_COL_WIDTHS = {
-  title: "180px",
+  title: "200px",
   type: "180px",
   volunteerSearch: "200px",
   district: "200px",
-  activeVolunteers: "160px",
+  activeVolunteers: "140px",
   numOpportunities: "160px",
   email: "200px",
 };
@@ -25,10 +25,10 @@ export const createAgentTableColumns = (t: TFunction): Column[] => [
     label: t("dashboard.agents.table.activeVolunteers"),
     width: AGENT_COL_WIDTHS.activeVolunteers,
   },
-  { key: "email", label: t("dashboard.agents.table.email"), width: AGENT_COL_WIDTHS.email },
   {
     key: "numOpportunities",
     label: t("dashboard.agents.table.numberOfOpportunities"),
     width: AGENT_COL_WIDTHS.numOpportunities,
   },
+  { key: "email", label: t("dashboard.agents.table.email"), width: AGENT_COL_WIDTHS.email },
 ];

--- a/src/components/Dashboard/Agents/agentsTableColumns.ts
+++ b/src/components/Dashboard/Agents/agentsTableColumns.ts
@@ -1,0 +1,34 @@
+import { TFunction } from "i18next";
+import { Column } from "../common/EntityTableList";
+
+export const AGENT_COL_WIDTHS = {
+  title: "180px",
+  type: "180px",
+  volunteerSearch: "200px",
+  district: "200px",
+  activeVolunteers: "160px",
+  numOpportunities: "160px",
+  email: "200px",
+};
+
+export const createAgentTableColumns = (t: TFunction): Column[] => [
+  { key: "title", label: t("dashboard.agents.table.title"), width: AGENT_COL_WIDTHS.title },
+  { key: "type", label: t("dashboard.agents.table.type"), width: AGENT_COL_WIDTHS.type },
+  {
+    key: "volunteerSearch",
+    label: t("dashboard.agents.table.volunteerSearch"),
+    width: AGENT_COL_WIDTHS.volunteerSearch,
+  },
+  { key: "district", label: t("dashboard.agents.table.district"), width: AGENT_COL_WIDTHS.district },
+  {
+    key: "activeVolunteers",
+    label: t("dashboard.agents.table.activeVolunteers"),
+    width: AGENT_COL_WIDTHS.activeVolunteers,
+  },
+  {
+    key: "numOpportunities",
+    label: t("dashboard.agents.table.numberOfOpportunities"),
+    width: AGENT_COL_WIDTHS.numOpportunities,
+  },
+  { key: "email", label: t("dashboard.agents.table.email"), width: AGENT_COL_WIDTHS.email },
+];

--- a/src/components/Dashboard/Agents/agentsTableColumns.ts
+++ b/src/components/Dashboard/Agents/agentsTableColumns.ts
@@ -25,10 +25,10 @@ export const createAgentTableColumns = (t: TFunction): Column[] => [
     label: t("dashboard.agents.table.activeVolunteers"),
     width: AGENT_COL_WIDTHS.activeVolunteers,
   },
+  { key: "email", label: t("dashboard.agents.table.email"), width: AGENT_COL_WIDTHS.email },
   {
     key: "numOpportunities",
     label: t("dashboard.agents.table.numberOfOpportunities"),
     width: AGENT_COL_WIDTHS.numOpportunities,
   },
-  { key: "email", label: t("dashboard.agents.table.email"), width: AGENT_COL_WIDTHS.email },
 ];

--- a/src/components/Dashboard/Agents/agentsTableColumns.ts
+++ b/src/components/Dashboard/Agents/agentsTableColumns.ts
@@ -1,18 +1,18 @@
 import { TFunction } from "i18next";
 import { Column } from "../common/EntityTableList";
+import { COLUMN_WIDTH } from "../common/EntityTableList/columnWidths";
 
 export const AGENT_COL_WIDTHS = {
-  title: "200px",
-  type: "180px",
-  volunteerSearch: "200px",
-  district: "200px",
-  activeVolunteers: "140px",
-  numOpportunities: "160px",
-  email: "200px",
+  type: COLUMN_WIDTH.MD,
+  volunteerSearch: COLUMN_WIDTH.LG,
+  district: COLUMN_WIDTH.LG,
+  activeVolunteers: COLUMN_WIDTH.XS,
+  numOpportunities: COLUMN_WIDTH.SM,
+  email: COLUMN_WIDTH.LG,
 };
 
 export const createAgentTableColumns = (t: TFunction): Column[] => [
-  { key: "title", label: t("dashboard.agents.table.title"), width: AGENT_COL_WIDTHS.title },
+  { key: "title", label: t("dashboard.agents.table.title") },
   { key: "type", label: t("dashboard.agents.table.type"), width: AGENT_COL_WIDTHS.type },
   {
     key: "volunteerSearch",
@@ -30,5 +30,5 @@ export const createAgentTableColumns = (t: TFunction): Column[] => [
     label: t("dashboard.agents.table.numberOfOpportunities"),
     width: AGENT_COL_WIDTHS.numOpportunities,
   },
-  { key: "email", label: t("dashboard.agents.table.email"), width: AGENT_COL_WIDTHS.email },
+  { key: "email", label: t("dashboard.agents.table.email") },
 ];

--- a/src/components/Dashboard/Agents/constants.ts
+++ b/src/components/Dashboard/Agents/constants.ts
@@ -1,0 +1,34 @@
+import { AgentServiceType, AgentType, AgentVolunteerSearchType } from "need4deed-sdk";
+import { TFunction } from "i18next";
+
+export const createAgentTypeMap = (t: TFunction): Record<AgentType, string> => ({
+  [AgentType.AE]: t("dashboard.agents.filters.type.ae"),
+  [AgentType.ASOG]: t("dashboard.agents.filters.type.asog"),
+  [AgentType.COUNSELING_CENTER]: t("dashboard.agents.filters.type.counseling-center"),
+  [AgentType.GU1]: t("dashboard.agents.filters.type.gu1"),
+  [AgentType.GU2]: t("dashboard.agents.filters.type.gu2"),
+  [AgentType.GU2_PLUS]: t("dashboard.agents.filters.type.gu2+"),
+  [AgentType.GU3]: t("dashboard.agents.filters.type.gu3"),
+  [AgentType.MULTIPLE_SOCIAL_SUPPORT]: t("dashboard.agents.filters.type.multiple-social-support"),
+  [AgentType.NU]: t("dashboard.agents.filters.type.nu"),
+  [AgentType.TANDEM]: t("dashboard.agents.filters.type.tandem"),
+});
+
+export const createVolunteerSearchMap = (t: TFunction): Record<AgentVolunteerSearchType, string> => ({
+  [AgentVolunteerSearchType.SEARCHING]: t("dashboard.agentProfile.status.volunteerSearch.searching"),
+  [AgentVolunteerSearchType.NOT_NEEDED]: t("dashboard.agentProfile.status.volunteerSearch.notNeeded"),
+  [AgentVolunteerSearchType.VOLUNTEERS_FOUND]: t("dashboard.agentProfile.status.volunteerSearch.filled"),
+});
+
+export const createServiceTypeMap = (t: TFunction): Record<AgentServiceType, string> => ({
+  [AgentServiceType.CHILDCARE]: t("dashboard.agentProfile.status.serviceType.childcare"),
+  [AgentServiceType.CONSULTATION]: t("dashboard.agentProfile.status.serviceType.consultation"),
+  [AgentServiceType.JOB_COACHING]: t("dashboard.agentProfile.status.serviceType.jobCoaching"),
+  [AgentServiceType.REFUGEE_ACCOMMODATION]: t("dashboard.agentProfile.status.serviceType.refugeeAccommodation"),
+  [AgentServiceType.SPORT]: t("dashboard.agentProfile.status.serviceType.sport"),
+  [AgentServiceType.TANDEM]: t("dashboard.agentProfile.status.serviceType.tandem"),
+  [AgentServiceType.TUTORING]: t("dashboard.agentProfile.status.serviceType.tutoring"),
+  [AgentServiceType.VOLUNTARY_SUPPORT]: t("dashboard.agentProfile.status.serviceType.volunteerSupport"),
+  [AgentServiceType.WELFARE]: t("dashboard.agentProfile.status.serviceType.welfare"),
+  [AgentServiceType.YOUTH]: t("dashboard.agentProfile.status.serviceType.youth"),
+});

--- a/src/components/Dashboard/Agents/helpers.ts
+++ b/src/components/Dashboard/Agents/helpers.ts
@@ -31,7 +31,7 @@ export function getNormalizedAgent(agent: AgentListItem): Omit<
     district: agent.district,
     volunteerSearch: agent.volunteerSearch ?? AgentVolunteerSearchType.NOT_NEEDED,
     trustLevel: agent.trustLevel ? agent.trustLevel : AgentTrustType.UNKNOWN,
-    serviceType: agent.serviceType,
+    serviceType: agent.serviceType ?? undefined,
   };
 }
 

--- a/src/components/Dashboard/Agents/icon.tsx
+++ b/src/components/Dashboard/Agents/icon.tsx
@@ -1,8 +1,5 @@
 import { CalendarDotsIcon, MapPinIcon, ShootingStarIcon, HandPalmIcon } from "@phosphor-icons/react";
-import { AgentServiceType, AgentType, AgentVolunteerSearchType } from "need4deed-sdk";
 import { JSX } from "react";
-
-import { TFunction } from "i18next";
 
 export enum IconName {
   ShootingStar = "shootingStar",
@@ -21,35 +18,3 @@ export const iconNameMap: IconMap = {
   [IconName.MapPin]: <MapPinIcon />,
   [IconName.HandPalmIcon]: <HandPalmIcon />,
 };
-
-export const createAgentTypeMap = (t: TFunction): Record<AgentType, string> => ({
-  [AgentType.AE]: t("dashboard.agents.filters.type.ae"),
-  [AgentType.ASOG]: t("dashboard.agents.filters.type.asog"),
-  [AgentType.COUNSELING_CENTER]: t("dashboard.agents.filters.type.counseling-center"),
-  [AgentType.GU1]: t("dashboard.agents.filters.type.gu1"),
-  [AgentType.GU2]: t("dashboard.agents.filters.type.gu2"),
-  [AgentType.GU2_PLUS]: t("dashboard.agents.filters.type.gu2+"),
-  [AgentType.GU3]: t("dashboard.agents.filters.type.gu3"),
-  [AgentType.MULTIPLE_SOCIAL_SUPPORT]: t("dashboard.agents.filters.type.multiple-social-support"),
-  [AgentType.NU]: t("dashboard.agents.filters.type.nu"),
-  [AgentType.TANDEM]: t("dashboard.agents.filters.type.tandem"),
-});
-
-export const createVolunteerSearchMap = (t: TFunction): Record<AgentVolunteerSearchType, string> => ({
-  [AgentVolunteerSearchType.SEARCHING]: t("dashboard.agentProfile.status.volunteerSearch.searching"),
-  [AgentVolunteerSearchType.NOT_NEEDED]: t("dashboard.agentProfile.status.volunteerSearch.notNeeded"),
-  [AgentVolunteerSearchType.VOLUNTEERS_FOUND]: t("dashboard.agentProfile.status.volunteerSearch.filled"),
-});
-
-export const createServiceTypeMap = (t: TFunction): Record<AgentServiceType, string> => ({
-  [AgentServiceType.CHILDCARE]: t("dashboard.agentProfile.status.serviceType.childcare"),
-  [AgentServiceType.CONSULTATION]: t("dashboard.agentProfile.status.serviceType.consultation"),
-  [AgentServiceType.JOB_COACHING]: t("dashboard.agentProfile.status.serviceType.jobCoaching"),
-  [AgentServiceType.REFUGEE_ACCOMMODATION]: t("dashboard.agentProfile.status.serviceType.refugeeAccommodation"),
-  [AgentServiceType.SPORT]: t("dashboard.agentProfile.status.serviceType.sport"),
-  [AgentServiceType.TANDEM]: t("dashboard.agentProfile.status.serviceType.tandem"),
-  [AgentServiceType.TUTORING]: t("dashboard.agentProfile.status.serviceType.tutoring"),
-  [AgentServiceType.VOLUNTARY_SUPPORT]: t("dashboard.agentProfile.status.serviceType.volunteerSupport"),
-  [AgentServiceType.WELFARE]: t("dashboard.agentProfile.status.serviceType.welfare"),
-  [AgentServiceType.YOUTH]: t("dashboard.agentProfile.status.serviceType.youth"),
-});

--- a/src/components/Dashboard/Opportunities/OpportunityListController.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityListController.tsx
@@ -1,15 +1,11 @@
 import { useEffect } from "react";
 import { DashboardListLoading } from "@/components/Dashboard/common/DashboardListLoading";
-import { apiPathOpportunity, cacheTTL } from "@/config/constants";
+import { apiPathOpportunity, cacheTTL, CARD_COLUMNS, CARD_LIMIT, CARD_ROWS } from "@/config/constants";
 import { useGetQuery, usePageParam } from "@/hooks";
 import { ApiVolunteerOpportunityGetList, ApiOptionLists, SortOrder } from "need4deed-sdk";
 import { OpportunityCardsFilter } from "./Filters/types";
 import { serializeOpportunityFilters } from "./helpers";
 import { OpportunityCardList } from "./OpportunityCardList";
-
-const columns = 3;
-const rows = 3;
-const limit = columns * rows;
 
 const APPOINTMENT_SORT_VALUES = ["appointment-proximal", "appointment-distant"] as const;
 type AppointmentSort = (typeof APPOINTMENT_SORT_VALUES)[number];
@@ -69,7 +65,7 @@ export function OpportunityListController({
     queryKey: ["opportunities"],
     apiPath: `${apiPathOpportunity}/`,
     params: {
-      limit,
+      limit: CARD_LIMIT,
       page: currentPage,
       sortOrder: backendSortOrder,
       filter: serializedFilter,
@@ -94,8 +90,8 @@ export function OpportunityListController({
       districtsList={apiFilterOptions?.district}
       opportunities={opportunities}
       count={count}
-      columns={columns - (isFiltersOpen ? 1 : 0)}
-      rows={rows + (isFiltersOpen ? 1 : 0)}
+      columns={CARD_COLUMNS - (isFiltersOpen ? 1 : 0)}
+      rows={CARD_ROWS + (isFiltersOpen ? 1 : 0)}
       currentPage={currentPage}
       setCurrentPage={setCurrentPage}
       volunteerId={volunteerId}

--- a/src/components/Dashboard/Volunteers/VolunteerListController.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerListController.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 
 import { DashboardListLoading } from "@/components/Dashboard/common/DashboardListLoading";
-import { apiPathVolunteer, cacheTTL, TABLE_LIMIT } from "@/config/constants";
+import { apiPathVolunteer, cacheTTL, CARD_COLUMNS, CARD_LIMIT, CARD_ROWS, TABLE_LIMIT } from "@/config/constants";
 import { useGetQuery, usePageParam } from "@/hooks";
 import { ApiOptionLists, ApiVolunteerGetList, SortOrder } from "need4deed-sdk";
 import { CardsFilter } from "./Filters/types";
@@ -9,10 +9,6 @@ import { serializeFilters } from "./helpers";
 import { VolunteerCardList } from "./VolunteerCardList";
 import { VolunteerTableList } from "./VolunteerTableList";
 import { ViewMode } from "../common/types";
-
-const CARD_COLUMNS = 3;
-const CARD_ROWS = 3;
-const CARD_LIMIT = CARD_COLUMNS * CARD_ROWS;
 
 interface VolunteerListControllerProps {
   setNumOfVols: (numOfVols: number) => void;

--- a/src/components/Dashboard/Volunteers/volunteerTableColumns.ts
+++ b/src/components/Dashboard/Volunteers/volunteerTableColumns.ts
@@ -1,12 +1,13 @@
 import { TFunction } from "i18next";
 import { Column } from "../common/EntityTableList";
+import { COLUMN_WIDTH } from "../common/EntityTableList/columnWidths";
 
 export const VOLUNTEER_COL_WIDTHS = {
-  type: "180px",
-  engagement: "200px",
-  matching: "140px",
-  language: "180px",
-  district: "200px",
+  type: COLUMN_WIDTH.MD,
+  engagement: COLUMN_WIDTH.LG,
+  matching: COLUMN_WIDTH.SM,
+  language: COLUMN_WIDTH.MD,
+  district: COLUMN_WIDTH.LG,
 };
 
 export const createVolunteerTableColumns = (t: TFunction): Column[] => [

--- a/src/components/Dashboard/common/EntityTableList/columnWidths.ts
+++ b/src/components/Dashboard/common/EntityTableList/columnWidths.ts
@@ -1,0 +1,6 @@
+export const COLUMN_WIDTH = {
+  XS: "140px",
+  SM: "160px",
+  MD: "180px",
+  LG: "200px",
+} as const;

--- a/src/components/Dashboard/common/EntityTableList/styles.ts
+++ b/src/components/Dashboard/common/EntityTableList/styles.ts
@@ -1,3 +1,4 @@
+import { TableCell } from "@/components/core/common/Table/styles";
 import styled from "styled-components";
 
 export const Wrapper = styled.div`
@@ -5,4 +6,8 @@ export const Wrapper = styled.div`
   flex-direction: column;
   gap: var(--entity-table-gap);
   width: 100%;
+`;
+
+export const WrapAnywhereCell = styled(TableCell)`
+  overflow-wrap: anywhere;
 `;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -20,7 +20,6 @@ export const apiPathPerson = `/${apiPrefix}/person/`;
 export const apiPathOrganization = `/${apiPrefix}/organization/`;
 export const cloudfrontDataURL = process.env.NEXT_PUBLIC_CLOUDFRONT_DATA_URL;
 export const cacheTTL = 1000 * 60 * 5; // 5 minutes
-export const TABLE_LIMIT = 20;
 
 export enum ScreenTypes {
   MOBILE = "mobile",
@@ -75,3 +74,8 @@ export const MAX_DESCRIPTION_LENGTH = 500;
 export const PHONE_NUMBER_REGEX = /^\+[0-9\s]+$/;
 
 export const LOGGED_IN_COOKIE = "is_logged_in=true; path=/; max-age=6000; SameSite=Lax; Secure";
+
+export const TABLE_LIMIT = 20;
+export const CARD_COLUMNS = 3;
+export const CARD_ROWS = 3;
+export const CARD_LIMIT = CARD_COLUMNS * CARD_ROWS;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,10 +2407,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@^0.0.85:
-  version "0.0.85"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.85.tgz#297b455e3e20fd2a8724cdea78d0d2db2edd0509"
-  integrity sha512-yIKwEGvaKb0JsIeeZKbPs7aceSYA7HhINTZuoa2cUmw6LUDr7lczGjmB63z4585mprEoLyz/dKBg+L9Yk/9x9A==
+need4deed-sdk@^0.0.90:
+  version "0.0.90"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.90.tgz#e65e465dacba77732427c8f62f829bc19f3b60f9"
+  integrity sha512-wIz9mN+g6uhfSEZlzX/3i0tuzSTvPtslrrhnoJ/2fcqTwWfcodLY+MW7lm9GyzWXBbh46VxoFV76FKaZk9AZfQ==
 
 next@15.3.8:
   version "15.3.8"


### PR DESCRIPTION
## Description
 Adds the list-view (table) variant for the agents dashboard.

## Related Issues
Closes #478 

## Changes

- New `AgentTableList` and `AgentTableRow` wired into `AgentListController` via `viewMode`
- 7 agent table columns (title, type, volunteerSearch, district, activeVolunteers, numberOfOpportunities, email) with EN and DE translations.
- District lookup via `districtsList` (table and  card paths)  fixes empty district render
- Email rendering with temporary cast workaround (see SDK note below)
- New shared `COLUMN_WIDTH` constants (`XS`/`SM`/`MD`/`LG`), both agent and volunteer tables migrated
- New shared `WrapAnywhereCell` for long unbreakable text (used by agent email column)
- Card constant globals consolidation: `CARD_COLUMNS`/`CARD_ROWS` moved to `src/config/constants.ts` (touches Agent, Volunteer and Opportunity controllers)
- `createAgentTypeMap` moved out of `icon.tsx` into `Agents/constants.ts` 
- DE translation fix: `dashboard.agents.*` now uses **Bezirk**

 ## SDK 0.0.91 note (relevant to email column)
 Tried to bump to `need4deed-sdk@0.0.91` to pick up the typed `email` field on `ApiAgentGetList`. 
0.0.91 introduced `Voidable<T>` (= `T | null | undefined`) on many fields where they were previously `T | undefined`, which broke 10 typecheck errors across 6 unrelated files. I stayed on `0.0.90` for this PR and used a cast workaround for `email` (with a TODO comment explaining when to remove).

- `numberOfOpportunities` column currently renders `0,` but currently the BE is not sending the number of opportunities; we have `activeVolunteers and numActiveVolunteers`  (which appear to be the same value, possibly duplicate metrics).

## Screenshots / Demos
<img width="1332" height="618" alt="Screenshot from 2026-05-24 12-14-24" src="https://github.com/user-attachments/assets/96c0d741-bd28-4b86-b00a-b67a3fdade6b" />

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

