### PR TITLE
🐛 fix(#558): align opportunity card status/matchStatus i18n keys with API values

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -753,15 +753,16 @@
         "opp-new": "Neu",
         "opp-searching": "Suche läuft",
         "opp-active": "Aktiv",
+        "opp-inactive": "Inaktiv",
         "opp-past": "Vergangen"
       },
       "matchStatus": {
-        "vol-no-matches": "Keine Zuweisungen",
-        "vol-pending-match": "Zuordnung ausstehend",
-        "vol-matched": "Zugeordnet",
-        "vol-needs-rematch": "Erneute Zuordnung erforderlich",
-        "vol-unmatched": "Nicht zugeordnet",
-        "vol-past": "Vergangen"
+        "opp-vol-no-matches": "Keine Zuweisungen",
+        "opp-vol-pending-match": "Zuordnung ausstehend",
+        "opp-vol-matched": "Zugeordnet",
+        "opp-vol-needs-rematch": "Erneute Zuordnung erforderlich",
+        "opp-vol-unmatched": "Nicht zugeordnet",
+        "opp-vol-past": "Vergangen"
       },
       "type": {
         "accompanying": "Begleitung",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -796,15 +796,16 @@
         "opp-new": "New",
         "opp-searching": "Searching",
         "opp-active": "Active",
+        "opp-inactive": "Inactive",
         "opp-past": "Past"
       },
       "matchStatus": {
-        "vol-no-matches": "No matches",
-        "vol-pending-match": "Pending match",
-        "vol-matched": "Matched",
-        "vol-needs-rematch": "Needs rematch",
-        "vol-unmatched": "Unmatched",
-        "vol-past": "Past"
+        "opp-vol-no-matches": "No matches",
+        "opp-vol-pending-match": "Pending match",
+        "opp-vol-matched": "Matched",
+        "opp-vol-needs-rematch": "Needs rematch",
+        "opp-vol-unmatched": "Unmatched",
+        "opp-vol-past": "Past"
       },
       "type": {
         "accompanying": "Accompanying",

--- a/src/components/Dashboard/Opportunities/OpportunityCard.helpers.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityCard.helpers.tsx
@@ -54,23 +54,22 @@ export const statusIconMap: Record<OpportunityStatusType, JSX.Element> = {
   [OpportunityStatusType.PAST]: <ShootingStarIcon size={18} color={statusColorMap[OpportunityStatusType.PAST]} />,
 };
 
-// TODO: replace string with OpportunityMatchStatusType once SDK PR #89 is merged
 export const matchStatusColorMap: Record<string, string> = {
-  "vol-no-matches": "var(--color-grey-700)",
-  "vol-pending-match": "var(--color-orange-500)",
-  "vol-matched": "var(--color-green-700)",
-  "vol-needs-rematch": "var(--color-red-50)",
-  "vol-unmatched": "var(--color-grey-700)",
-  "vol-past": "var(--color-grey-700)",
+  "opp-vol-no-matches": "var(--color-grey-700)",
+  "opp-vol-pending-match": "var(--color-orange-500)",
+  "opp-vol-matched": "var(--color-green-700)",
+  "opp-vol-needs-rematch": "var(--color-red-50)",
+  "opp-vol-unmatched": "var(--color-grey-700)",
+  "opp-vol-past": "var(--color-grey-700)",
 };
 
 export const matchStatusIconMap: Record<string, JSX.Element> = {
-  "vol-no-matches": <ProhibitInsetIcon size={18} color={matchStatusColorMap["vol-no-matches"]} />,
-  "vol-pending-match": <HourglassIcon size={18} color={matchStatusColorMap["vol-pending-match"]} />,
-  "vol-matched": <CheckCircleIcon size={18} color={matchStatusColorMap["vol-matched"]} />,
-  "vol-needs-rematch": <ArrowsClockwiseIcon size={18} color={matchStatusColorMap["vol-needs-rematch"]} />,
-  "vol-unmatched": <ProhibitInsetIcon size={18} color={matchStatusColorMap["vol-unmatched"]} />,
-  "vol-past": <StopCircleIcon size={18} color={matchStatusColorMap["vol-past"]} />,
+  "opp-vol-no-matches": <ProhibitInsetIcon size={18} color={matchStatusColorMap["opp-vol-no-matches"]} />,
+  "opp-vol-pending-match": <HourglassIcon size={18} color={matchStatusColorMap["opp-vol-pending-match"]} />,
+  "opp-vol-matched": <CheckCircleIcon size={18} color={matchStatusColorMap["opp-vol-matched"]} />,
+  "opp-vol-needs-rematch": <ArrowsClockwiseIcon size={18} color={matchStatusColorMap["opp-vol-needs-rematch"]} />,
+  "opp-vol-unmatched": <ProhibitInsetIcon size={18} color={matchStatusColorMap["opp-vol-unmatched"]} />,
+  "opp-vol-past": <StopCircleIcon size={18} color={matchStatusColorMap["opp-vol-past"]} />,
 };
 
 export const volunteerTypeIconMap: Record<ProfileVolunteeringType, JSX.Element> = {

--- a/src/components/Dashboard/Opportunities/OpportunityCard.helpers.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityCard.helpers.tsx
@@ -10,7 +10,7 @@ import {
   TranslateIcon,
 } from "@phosphor-icons/react";
 import { format } from "date-fns";
-import { ApiVolunteerOpportunityGetList, OpportunityStatusType, ProfileVolunteeringType } from "need4deed-sdk";
+import { ApiVolunteerOpportunityGetList, OpportunityMatchStatusType, OpportunityStatusType, ProfileVolunteeringType } from "need4deed-sdk";
 import { utcHhmmToLocal } from "@/utils";
 import { JSX } from "react";
 
@@ -54,7 +54,7 @@ export const statusIconMap: Record<OpportunityStatusType, JSX.Element> = {
   [OpportunityStatusType.PAST]: <ShootingStarIcon size={18} color={statusColorMap[OpportunityStatusType.PAST]} />,
 };
 
-export const matchStatusColorMap: Record<string, string> = {
+export const matchStatusColorMap: Record<OpportunityMatchStatusType, string> = {
   "opp-vol-no-matches": "var(--color-grey-700)",
   "opp-vol-pending-match": "var(--color-orange-500)",
   "opp-vol-matched": "var(--color-green-700)",
@@ -63,7 +63,7 @@ export const matchStatusColorMap: Record<string, string> = {
   "opp-vol-past": "var(--color-grey-700)",
 };
 
-export const matchStatusIconMap: Record<string, JSX.Element> = {
+export const matchStatusIconMap: Record<OpportunityMatchStatusType, JSX.Element> = {
   "opp-vol-no-matches": <ProhibitInsetIcon size={18} color={matchStatusColorMap["opp-vol-no-matches"]} />,
   "opp-vol-pending-match": <HourglassIcon size={18} color={matchStatusColorMap["opp-vol-pending-match"]} />,
   "opp-vol-matched": <CheckCircleIcon size={18} color={matchStatusColorMap["opp-vol-matched"]} />,


### PR DESCRIPTION
Fixes https://github.com/need4deed-org/fe/issues/558

## What

The opportunity cards in the dashboard list view were showing raw i18n keys instead of translated labels (e.g. `dashboard.opportunities.matchStatus.opp-vol-no-matches`).

## Why

Two mismatches between what the API returns and what the translations/maps expected:

1. **`matchStatus` key prefix** — The API returns `OpportunityMatchStatusType` values like `opp-vol-no-matches`, but translation keys and the `matchStatusColorMap`/`matchStatusIconMap` in `OpportunityCard.helpers.tsx` were keyed as `vol-no-matches` (missing `opp-` prefix). So `t(`dashboard.opportunities.matchStatus.opp-vol-no-matches`)` always fell back to the raw key.

2. **Missing `opp-inactive`** — `OpportunityStatusType.INACTIVE = "opp-inactive"` had no translation entry in either locale, so inactive opportunities showed the raw key.

## Changes

- `public/locales/de/translations.json` — rename `matchStatus` keys `vol-*` → `opp-vol-*`, add `opp-inactive`
- `public/locales/en/translations.json` — same
- `OpportunityCard.helpers.tsx` — rename `matchStatusColorMap`/`matchStatusIconMap` keys `vol-*` → `opp-vol-*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)