### PR TITLE
✨ Bump SDK to 0.0.95 to unlock new typed fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "^0.0.85",
+    "need4deed-sdk": "0.0.95",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "0.0.95",
+    "need4deed-sdk": "^0.0.95",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/src/components/Dashboard/Agents/helpers.ts
+++ b/src/components/Dashboard/Agents/helpers.ts
@@ -28,10 +28,10 @@ export function getNormalizedAgent(agent: AgentListItem): Omit<
   return {
     ...agent,
     type: agent.type,
-    district: agent.district,
+    district: agent.district ?? undefined,
     volunteerSearch: agent.volunteerSearch ?? AgentVolunteerSearchType.NOT_NEEDED,
     trustLevel: agent.trustLevel ? agent.trustLevel : AgentTrustType.UNKNOWN,
-    serviceType: agent.serviceType,
+    serviceType: agent.serviceType ?? undefined,
   };
 }
 

--- a/src/components/Dashboard/Home/NewestOpportunities.tsx
+++ b/src/components/Dashboard/Home/NewestOpportunities.tsx
@@ -19,14 +19,20 @@ export function NewestOpportunities() {
     },
     staleTime: cacheTTL,
   });
-  const activitiesList = apiFilterOptions?.activity;
-  const districtsList = apiFilterOptions?.district;
+  const activitiesList = apiFilterOptions?.activity ?? undefined;
+  const districtsList = apiFilterOptions?.district ?? undefined;
 
   if (isLoading) {
     return <Heading4>{t("dashboard.home.content.loading")}</Heading4>;
   }
 
   return opportunities?.map((opp) => (
-    <OpportunityCard key={opp.id} opportunity={opp} volunteerId={undefined} activitiesList={activitiesList} districtsList={districtsList} />
+    <OpportunityCard
+      key={opp.id}
+      opportunity={opp}
+      volunteerId={undefined}
+      activitiesList={activitiesList}
+      districtsList={districtsList}
+    />
   ));
 }

--- a/src/components/Dashboard/Opportunities/OpportunityListController.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityListController.tsx
@@ -90,8 +90,8 @@ export function OpportunityListController({
 
   return (
     <OpportunityCardList
-      activitiesList={apiFilterOptions?.activity}
-      districtsList={apiFilterOptions?.district}
+      activitiesList={apiFilterOptions?.activity ?? undefined}
+      districtsList={apiFilterOptions?.district ?? undefined}
       opportunities={opportunities}
       count={count}
       columns={columns - (isFiltersOpen ? 1 : 0)}

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
@@ -23,7 +23,7 @@ export const getMinAppointmentDate = (): Date => {
   return date;
 };
 
-export const parseDate = (date: Date | string | undefined): Date | null => {
+export const parseDate = (date: Date | string | undefined | null): Date | null => {
   if (!date) return null;
   const parsed = date instanceof Date ? date : new Date(date);
   return isNaN(parsed.getTime()) ? null : parsed;

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
@@ -35,6 +35,7 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
 
   const initialFormValues = {
     ...details,
+    website: details?.website || "",
     operator: details?.operator || agent.operator || "",
     clientLanguages: apiLanguagesToFormValues(details?.clientLanguages),
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,7 +2407,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.95:
+need4deed-sdk@^0.0.95:
   version "0.0.95"
   resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.95.tgz#5ec9da926e280ca625b91500e849fe8ce85af38e"
   integrity sha512-/Nefb2VgH/2FOYIuqti23DL2AraQsMWpCOTDH+2myAV3aDgmJsRp+DWNecA0o6nsp40MvuEF2JJVmz+I6opjkA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,10 +2407,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@^0.0.85:
-  version "0.0.85"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.85.tgz#297b455e3e20fd2a8724cdea78d0d2db2edd0509"
-  integrity sha512-yIKwEGvaKb0JsIeeZKbPs7aceSYA7HhINTZuoa2cUmw6LUDr7lczGjmB63z4585mprEoLyz/dKBg+L9Yk/9x9A==
+need4deed-sdk@0.0.95:
+  version "0.0.95"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.95.tgz#5ec9da926e280ca625b91500e849fe8ce85af38e"
+  integrity sha512-/Nefb2VgH/2FOYIuqti23DL2AraQsMWpCOTDH+2myAV3aDgmJsRp+DWNecA0o6nsp40MvuEF2JJVmz+I6opjkA==
 
 next@15.3.8:
   version "15.3.8"


### PR DESCRIPTION
 ## Description
  Bumps `need4deed-sdk` from ^0.0.85 to 0.0.95 to unlock new typed fields the team needs for ongoing work.
- email, statusMatch on volunteer list
- statusMatch, agentTitle, and numberOfVolunteers on the opportunity list

## Related Issues
Closes #560 

## Changes
 - Bump `need4deed-sdk` ^0.0.85 to 0.0.95
 - `Agents/helpers.ts`,  coerce null to undefined inside `getNormalizedAgent`
 - `Home/NewestOpportunities.tsx`, `Opportunities/OpportunityListController.tsx`  coerce filter lookup nulls at call site (`?? undefined`)
 - `AccompanyingDetails/helpers.ts`, widen `parseDate` signature to accept null 
 - `OrganisationDetails.tsx`  coerce voidable `website` to `""` in `initialFormValues`

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

