### PR TITLE
✨ feat(#444): agent self-registration wizard

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1810,5 +1810,63 @@
     "urdu": "Urdu",
     "vietnamese": "Vietnamesisch",
     "other": "Andere"
+  },
+  "agentRegistration": {
+    "title": "Ihre Organisation registrieren",
+    "subtitle": "Erstellen Sie ein Konto, um sich mit Ehrenamtlichen in Berlin zu vernetzen.",
+    "step": "Schritt",
+    "next": "Weiter",
+    "back": "Zurück",
+    "submit": "Konto erstellen",
+    "optional": "optional",
+    "steps": {
+      "account": {
+        "title": "Ihr Konto",
+        "description": "Geben Sie Ihre persönlichen Daten ein, um ein Login zu erstellen."
+      },
+      "orgInfo": {
+        "title": "Ihre Organisation",
+        "description": "Erzählen Sie uns von Ihrer Unterkunft."
+      },
+      "address": {
+        "title": "Standort",
+        "description": "Wo befindet sich Ihre Einrichtung?"
+      },
+      "services": {
+        "title": "Leistungen & Sprachen",
+        "description": "Welche Leistungen bieten Sie an und welche Sprachen sprechen die Bewohnenden?"
+      },
+      "review": {
+        "title": "Überprüfung",
+        "description": "Bitte überprüfen Sie Ihre Angaben vor dem Absenden."
+      }
+    },
+    "fields": {
+      "firstName": "Vorname",
+      "lastName": "Nachname",
+      "email": "E-Mail-Adresse",
+      "password": "Passwort",
+      "confirmPassword": "Passwort bestätigen",
+      "organizationName": "Name der Organisation",
+      "organizationType": "Art der Organisation",
+      "selectOrganizationType": "Typ auswählen…",
+      "about": "Über Ihre Einrichtung",
+      "aboutPlaceholder": "Beschreiben Sie kurz Ihre Einrichtung und die angebotene Unterstützung.",
+      "website": "Website",
+      "addressStreet": "Straße und Hausnummer",
+      "addressPostcode": "Postleitzahl",
+      "district": "Bezirk",
+      "selectDistrict": "Bezirk auswählen…",
+      "services": "Angebotene Leistungen",
+      "clientLanguages": "Von Bewohnenden gesprochene Sprachen"
+    },
+    "errors": {
+      "passwordTooShort": "Das Passwort muss mindestens 8 Zeichen lang sein",
+      "passwordMismatch": "Die Passwörter stimmen nicht überein"
+    },
+    "success": {
+      "title": "Registrierung erfolgreich!",
+      "description": "Ihr Konto wurde erstellt. Sie werden in Kürze zur Anmeldeseite weitergeleitet."
+    }
   }
 }

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1442,5 +1442,63 @@
     "urdu": "Urdu",
     "vietnamese": "Vietnamese",
     "other": "Other"
+  },
+  "agentRegistration": {
+    "title": "Register your organisation",
+    "subtitle": "Create an account to connect with volunteers in Berlin.",
+    "step": "Step",
+    "next": "Next",
+    "back": "Back",
+    "submit": "Create account",
+    "optional": "optional",
+    "steps": {
+      "account": {
+        "title": "Your account",
+        "description": "Enter your personal details to create a login."
+      },
+      "orgInfo": {
+        "title": "Your organisation",
+        "description": "Tell us about your accommodation centre."
+      },
+      "address": {
+        "title": "Location",
+        "description": "Where is your centre located?"
+      },
+      "services": {
+        "title": "Services & languages",
+        "description": "What services do you offer and which languages do residents speak?"
+      },
+      "review": {
+        "title": "Review",
+        "description": "Please check your details before submitting."
+      }
+    },
+    "fields": {
+      "firstName": "First name",
+      "lastName": "Last name",
+      "email": "Email address",
+      "password": "Password",
+      "confirmPassword": "Confirm password",
+      "organizationName": "Organisation name",
+      "organizationType": "Organisation type",
+      "selectOrganizationType": "Select type…",
+      "about": "About your centre",
+      "aboutPlaceholder": "Briefly describe your centre and the support you offer.",
+      "website": "Website",
+      "addressStreet": "Street address",
+      "addressPostcode": "Postcode",
+      "district": "District",
+      "selectDistrict": "Select district…",
+      "services": "Services provided",
+      "clientLanguages": "Languages spoken by residents"
+    },
+    "errors": {
+      "passwordTooShort": "Password must be at least 8 characters",
+      "passwordMismatch": "Passwords do not match"
+    },
+    "success": {
+      "title": "Registration successful!",
+      "description": "Your account has been created. You will be redirected to the login page shortly."
+    }
   }
 }

--- a/src/app/[lang]/register/agent/page.tsx
+++ b/src/app/[lang]/register/agent/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { AgentRegistration } from "@/components/AgentRegistration";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
+
+export default function AgentRegistrationPage() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AgentRegistration />
+    </QueryClientProvider>
+  );
+}

--- a/src/components/AgentRegistration/AgentRegistration.tsx
+++ b/src/components/AgentRegistration/AgentRegistration.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Button } from "@/components/core/button";
-import { apiPathAgent, apiPathLogin, apiPathOption, LOGGED_IN_COOKIE } from "@/config/constants";
+import { apiPathAgent, apiPathLogin, apiPathOption, apiPathUser, LOGGED_IN_COOKIE } from "@/config/constants";
 import { useGetQuery } from "@/hooks";
 import axios from "axios";
 import i18next from "i18next";
@@ -8,116 +8,29 @@ import { ApiOptionLists, UserRole } from "need4deed-sdk";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import styled from "styled-components";
+import { validateStep } from "./helpers";
 import { ProgressBar } from "./ProgressBar";
 import { AccountStep } from "./steps/AccountStep";
 import { AddressStep } from "./steps/AddressStep";
 import { OrgInfoStep } from "./steps/OrgInfoStep";
 import { ReviewStep } from "./steps/ReviewStep";
 import { ServicesStep } from "./steps/ServicesStep";
+import {
+  Actions,
+  Card,
+  ErrorBanner,
+  PageSubtitle,
+  PageTitle,
+  SuccessText,
+  SuccessTitle,
+  SuccessWrapper,
+  Wrapper,
+} from "./styled";
 import { AgentRegistrationData, defaultAgentRegistrationData, TOTAL_STEPS } from "./types";
 
-// NOTE: The following BE changes are required before this flow is fully functional:
+// NOTE: Two BE changes are required before this flow is fully functional:
 // 1. POST /api/user must allow role: "agent" (currently only "user" | "admin" are permitted)
 // 2. POST /api/agent endpoint must be created (currently only GET/PATCH/DELETE exist)
-const API_PATH_USER = "/api/user";
-
-const Wrapper = styled.div`
-  min-height: 100vh;
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  padding: 48px 16px;
-  background: var(--layout-static-page-background-default, #f8f6f8);
-`;
-
-const Card = styled.div`
-  background: var(--color-white);
-  border-radius: 16px;
-  padding: 40px;
-  width: 100%;
-  max-width: 560px;
-  box-shadow: 0 2px 16px rgba(0, 0, 0, 0.08);
-`;
-
-const PageTitle = styled.h1`
-  font-size: 1.625rem;
-  font-weight: 700;
-  color: var(--color-midnight);
-  margin: 0 0 4px;
-`;
-
-const PageSubtitle = styled.p`
-  font-size: 0.9375rem;
-  color: var(--color-grey-500);
-  margin: 0 0 32px;
-`;
-
-const Actions = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 32px;
-  gap: 12px;
-`;
-
-const ErrorBanner = styled.div`
-  background: #fef2f2;
-  border: 1px solid #fecaca;
-  border-radius: 8px;
-  padding: 12px 16px;
-  margin-bottom: 20px;
-  font-size: 0.9375rem;
-  color: #dc2626;
-`;
-
-const SuccessWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 16px;
-  padding: 24px 0;
-  text-align: center;
-`;
-
-const SuccessTitle = styled.h2`
-  font-size: 1.375rem;
-  font-weight: 700;
-  color: var(--color-midnight);
-`;
-
-const SuccessText = styled.p`
-  font-size: 0.9375rem;
-  color: var(--color-grey-500);
-`;
-
-function validateStep(step: number, data: AgentRegistrationData, t: (k: string) => string) {
-  const errors: Partial<Record<keyof AgentRegistrationData, string>> = {};
-  const required = t("form.error.required");
-
-  if (step === 1) {
-    if (!data.firstName.trim()) errors.firstName = required;
-    if (!data.lastName.trim()) errors.lastName = required;
-    if (!data.email.trim()) errors.email = required;
-    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) errors.email = t("form.error.email");
-    if (!data.password) errors.password = required;
-    else if (data.password.length < 8) errors.password = t("agentRegistration.errors.passwordTooShort");
-    if (!data.confirmPassword) errors.confirmPassword = required;
-    else if (data.password !== data.confirmPassword) errors.confirmPassword = t("agentRegistration.errors.passwordMismatch");
-  }
-
-  if (step === 2) {
-    if (!data.organizationName.trim()) errors.organizationName = required;
-    if (!data.organizationType) errors.organizationType = required;
-  }
-
-  if (step === 3) {
-    if (!data.addressStreet.trim()) errors.addressStreet = required;
-    if (!data.addressPostcode.trim()) errors.addressPostcode = required;
-  }
-
-  return errors;
-}
 
 export function AgentRegistration() {
   const { t } = useTranslation();
@@ -147,15 +60,13 @@ export function AgentRegistration() {
   };
 
   const handleNext = () => {
-    if (step < TOTAL_STEPS) {
-      const stepErrors = validateStep(step, formData, t);
-      if (Object.keys(stepErrors).length > 0) {
-        setErrors(stepErrors);
-        return;
-      }
-      setErrors({});
-      setStep((s) => s + 1);
+    const stepErrors = validateStep(step, formData, t);
+    if (Object.keys(stepErrors).length > 0) {
+      setErrors(stepErrors);
+      return;
     }
+    setErrors({});
+    setStep((s) => s + 1);
   };
 
   const handleBack = () => {
@@ -168,9 +79,7 @@ export function AgentRegistration() {
     setIsSubmitting(true);
 
     try {
-      // Step 1: create user account with role "agent"
-      // BE requirement: POST /api/user must allow role: "agent"
-      await axios.post(API_PATH_USER, {
+      await axios.post(apiPathUser, {
         email: formData.email,
         password: formData.password,
         role: UserRole.AGENT,
@@ -180,15 +89,12 @@ export function AgentRegistration() {
         },
       });
 
-      // Step 2: auto-login to obtain session cookie
       await axios.post(apiPathLogin, {
         email: formData.email,
         password: formData.password,
       });
       document.cookie = LOGGED_IN_COOKIE;
 
-      // Step 3: create agent profile
-      // BE requirement: POST /api/agent endpoint must be implemented
       await axios.post(apiPathAgent, {
         title: formData.organizationName,
         type: formData.organizationType || undefined,
@@ -203,14 +109,13 @@ export function AgentRegistration() {
 
       setIsSuccess(true);
       setTimeout(() => {
-        const { language } = i18next;
-        router.push(`/${language}/dashboard`);
+        router.push(`/${i18next.language}/dashboard`);
       }, 3000);
     } catch (err) {
       let message = t("message.errorGeneric");
       if (axios.isAxiosError(err)) {
         const data = err.response?.data as { message?: string } | undefined;
-        message = data?.message || message;
+        message = data?.message ?? message;
       }
       setSubmitError(message);
     } finally {

--- a/src/components/AgentRegistration/AgentRegistration.tsx
+++ b/src/components/AgentRegistration/AgentRegistration.tsx
@@ -1,0 +1,286 @@
+"use client";
+import { Button } from "@/components/core/button";
+import { apiPathAgent, apiPathLogin, apiPathOption, LOGGED_IN_COOKIE } from "@/config/constants";
+import { useGetQuery } from "@/hooks";
+import axios from "axios";
+import i18next from "i18next";
+import { ApiOptionLists, UserRole } from "need4deed-sdk";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+import { ProgressBar } from "./ProgressBar";
+import { AccountStep } from "./steps/AccountStep";
+import { AddressStep } from "./steps/AddressStep";
+import { OrgInfoStep } from "./steps/OrgInfoStep";
+import { ReviewStep } from "./steps/ReviewStep";
+import { ServicesStep } from "./steps/ServicesStep";
+import { AgentRegistrationData, defaultAgentRegistrationData, TOTAL_STEPS } from "./types";
+
+// NOTE: The following BE changes are required before this flow is fully functional:
+// 1. POST /api/user must allow role: "agent" (currently only "user" | "admin" are permitted)
+// 2. POST /api/agent endpoint must be created (currently only GET/PATCH/DELETE exist)
+const API_PATH_USER = "/api/user";
+
+const Wrapper = styled.div`
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 48px 16px;
+  background: var(--layout-static-page-background-default, #f8f6f8);
+`;
+
+const Card = styled.div`
+  background: var(--color-white);
+  border-radius: 16px;
+  padding: 40px;
+  width: 100%;
+  max-width: 560px;
+  box-shadow: 0 2px 16px rgba(0, 0, 0, 0.08);
+`;
+
+const PageTitle = styled.h1`
+  font-size: 1.625rem;
+  font-weight: 700;
+  color: var(--color-midnight);
+  margin: 0 0 4px;
+`;
+
+const PageSubtitle = styled.p`
+  font-size: 0.9375rem;
+  color: var(--color-grey-500);
+  margin: 0 0 32px;
+`;
+
+const Actions = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 32px;
+  gap: 12px;
+`;
+
+const ErrorBanner = styled.div`
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin-bottom: 20px;
+  font-size: 0.9375rem;
+  color: #dc2626;
+`;
+
+const SuccessWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 24px 0;
+  text-align: center;
+`;
+
+const SuccessTitle = styled.h2`
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: var(--color-midnight);
+`;
+
+const SuccessText = styled.p`
+  font-size: 0.9375rem;
+  color: var(--color-grey-500);
+`;
+
+function validateStep(step: number, data: AgentRegistrationData, t: (k: string) => string) {
+  const errors: Partial<Record<keyof AgentRegistrationData, string>> = {};
+  const required = t("form.error.required");
+
+  if (step === 1) {
+    if (!data.firstName.trim()) errors.firstName = required;
+    if (!data.lastName.trim()) errors.lastName = required;
+    if (!data.email.trim()) errors.email = required;
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) errors.email = t("form.error.email");
+    if (!data.password) errors.password = required;
+    else if (data.password.length < 8) errors.password = t("agentRegistration.errors.passwordTooShort");
+    if (!data.confirmPassword) errors.confirmPassword = required;
+    else if (data.password !== data.confirmPassword) errors.confirmPassword = t("agentRegistration.errors.passwordMismatch");
+  }
+
+  if (step === 2) {
+    if (!data.organizationName.trim()) errors.organizationName = required;
+    if (!data.organizationType) errors.organizationType = required;
+  }
+
+  if (step === 3) {
+    if (!data.addressStreet.trim()) errors.addressStreet = required;
+    if (!data.addressPostcode.trim()) errors.addressPostcode = required;
+  }
+
+  return errors;
+}
+
+export function AgentRegistration() {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const [step, setStep] = useState(1);
+  const [formData, setFormData] = useState<AgentRegistrationData>(defaultAgentRegistrationData);
+  const [errors, setErrors] = useState<Partial<Record<keyof AgentRegistrationData, string>>>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  const { data: optionLists } = useGetQuery<ApiOptionLists>({
+    queryKey: ["options"],
+    apiPath: apiPathOption,
+  });
+
+  const update = (fields: Partial<AgentRegistrationData>) => {
+    setFormData((prev) => ({ ...prev, ...fields }));
+    const touchedKeys = Object.keys(fields) as (keyof AgentRegistrationData)[];
+    if (touchedKeys.some((k) => errors[k])) {
+      setErrors((prev) => {
+        const next = { ...prev };
+        touchedKeys.forEach((k) => delete next[k]);
+        return next;
+      });
+    }
+  };
+
+  const handleNext = () => {
+    if (step < TOTAL_STEPS) {
+      const stepErrors = validateStep(step, formData, t);
+      if (Object.keys(stepErrors).length > 0) {
+        setErrors(stepErrors);
+        return;
+      }
+      setErrors({});
+      setStep((s) => s + 1);
+    }
+  };
+
+  const handleBack = () => {
+    setErrors({});
+    setStep((s) => s - 1);
+  };
+
+  const handleSubmit = async () => {
+    setSubmitError(null);
+    setIsSubmitting(true);
+
+    try {
+      // Step 1: create user account with role "agent"
+      // BE requirement: POST /api/user must allow role: "agent"
+      await axios.post(API_PATH_USER, {
+        email: formData.email,
+        password: formData.password,
+        role: UserRole.AGENT,
+        person: {
+          firstName: formData.firstName,
+          lastName: formData.lastName,
+        },
+      });
+
+      // Step 2: auto-login to obtain session cookie
+      await axios.post(apiPathLogin, {
+        email: formData.email,
+        password: formData.password,
+      });
+      document.cookie = LOGGED_IN_COOKIE;
+
+      // Step 3: create agent profile
+      // BE requirement: POST /api/agent endpoint must be implemented
+      await axios.post(apiPathAgent, {
+        title: formData.organizationName,
+        type: formData.organizationType || undefined,
+        info: formData.about || undefined,
+        website: formData.website || undefined,
+        services: formData.services.length > 0 ? formData.services : undefined,
+        addressStreet: formData.addressStreet || undefined,
+        addressPostcode: formData.addressPostcode || undefined,
+        districtId: formData.districtId ?? undefined,
+        languages: formData.clientLanguageIds.length > 0 ? formData.clientLanguageIds : undefined,
+      });
+
+      setIsSuccess(true);
+      setTimeout(() => {
+        const { language } = i18next;
+        router.push(`/${language}/dashboard`);
+      }, 3000);
+    } catch (err) {
+      let message = t("message.errorGeneric");
+      if (axios.isAxiosError(err)) {
+        const data = err.response?.data as { message?: string } | undefined;
+        message = data?.message || message;
+      }
+      setSubmitError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isSuccess) {
+    return (
+      <Wrapper>
+        <Card>
+          <SuccessWrapper>
+            <SuccessTitle>{t("agentRegistration.success.title")}</SuccessTitle>
+            <SuccessText>{t("agentRegistration.success.description")}</SuccessText>
+          </SuccessWrapper>
+        </Card>
+      </Wrapper>
+    );
+  }
+
+  const isLastStep = step === TOTAL_STEPS;
+
+  return (
+    <Wrapper>
+      <Card>
+        <PageTitle>{t("agentRegistration.title")}</PageTitle>
+        <PageSubtitle>{t("agentRegistration.subtitle")}</PageSubtitle>
+
+        <ProgressBar currentStep={step} />
+
+        {submitError && <ErrorBanner>{submitError}</ErrorBanner>}
+
+        {step === 1 && <AccountStep data={formData} onChange={update} errors={errors} />}
+        {step === 2 && <OrgInfoStep data={formData} onChange={update} errors={errors} />}
+        {step === 3 && <AddressStep data={formData} onChange={update} errors={errors} optionLists={optionLists} />}
+        {step === 4 && <ServicesStep data={formData} onChange={update} optionLists={optionLists} />}
+        {step === 5 && <ReviewStep data={formData} />}
+
+        <Actions>
+          {step > 1 ? (
+            <Button
+              text={t("agentRegistration.back")}
+              backgroundcolor="var(--color-white)"
+              textColor="var(--color-aubergine)"
+              border="1px solid var(--color-aubergine)"
+              onClick={handleBack}
+              disabled={isSubmitting}
+            />
+          ) : (
+            <div />
+          )}
+
+          {isLastStep ? (
+            <Button
+              text={t("agentRegistration.submit")}
+              backgroundcolor="var(--color-aubergine)"
+              textColor="var(--color-white)"
+              onClick={handleSubmit}
+              disabled={isSubmitting}
+            />
+          ) : (
+            <Button
+              text={t("agentRegistration.next")}
+              backgroundcolor="var(--color-aubergine)"
+              textColor="var(--color-white)"
+              onClick={handleNext}
+            />
+          )}
+        </Actions>
+      </Card>
+    </Wrapper>
+  );
+}

--- a/src/components/AgentRegistration/ProgressBar.tsx
+++ b/src/components/AgentRegistration/ProgressBar.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+import { TOTAL_STEPS } from "./types";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 32px;
+`;
+
+const StepLabel = styled.span`
+  font-size: 0.875rem;
+  color: var(--color-grey-500);
+`;
+
+const Track = styled.div`
+  display: flex;
+  gap: 6px;
+`;
+
+interface SegmentProps {
+  $active: boolean;
+}
+
+const Segment = styled.div<SegmentProps>`
+  flex: 1;
+  height: 4px;
+  border-radius: 2px;
+  background: ${({ $active }) => ($active ? "var(--color-aubergine)" : "var(--color-grey-200)")};
+  transition: background 0.2s ease;
+`;
+
+interface Props {
+  currentStep: number;
+}
+
+export function ProgressBar({ currentStep }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <Container>
+      <StepLabel>
+        {t("agentRegistration.step")} {currentStep} / {TOTAL_STEPS}
+      </StepLabel>
+      <Track>
+        {Array.from({ length: TOTAL_STEPS }, (_, i) => (
+          <Segment key={i} $active={i < currentStep} />
+        ))}
+      </Track>
+    </Container>
+  );
+}

--- a/src/components/AgentRegistration/helpers.ts
+++ b/src/components/AgentRegistration/helpers.ts
@@ -1,0 +1,48 @@
+import { AgentType } from "need4deed-sdk";
+import { AgentRegistrationData } from "./types";
+
+export const AGENT_TYPE_LABELS: Record<AgentType, string> = {
+  [AgentType.AE]: "AE",
+  [AgentType.GU1]: "GU1",
+  [AgentType.GU2]: "GU2",
+  [AgentType.GU2_PLUS]: "GU2+",
+  [AgentType.GU3]: "GU3",
+  [AgentType.NU]: "NU",
+  [AgentType.ASOG]: "ASOG",
+  [AgentType.COUNSELING_CENTER]: "Counseling Center",
+  [AgentType.TANDEM]: "Tandem",
+  [AgentType.MULTIPLE_SOCIAL_SUPPORT]: "Multiple Social Support",
+};
+
+export function validateStep(
+  step: number,
+  data: AgentRegistrationData,
+  t: (k: string) => string,
+): Partial<Record<keyof AgentRegistrationData, string>> {
+  const errors: Partial<Record<keyof AgentRegistrationData, string>> = {};
+  const required = t("form.error.required");
+
+  if (step === 1) {
+    if (!data.firstName.trim()) errors.firstName = required;
+    if (!data.lastName.trim()) errors.lastName = required;
+    if (!data.email.trim()) errors.email = required;
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) errors.email = t("form.error.email");
+    if (!data.password) errors.password = required;
+    else if (data.password.length < 8) errors.password = t("agentRegistration.errors.passwordTooShort");
+    if (!data.confirmPassword) errors.confirmPassword = required;
+    else if (data.password !== data.confirmPassword)
+      errors.confirmPassword = t("agentRegistration.errors.passwordMismatch");
+  }
+
+  if (step === 2) {
+    if (!data.organizationName.trim()) errors.organizationName = required;
+    if (!data.organizationType) errors.organizationType = required;
+  }
+
+  if (step === 3) {
+    if (!data.addressStreet.trim()) errors.addressStreet = required;
+    if (!data.addressPostcode.trim()) errors.addressPostcode = required;
+  }
+
+  return errors;
+}

--- a/src/components/AgentRegistration/index.ts
+++ b/src/components/AgentRegistration/index.ts
@@ -1,0 +1,1 @@
+export * from "./AgentRegistration";

--- a/src/components/AgentRegistration/steps/AccountStep.tsx
+++ b/src/components/AgentRegistration/steps/AccountStep.tsx
@@ -1,0 +1,75 @@
+"use client";
+import { FormInput } from "@/components/core/common";
+import { useTranslation } from "react-i18next";
+import { AgentRegistrationData } from "../types";
+import { FieldLabel, FieldWrapper, StepDescription, StepTitle } from "../styled";
+
+interface Props {
+  data: AgentRegistrationData;
+  onChange: (fields: Partial<AgentRegistrationData>) => void;
+  errors: Partial<Record<keyof AgentRegistrationData, string>>;
+}
+
+export function AccountStep({ data, onChange, errors }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <StepTitle>{t("agentRegistration.steps.account.title")}</StepTitle>
+      <StepDescription>{t("agentRegistration.steps.account.description")}</StepDescription>
+
+      <FieldWrapper>
+        <FieldLabel>{t("agentRegistration.fields.firstName")}</FieldLabel>
+        <FormInput
+          value={data.firstName}
+          onInputChange={(v) => onChange({ firstName: v })}
+          placeHolder={t("agentRegistration.fields.firstName")}
+          errors={errors.firstName ? [errors.firstName] : []}
+        />
+      </FieldWrapper>
+
+      <FieldWrapper>
+        <FieldLabel>{t("agentRegistration.fields.lastName")}</FieldLabel>
+        <FormInput
+          value={data.lastName}
+          onInputChange={(v) => onChange({ lastName: v })}
+          placeHolder={t("agentRegistration.fields.lastName")}
+          errors={errors.lastName ? [errors.lastName] : []}
+        />
+      </FieldWrapper>
+
+      <FieldWrapper>
+        <FieldLabel>{t("agentRegistration.fields.email")}</FieldLabel>
+        <FormInput
+          type="email"
+          value={data.email}
+          onInputChange={(v) => onChange({ email: v })}
+          placeHolder={t("agentRegistration.fields.email")}
+          errors={errors.email ? [errors.email] : []}
+        />
+      </FieldWrapper>
+
+      <FieldWrapper>
+        <FieldLabel>{t("agentRegistration.fields.password")}</FieldLabel>
+        <FormInput
+          type="password"
+          value={data.password}
+          onInputChange={(v) => onChange({ password: v })}
+          placeHolder={t("agentRegistration.fields.password")}
+          errors={errors.password ? [errors.password] : []}
+        />
+      </FieldWrapper>
+
+      <FieldWrapper>
+        <FieldLabel>{t("agentRegistration.fields.confirmPassword")}</FieldLabel>
+        <FormInput
+          type="password"
+          value={data.confirmPassword}
+          onInputChange={(v) => onChange({ confirmPassword: v })}
+          placeHolder={t("agentRegistration.fields.confirmPassword")}
+          errors={errors.confirmPassword ? [errors.confirmPassword] : []}
+        />
+      </FieldWrapper>
+    </div>
+  );
+}

--- a/src/components/AgentRegistration/steps/AccountStep.tsx
+++ b/src/components/AgentRegistration/steps/AccountStep.tsx
@@ -4,11 +4,11 @@ import { useTranslation } from "react-i18next";
 import { AgentRegistrationData } from "../types";
 import { FieldLabel, FieldWrapper, StepDescription, StepTitle } from "../styled";
 
-interface Props {
+type Props = {
   data: AgentRegistrationData;
   onChange: (fields: Partial<AgentRegistrationData>) => void;
   errors: Partial<Record<keyof AgentRegistrationData, string>>;
-}
+};
 
 export function AccountStep({ data, onChange, errors }: Props) {
   const { t } = useTranslation();

--- a/src/components/AgentRegistration/steps/AddressStep.tsx
+++ b/src/components/AgentRegistration/steps/AddressStep.tsx
@@ -1,0 +1,63 @@
+"use client";
+import { FormInput } from "@/components/core/common";
+import { ApiOptionLists, EntityTableName } from "need4deed-sdk";
+import { useTranslation } from "react-i18next";
+import { FieldLabel, FieldWrapper, StepDescription, StepTitle, StyledSelect } from "../styled";
+import { AgentRegistrationData } from "../types";
+
+interface Props {
+  data: AgentRegistrationData;
+  onChange: (fields: Partial<AgentRegistrationData>) => void;
+  errors: Partial<Record<keyof AgentRegistrationData, string>>;
+  optionLists?: ApiOptionLists;
+}
+
+export function AddressStep({ data, onChange, errors, optionLists }: Props) {
+  const { t } = useTranslation();
+  const districts = optionLists?.[EntityTableName.DISTRICT] ?? [];
+
+  return (
+    <div>
+      <StepTitle>{t("agentRegistration.steps.address.title")}</StepTitle>
+      <StepDescription>{t("agentRegistration.steps.address.description")}</StepDescription>
+
+      <FieldWrapper>
+        <FieldLabel>{t("agentRegistration.fields.addressStreet")}</FieldLabel>
+        <FormInput
+          value={data.addressStreet}
+          onInputChange={(v) => onChange({ addressStreet: v })}
+          placeHolder={t("agentRegistration.fields.addressStreet")}
+          errors={errors.addressStreet ? [errors.addressStreet] : []}
+        />
+      </FieldWrapper>
+
+      <FieldWrapper>
+        <FieldLabel>{t("agentRegistration.fields.addressPostcode")}</FieldLabel>
+        <FormInput
+          value={data.addressPostcode}
+          onInputChange={(v) => onChange({ addressPostcode: v })}
+          placeHolder="12345"
+          errors={errors.addressPostcode ? [errors.addressPostcode] : []}
+        />
+      </FieldWrapper>
+
+      <FieldWrapper>
+        <FieldLabel>
+          {t("agentRegistration.fields.district")} ({t("agentRegistration.optional")})
+        </FieldLabel>
+        <StyledSelect
+          value={data.districtId ?? ""}
+          onChange={(e) => onChange({ districtId: e.target.value ? Number(e.target.value) : null })}
+          $hasError={false}
+        >
+          <option value="">{t("agentRegistration.fields.selectDistrict")}</option>
+          {districts.map((d) => (
+            <option key={d.id} value={d.id}>
+              {d.title}
+            </option>
+          ))}
+        </StyledSelect>
+      </FieldWrapper>
+    </div>
+  );
+}

--- a/src/components/AgentRegistration/steps/AddressStep.tsx
+++ b/src/components/AgentRegistration/steps/AddressStep.tsx
@@ -5,12 +5,12 @@ import { useTranslation } from "react-i18next";
 import { FieldLabel, FieldWrapper, StepDescription, StepTitle, StyledSelect } from "../styled";
 import { AgentRegistrationData } from "../types";
 
-interface Props {
+type Props = {
   data: AgentRegistrationData;
   onChange: (fields: Partial<AgentRegistrationData>) => void;
   errors: Partial<Record<keyof AgentRegistrationData, string>>;
   optionLists?: ApiOptionLists;
-}
+};
 
 export function AddressStep({ data, onChange, errors, optionLists }: Props) {
   const { t } = useTranslation();

--- a/src/components/AgentRegistration/steps/OrgInfoStep.tsx
+++ b/src/components/AgentRegistration/steps/OrgInfoStep.tsx
@@ -2,26 +2,14 @@
 import { FormInput } from "@/components/core/common";
 import { AgentType } from "need4deed-sdk";
 import { useTranslation } from "react-i18next";
+import { AGENT_TYPE_LABELS } from "../helpers";
 import { FieldLabel, FieldWrapper, StepDescription, StepTitle, StyledSelect, StyledTextarea } from "../styled";
 import { AgentRegistrationData } from "../types";
 
-interface Props {
+type Props = {
   data: AgentRegistrationData;
   onChange: (fields: Partial<AgentRegistrationData>) => void;
   errors: Partial<Record<keyof AgentRegistrationData, string>>;
-}
-
-const AGENT_TYPE_LABELS: Record<AgentType, string> = {
-  [AgentType.AE]: "AE",
-  [AgentType.GU1]: "GU1",
-  [AgentType.GU2]: "GU2",
-  [AgentType.GU2_PLUS]: "GU2+",
-  [AgentType.GU3]: "GU3",
-  [AgentType.NU]: "NU",
-  [AgentType.ASOG]: "ASOG",
-  [AgentType.COUNSELING_CENTER]: "Counseling Center",
-  [AgentType.TANDEM]: "Tandem",
-  [AgentType.MULTIPLE_SOCIAL_SUPPORT]: "Multiple Social Support",
 };
 
 export function OrgInfoStep({ data, onChange, errors }: Props) {

--- a/src/components/AgentRegistration/steps/OrgInfoStep.tsx
+++ b/src/components/AgentRegistration/steps/OrgInfoStep.tsx
@@ -1,0 +1,89 @@
+"use client";
+import { FormInput } from "@/components/core/common";
+import { AgentType } from "need4deed-sdk";
+import { useTranslation } from "react-i18next";
+import { FieldLabel, FieldWrapper, StepDescription, StepTitle, StyledSelect, StyledTextarea } from "../styled";
+import { AgentRegistrationData } from "../types";
+
+interface Props {
+  data: AgentRegistrationData;
+  onChange: (fields: Partial<AgentRegistrationData>) => void;
+  errors: Partial<Record<keyof AgentRegistrationData, string>>;
+}
+
+const AGENT_TYPE_LABELS: Record<AgentType, string> = {
+  [AgentType.AE]: "AE",
+  [AgentType.GU1]: "GU1",
+  [AgentType.GU2]: "GU2",
+  [AgentType.GU2_PLUS]: "GU2+",
+  [AgentType.GU3]: "GU3",
+  [AgentType.NU]: "NU",
+  [AgentType.ASOG]: "ASOG",
+  [AgentType.COUNSELING_CENTER]: "Counseling Center",
+  [AgentType.TANDEM]: "Tandem",
+  [AgentType.MULTIPLE_SOCIAL_SUPPORT]: "Multiple Social Support",
+};
+
+export function OrgInfoStep({ data, onChange, errors }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <StepTitle>{t("agentRegistration.steps.orgInfo.title")}</StepTitle>
+      <StepDescription>{t("agentRegistration.steps.orgInfo.description")}</StepDescription>
+
+      <FieldWrapper>
+        <FieldLabel>{t("agentRegistration.fields.organizationName")}</FieldLabel>
+        <FormInput
+          value={data.organizationName}
+          onInputChange={(v) => onChange({ organizationName: v })}
+          placeHolder={t("agentRegistration.fields.organizationName")}
+          errors={errors.organizationName ? [errors.organizationName] : []}
+        />
+      </FieldWrapper>
+
+      <FieldWrapper>
+        <FieldLabel>{t("agentRegistration.fields.organizationType")}</FieldLabel>
+        <StyledSelect
+          value={data.organizationType}
+          onChange={(e) => onChange({ organizationType: e.target.value as AgentType })}
+          $hasError={!!errors.organizationType}
+        >
+          <option value="">{t("agentRegistration.fields.selectOrganizationType")}</option>
+          {Object.values(AgentType).map((type) => (
+            <option key={type} value={type}>
+              {AGENT_TYPE_LABELS[type]}
+            </option>
+          ))}
+        </StyledSelect>
+        {errors.organizationType && (
+          <span style={{ color: "var(--form-input-error-message-color)", fontSize: "0.875rem" }}>
+            {errors.organizationType}
+          </span>
+        )}
+      </FieldWrapper>
+
+      <FieldWrapper>
+        <FieldLabel>{t("agentRegistration.fields.about")}</FieldLabel>
+        <StyledTextarea
+          value={data.about}
+          onChange={(e) => onChange({ about: e.target.value })}
+          placeholder={t("agentRegistration.fields.aboutPlaceholder")}
+          rows={4}
+        />
+      </FieldWrapper>
+
+      <FieldWrapper>
+        <FieldLabel>
+          {t("agentRegistration.fields.website")} ({t("agentRegistration.optional")})
+        </FieldLabel>
+        <FormInput
+          type="url"
+          value={data.website}
+          onInputChange={(v) => onChange({ website: v })}
+          placeHolder="https://..."
+        />
+      </FieldWrapper>
+    </div>
+  );
+}

--- a/src/components/AgentRegistration/steps/ReviewStep.tsx
+++ b/src/components/AgentRegistration/steps/ReviewStep.tsx
@@ -1,0 +1,90 @@
+"use client";
+import { AgentType } from "need4deed-sdk";
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+import { StepDescription, StepTitle } from "../styled";
+import { AgentRegistrationData } from "../types";
+
+const ReviewList = styled.dl`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const ReviewRow = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+const ReviewKey = styled.dt`
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-grey-500);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+`;
+
+const ReviewValue = styled.dd`
+  font-size: 0.9375rem;
+  color: var(--color-midnight);
+  margin: 0;
+`;
+
+const AGENT_TYPE_LABELS: Record<AgentType, string> = {
+  [AgentType.AE]: "AE",
+  [AgentType.GU1]: "GU1",
+  [AgentType.GU2]: "GU2",
+  [AgentType.GU2_PLUS]: "GU2+",
+  [AgentType.GU3]: "GU3",
+  [AgentType.NU]: "NU",
+  [AgentType.ASOG]: "ASOG",
+  [AgentType.COUNSELING_CENTER]: "Counseling Center",
+  [AgentType.TANDEM]: "Tandem",
+  [AgentType.MULTIPLE_SOCIAL_SUPPORT]: "Multiple Social Support",
+};
+
+interface Props {
+  data: AgentRegistrationData;
+}
+
+export function ReviewStep({ data }: Props) {
+  const { t } = useTranslation();
+
+  const rows: { key: string; value: string }[] = [
+    { key: t("agentRegistration.fields.firstName"), value: data.firstName },
+    { key: t("agentRegistration.fields.lastName"), value: data.lastName },
+    { key: t("agentRegistration.fields.email"), value: data.email },
+    { key: t("agentRegistration.fields.organizationName"), value: data.organizationName },
+    {
+      key: t("agentRegistration.fields.organizationType"),
+      value: data.organizationType ? AGENT_TYPE_LABELS[data.organizationType] : "—",
+    },
+    { key: t("agentRegistration.fields.addressStreet"), value: data.addressStreet || "—" },
+    { key: t("agentRegistration.fields.addressPostcode"), value: data.addressPostcode || "—" },
+    {
+      key: t("agentRegistration.fields.services"),
+      value:
+        data.services.length > 0
+          ? data.services
+              .map((s) => t(`dashboard.agents.filters.services.${s}`, { defaultValue: s }))
+              .join(", ")
+          : "—",
+    },
+  ];
+
+  return (
+    <div>
+      <StepTitle>{t("agentRegistration.steps.review.title")}</StepTitle>
+      <StepDescription>{t("agentRegistration.steps.review.description")}</StepDescription>
+      <ReviewList>
+        {rows.map(({ key, value }) => (
+          <ReviewRow key={key}>
+            <ReviewKey>{key}</ReviewKey>
+            <ReviewValue>{value}</ReviewValue>
+          </ReviewRow>
+        ))}
+      </ReviewList>
+    </div>
+  );
+}

--- a/src/components/AgentRegistration/steps/ReviewStep.tsx
+++ b/src/components/AgentRegistration/steps/ReviewStep.tsx
@@ -1,7 +1,7 @@
 "use client";
-import { AgentType } from "need4deed-sdk";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
+import { AGENT_TYPE_LABELS } from "../helpers";
 import { StepDescription, StepTitle } from "../styled";
 import { AgentRegistrationData } from "../types";
 
@@ -31,22 +31,9 @@ const ReviewValue = styled.dd`
   margin: 0;
 `;
 
-const AGENT_TYPE_LABELS: Record<AgentType, string> = {
-  [AgentType.AE]: "AE",
-  [AgentType.GU1]: "GU1",
-  [AgentType.GU2]: "GU2",
-  [AgentType.GU2_PLUS]: "GU2+",
-  [AgentType.GU3]: "GU3",
-  [AgentType.NU]: "NU",
-  [AgentType.ASOG]: "ASOG",
-  [AgentType.COUNSELING_CENTER]: "Counseling Center",
-  [AgentType.TANDEM]: "Tandem",
-  [AgentType.MULTIPLE_SOCIAL_SUPPORT]: "Multiple Social Support",
-};
-
-interface Props {
+type Props = {
   data: AgentRegistrationData;
-}
+};
 
 export function ReviewStep({ data }: Props) {
   const { t } = useTranslation();

--- a/src/components/AgentRegistration/steps/ServicesStep.tsx
+++ b/src/components/AgentRegistration/steps/ServicesStep.tsx
@@ -27,11 +27,11 @@ const CheckboxLabel = styled.label`
   }
 `;
 
-interface Props {
+type Props = {
   data: AgentRegistrationData;
   onChange: (fields: Partial<AgentRegistrationData>) => void;
   optionLists?: ApiOptionLists;
-}
+};
 
 export function ServicesStep({ data, onChange, optionLists }: Props) {
   const { t } = useTranslation();

--- a/src/components/AgentRegistration/steps/ServicesStep.tsx
+++ b/src/components/AgentRegistration/steps/ServicesStep.tsx
@@ -1,0 +1,94 @@
+"use client";
+import { ApiOptionLists, AgentServiceType, EntityTableName } from "need4deed-sdk";
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+import { FieldLabel, FieldWrapper, StepDescription, StepTitle } from "../styled";
+import { AgentRegistrationData } from "../types";
+
+const CheckboxGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 10px;
+`;
+
+const CheckboxLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 0.9375rem;
+  color: var(--color-midnight);
+
+  input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--color-aubergine);
+    cursor: pointer;
+  }
+`;
+
+interface Props {
+  data: AgentRegistrationData;
+  onChange: (fields: Partial<AgentRegistrationData>) => void;
+  optionLists?: ApiOptionLists;
+}
+
+export function ServicesStep({ data, onChange, optionLists }: Props) {
+  const { t } = useTranslation();
+  const languages = optionLists?.[EntityTableName.LANGUAGE] ?? [];
+
+  const toggleService = (service: AgentServiceType) => {
+    const updated = data.services.includes(service)
+      ? data.services.filter((s) => s !== service)
+      : [...data.services, service];
+    onChange({ services: updated });
+  };
+
+  const toggleLanguage = (id: number) => {
+    const updated = data.clientLanguageIds.includes(id)
+      ? data.clientLanguageIds.filter((l) => l !== id)
+      : [...data.clientLanguageIds, id];
+    onChange({ clientLanguageIds: updated });
+  };
+
+  return (
+    <div>
+      <StepTitle>{t("agentRegistration.steps.services.title")}</StepTitle>
+      <StepDescription>{t("agentRegistration.steps.services.description")}</StepDescription>
+
+      <FieldWrapper>
+        <FieldLabel>{t("agentRegistration.fields.services")}</FieldLabel>
+        <CheckboxGrid>
+          {Object.values(AgentServiceType).map((service) => (
+            <CheckboxLabel key={service}>
+              <input
+                type="checkbox"
+                checked={data.services.includes(service)}
+                onChange={() => toggleService(service)}
+              />
+              {t(`dashboard.agents.filters.services.${service}`, { defaultValue: service })}
+            </CheckboxLabel>
+          ))}
+        </CheckboxGrid>
+      </FieldWrapper>
+
+      {languages.length > 0 && (
+        <FieldWrapper>
+          <FieldLabel>{t("agentRegistration.fields.clientLanguages")}</FieldLabel>
+          <CheckboxGrid>
+            {languages.map((lang) => (
+              <CheckboxLabel key={lang.id}>
+                <input
+                  type="checkbox"
+                  checked={data.clientLanguageIds.includes(lang.id)}
+                  onChange={() => toggleLanguage(lang.id)}
+                />
+                {lang.title}
+              </CheckboxLabel>
+            ))}
+          </CheckboxGrid>
+        </FieldWrapper>
+      )}
+    </div>
+  );
+}

--- a/src/components/AgentRegistration/styled.ts
+++ b/src/components/AgentRegistration/styled.ts
@@ -1,5 +1,74 @@
 import styled from "styled-components";
 
+export const Wrapper = styled.div`
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 48px 16px;
+  background: var(--layout-static-page-background-default, #f8f6f8);
+`;
+
+export const Card = styled.div`
+  background: var(--color-white);
+  border-radius: 16px;
+  padding: 40px;
+  width: 100%;
+  max-width: 560px;
+  box-shadow: 0 2px 16px rgba(0, 0, 0, 0.08);
+`;
+
+export const PageTitle = styled.h1`
+  font-size: 1.625rem;
+  font-weight: 700;
+  color: var(--color-midnight);
+  margin: 0 0 4px;
+`;
+
+export const PageSubtitle = styled.p`
+  font-size: 0.9375rem;
+  color: var(--color-grey-500);
+  margin: 0 0 32px;
+`;
+
+export const Actions = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 32px;
+  gap: 12px;
+`;
+
+export const ErrorBanner = styled.div`
+  background: var(--color-error-light, #fef2f2);
+  border: 1px solid var(--color-error-border, #fecaca);
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin-bottom: 20px;
+  font-size: 0.9375rem;
+  color: var(--color-error, #dc2626);
+`;
+
+export const SuccessWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 24px 0;
+  text-align: center;
+`;
+
+export const SuccessTitle = styled.h2`
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: var(--color-midnight);
+`;
+
+export const SuccessText = styled.p`
+  font-size: 0.9375rem;
+  color: var(--color-grey-500);
+`;
+
 export const StepTitle = styled.h2`
   font-size: 1.375rem;
   font-weight: 700;
@@ -26,9 +95,9 @@ export const FieldLabel = styled.label`
   color: var(--color-midnight);
 `;
 
-interface SelectProps {
+type SelectProps = {
   $hasError: boolean;
-}
+};
 
 export const StyledSelect = styled.select<SelectProps>`
   color: var(--color-midnight);

--- a/src/components/AgentRegistration/styled.ts
+++ b/src/components/AgentRegistration/styled.ts
@@ -1,0 +1,66 @@
+import styled from "styled-components";
+
+export const StepTitle = styled.h2`
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: var(--color-midnight);
+  margin: 0 0 8px;
+`;
+
+export const StepDescription = styled.p`
+  font-size: 0.9375rem;
+  color: var(--color-grey-500);
+  margin: 0 0 28px;
+`;
+
+export const FieldWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 20px;
+`;
+
+export const FieldLabel = styled.label`
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-midnight);
+`;
+
+interface SelectProps {
+  $hasError: boolean;
+}
+
+export const StyledSelect = styled.select<SelectProps>`
+  color: var(--color-midnight);
+  font-size: var(--form-input-fontSize, 1rem);
+  height: var(--form-input-container-height, 48px);
+  width: -webkit-fill-available;
+  background-color: var(--color-white);
+  border-radius: var(--form-input-container-border-radius, 8px);
+  padding: var(--form-input-container-padding, 0 12px);
+  border: ${({ $hasError }) =>
+    $hasError ? "var(--form-input-container-border-error)" : "var(--form-input-container-border)"};
+  cursor: pointer;
+
+  &:focus {
+    outline: none;
+    border: var(--form-input-container-border-focus);
+  }
+`;
+
+export const StyledTextarea = styled.textarea`
+  color: var(--color-midnight);
+  font-size: var(--form-input-fontSize, 1rem);
+  width: -webkit-fill-available;
+  background-color: var(--color-white);
+  border-radius: var(--form-input-container-border-radius, 8px);
+  padding: 12px;
+  border: var(--form-input-container-border);
+  resize: vertical;
+  font-family: inherit;
+
+  &:focus {
+    outline: none;
+    border: var(--form-input-container-border-focus);
+  }
+`;

--- a/src/components/AgentRegistration/types.ts
+++ b/src/components/AgentRegistration/types.ts
@@ -1,0 +1,37 @@
+import { AgentServiceType, AgentType } from "need4deed-sdk";
+
+export interface AgentRegistrationData {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+  organizationName: string;
+  organizationType: AgentType | "";
+  about: string;
+  website: string;
+  addressStreet: string;
+  addressPostcode: string;
+  districtId: number | null;
+  services: AgentServiceType[];
+  clientLanguageIds: number[];
+}
+
+export const defaultAgentRegistrationData: AgentRegistrationData = {
+  firstName: "",
+  lastName: "",
+  email: "",
+  password: "",
+  confirmPassword: "",
+  organizationName: "",
+  organizationType: "",
+  about: "",
+  website: "",
+  addressStreet: "",
+  addressPostcode: "",
+  districtId: null,
+  services: [],
+  clientLanguageIds: [],
+};
+
+export const TOTAL_STEPS = 5;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -15,6 +15,7 @@ export const apiPathOpportunity = `/${apiPrefix}/opportunity`;
 export const apiPathAgent = `/${apiPrefix}/agent`;
 export const apiPathOption = `/${apiPrefix}/option`;
 export const apiPathOpportunityVolunteer = `/${apiPrefix}/opportunity-volunteer`;
+export const apiPathUser = `/${apiPrefix}/user`;
 export const apiPathMe = `/${apiPrefix}/user/me`;
 export const apiPathPerson = `/${apiPrefix}/person/`;
 export const apiPathOrganization = `/${apiPrefix}/organization/`;


### PR DESCRIPTION
## Summary

- Adds 5-step registration wizard at `/[lang]/register/agent` for RAC organisations to create their own account and agent profile
- Steps: **Account** → **Organisation** → **Location** → **Services & Languages** → **Review & Submit**
- EN + DE translations included
- Per-step validation with inline error messages

## API flow (on final submit)

1. `POST /api/user` — creates user account with `role: "agent"`
2. `POST /api/auth/login` — auto-login after account creation, sets `is_logged_in` cookie
3. `POST /api/agent` — creates agent profile with all collected data

## BE changes required (tracked separately)

This PR is FE-ready but two BE changes are needed before the flow works end-to-end:

1. **`POST /api/user` schema** must allow `role: "agent"` (currently only `"user"` and `"admin"` are permitted in `createUserBodySchema`)
2. **`POST /api/agent` endpoint** must be implemented (currently only `GET`, `PATCH`, `DELETE` exist, all behind `COORDINATOR` auth)

## Test plan

- [ ] Navigate to `/en/register/agent` and `/de/register/agent`
- [ ] Step 1: verify validation for required fields (firstName, lastName, email, password ≥8 chars, passwords match)
- [ ] Step 2: verify org name and type are required
- [ ] Step 3: verify street and postcode are required; district dropdown populates from `/api/option`
- [ ] Step 4: verify service and language checkboxes are multi-selectable
- [ ] Step 5 (Review): verify all entered data displays correctly before submit
- [ ] Back/Next navigation preserves form state
- [ ] Error banner appears on submit failure with BE message

Closes https://github.com/need4deed-org/fe/issues/444

🤖 Generated with [Claude Code](https://claude.com/claude-code)