### PR TITLE
feat: show logged-by username in communication tracker

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1262,6 +1262,7 @@
       "whatPlatform": "Welche Plattform haben Sie verwendet?",
       "howDidYouSend": "Wie haben Sie Ihre Nachricht gesendet?",
       "contactMethodLabel": "Kontaktmethode",
+      "loggedBy": "Von",
       "contactMethodRequired": "Kontaktmethode*",
       "communicationTypeRequired": "Kommunikationstyp*",
       "communicationTypes": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1260,6 +1260,7 @@
       "whatPlatform": "What platform did you use?",
       "howDidYouSend": "How did you send your message?",
       "contactMethodLabel": "Contact method",
+      "loggedBy": "By",
       "contactMethodRequired": "Contact method*",
       "communicationTypeRequired": "Communication type*",
       "communicationTypes": {

--- a/src/components/Dashboard/Profile/sections/CommunicationTracker/CommunicationTracker.tsx
+++ b/src/components/Dashboard/Profile/sections/CommunicationTracker/CommunicationTracker.tsx
@@ -1,19 +1,13 @@
 import { useCommunicationTracker } from "@/hooks/useCommunicationTracker";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { PencilSimple, Trash } from "@phosphor-icons/react";
-import {
-  ApiCommunicationGet,
-  ApiVolunteerCommunicationPost,
-  ApiVolunteerCommunicationPatch,
-} from "need4deed-sdk";
+import { ApiCommunicationGet, ApiVolunteerCommunicationPost, ApiVolunteerCommunicationPatch } from "need4deed-sdk";
 import { EntityType } from "@/components/Dashboard/Profile/types";
 import { forwardRef, useImperativeHandle, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CommunicationDialog } from "./CommunicationDialog";
 import { ConfirmationDialog } from "../shared/ConfirmationDialog";
-import {
-  SectionWrapper,
-  SectionEmptyState,
-} from "../shared/styles";
+import { SectionWrapper, SectionEmptyState } from "../shared/styles";
 import {
   Table,
   TableHeader,
@@ -36,18 +30,20 @@ export type CommunicationTrackerRef = {
   handleAddNew: () => void;
 };
 
-export const CommunicationTracker = forwardRef<CommunicationTrackerRef, Props>(function CommunicationTracker({ entityId, entityType }, ref) {
+export const CommunicationTracker = forwardRef<CommunicationTrackerRef, Props>(function CommunicationTracker(
+  { entityId, entityType },
+  ref,
+) {
   const { t } = useTranslation();
+  const currentUser = useCurrentUser(true);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingEntry, setEditingEntry] = useState<ApiCommunicationGet | undefined>(undefined);
   const [deleteConfirmEntry, setDeleteConfirmEntry] = useState<ApiCommunicationGet | null>(null);
 
-  const {
-    communications,
-    createCommunication,
-    updateCommunication,
-    deleteCommunication,
-  } = useCommunicationTracker(entityId, entityType);
+  const { communications, createCommunication, updateCommunication, deleteCommunication } = useCommunicationTracker(
+    entityId,
+    entityType,
+  );
 
   const handleAddNew = () => {
     setEditingEntry(undefined);
@@ -81,28 +77,36 @@ export const CommunicationTracker = forwardRef<CommunicationTrackerRef, Props>(f
     setDeleteConfirmEntry(null);
   };
 
+  const getLoggedByLabel = (userId: number): string => {
+    if (currentUser && userId === currentUser.id) return currentUser.fullName;
+    return `#${userId}`;
+  };
+
   const handleSave = (data: Partial<ApiCommunicationGet>) => {
     if (!data.contactType || !data.contactMethod || !data.date) {
-        return;
+      return;
     }
 
     if (data.id) {
-        const payload: ApiVolunteerCommunicationPatch = {
-            contactType: data.contactType,
-            contactMethod: data.contactMethod,
-            communicationType: data.communicationType!,
-            date: data.date,
-        };
-      updateCommunication({ id: data.id, data: payload }, {
-        onSuccess: () => setIsDialogOpen(false),
-      });
+      const payload: ApiVolunteerCommunicationPatch = {
+        contactType: data.contactType,
+        contactMethod: data.contactMethod,
+        communicationType: data.communicationType!,
+        date: data.date,
+      };
+      updateCommunication(
+        { id: data.id, data: payload },
+        {
+          onSuccess: () => setIsDialogOpen(false),
+        },
+      );
     } else {
-        const payload: ApiVolunteerCommunicationPost = {
-            contactType: data.contactType,
-            contactMethod: data.contactMethod,
-            communicationType: data.communicationType!,
-            date: data.date,
-          };
+      const payload: ApiVolunteerCommunicationPost = {
+        contactType: data.contactType,
+        contactMethod: data.contactMethod,
+        communicationType: data.communicationType!,
+        date: data.date,
+      };
       createCommunication(payload, {
         onSuccess: () => setIsDialogOpen(false),
       });
@@ -120,19 +124,29 @@ export const CommunicationTracker = forwardRef<CommunicationTrackerRef, Props>(f
           <Table>
             <TableHeader>
               <TableHeaderCell>{t("dashboard.communicationSection.typeOfContact")}</TableHeaderCell>
-              <TableHeaderCell $maxWidth="310px">{t("dashboard.communicationSection.contactMethodLabel")}</TableHeaderCell>
+              <TableHeaderCell $maxWidth="310px">
+                {t("dashboard.communicationSection.contactMethodLabel")}
+              </TableHeaderCell>
               <TableHeaderCell $width="152px">{t("dashboard.communicationSection.date")}</TableHeaderCell>
+              <TableHeaderCell $width="140px">{t("dashboard.communicationSection.loggedBy")}</TableHeaderCell>
               <TableHeaderCell $width="var(--communication-tracker-action-column-width)"></TableHeaderCell>
               <TableHeaderCell $width="var(--communication-tracker-action-column-width)"></TableHeaderCell>
             </TableHeader>
             <TableBody>
               {communications.map((entry, index) => (
-                <TableRow key={entry.id} $isLast={index === communications.length - 1} data-testid={`communication-row-${entry.id}`}>
-                  <TableCell>
-                    {getDisplayLabel(t, entry.contactType, entry.communicationType)}
-                  </TableCell>
+                <TableRow
+                  key={entry.id}
+                  $isLast={index === communications.length - 1}
+                  data-testid={`communication-row-${entry.id}`}
+                >
+                  <TableCell>{getDisplayLabel(t, entry.contactType, entry.communicationType)}</TableCell>
                   <TableCell $maxWidth="310px">{getContactMethodLabel(t, entry.contactMethod)}</TableCell>
-                  <TableCell $width="152px" $noWrap>{formatDate(entry.date)}</TableCell>
+                  <TableCell $width="152px" $noWrap>
+                    {formatDate(entry.date)}
+                  </TableCell>
+                  <TableCell $width="140px" $noWrap>
+                    {getLoggedByLabel(entry.userId)}
+                  </TableCell>
                   <ActionCell>
                     <ActionButton onClick={() => handleEdit(entry)} data-testid={`edit-button-${entry.id}`}>
                       <PencilSimple size={20} weight="regular" />

--- a/src/components/Dashboard/Profile/sections/CommunicationTracker/CommunicationTracker.tsx
+++ b/src/components/Dashboard/Profile/sections/CommunicationTracker/CommunicationTracker.tsx
@@ -19,7 +19,7 @@ import {
   ActionButton,
 } from "@/components/core/common/Table";
 import { CommunicationTableContainer } from "./styles";
-import { formatDate, getDisplayLabel, getContactMethodLabel } from "./utils/translations";
+import { formatDate, getDisplayLabel, getContactMethodLabel, getLoggedByLabel } from "./utils/translations";
 
 type Props = {
   entityId: number;
@@ -35,6 +35,7 @@ export const CommunicationTracker = forwardRef<CommunicationTrackerRef, Props>(f
   ref,
 ) {
   const { t } = useTranslation();
+  // true = only fetch when the user is logged in (has auth cookie)
   const currentUser = useCurrentUser(true);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingEntry, setEditingEntry] = useState<ApiCommunicationGet | undefined>(undefined);
@@ -75,11 +76,6 @@ export const CommunicationTracker = forwardRef<CommunicationTrackerRef, Props>(f
 
   const cancelDelete = () => {
     setDeleteConfirmEntry(null);
-  };
-
-  const getLoggedByLabel = (userId: number): string => {
-    if (currentUser && userId === currentUser.id) return currentUser.fullName;
-    return `#${userId}`;
   };
 
   const handleSave = (data: Partial<ApiCommunicationGet>) => {
@@ -145,7 +141,7 @@ export const CommunicationTracker = forwardRef<CommunicationTrackerRef, Props>(f
                     {formatDate(entry.date)}
                   </TableCell>
                   <TableCell $width="140px" $noWrap>
-                    {getLoggedByLabel(entry.userId)}
+                    {entry.userId ? getLoggedByLabel(entry.userId, currentUser) : "-"}
                   </TableCell>
                   <ActionCell>
                     <ActionButton onClick={() => handleEdit(entry)} data-testid={`edit-button-${entry.id}`}>

--- a/src/components/Dashboard/Profile/sections/CommunicationTracker/utils/translations.ts
+++ b/src/components/Dashboard/Profile/sections/CommunicationTracker/utils/translations.ts
@@ -51,3 +51,8 @@ export function getDisplayLabel(t: TFunction, contactType: ContactType, communic
 }
 
 export { formatDate } from "../../shared/utils/formatDate";
+
+export function getLoggedByLabel(userId: number, currentUser?: { id: number; fullName: string } | null): string {
+  if (currentUser && userId === currentUser.id) return currentUser.fullName || `#${userId}`;
+  return `#${userId}`;
+}


### PR DESCRIPTION
Closes #455

The communication tracker table had no indication of who logged each contact entry. A new "By" column is added that shows the coordinator's full name for entries made by the currently logged-in user, falling back to a numeric user ID for entries by other users.

The fallback is intentional: the communication GET endpoint currently returns only userId (not the full user object), so resolving names for other coordinators requires a backend update to load the user relation and embed fullName in the response.

Changes:
- CommunicationTracker: import useCurrentUser, add getLoggedByLabel helper, add By column header and cell to the table
- locales EN/DE: add dashboard.communicationSection.loggedBy key ("By" / "Von")

How to test:
1. Open any volunteer or agent profile with communication tracker entries
2. The table should now have a "By" column as the 4th column
3. Entries logged by the current user should show their full name
4. Entries logged by other users show their numeric user ID (e.g. #3) until the BE embeds user info