### PR TITLE
chore: remove commented-out code leftovers

### DIFF
--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
@@ -24,7 +24,7 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
 ) {
   const { t, i18n } = useTranslation();
   const [isEditing, setIsEditing] = useState(false);
-  const { mutate: updateOrganization /*, isPending */ } = useUpdateOrganization(String(agent?.id));
+  const { mutate: updateOrganization } = useUpdateOrganization(String(agent?.id));
 
   useEditingChangeNotifier(isEditing, onEditingChange);
   const { data: apiLanguages } = useApiLanguages();

--- a/src/components/Static/Legal/DataPrivacy.tsx
+++ b/src/components/Static/Legal/DataPrivacy.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { PageLayout } from "@/components/Layout";
@@ -43,7 +43,7 @@ function DataPrivacy() {
             {t("legal.dataPrivacy.generalInfo.responsible.address")}
             {": "}
           </strong>
-          Lindower StraÃŸe 18, 13347 Berlin
+          Lindower Straße 18, 13347 Berlin
         </p>
         <p>
           <strong>
@@ -79,7 +79,7 @@ function DataPrivacy() {
           <strong>clubdialog@ws-datenschutz.de</strong>
         </p>
         <p>WS Datenschutz GmbH</p>
-        <p>DircksenstraÃŸe 51 </p>
+        <p>Dircksenstraße 51 </p>
         <p>D-10178 Berlin</p>
         <p>
           <a href="https://webersohnundscholtz.de">https://webersohnundscholtz.de</a>
@@ -95,7 +95,7 @@ function DataPrivacy() {
         <h6>{t("legal.dataPrivacy.dataProcessing.description.header")}</h6>
         <p>{t("legal.dataPrivacy.dataProcessing.description.para1")}</p>
         <p>{t("legal.dataPrivacy.dataProcessing.description.para2")}</p>
-        <p>ALL-INKL.COM â€“ Neue Medien MÃ¼nnich, HauptstraÃŸe 68, 02742 Friedersdorf, Deutschland.</p>
+        <p>ALL-INKL.COM – Neue Medien Münnich, Hauptstraße 68, 02742 Friedersdorf, Deutschland.</p>
         <p>
           {t("legal.dataPrivacy.dataProcessing.description.para3")}{" "}
           <strong>
@@ -376,7 +376,7 @@ function DataPrivacy() {
         </p>
         <p>{t("legal:dataPrivacy:excercise.para2")}</p>
         <p>WS Datenschutz GmbH</p>
-        <p>DircksenstraÃŸe 51</p>
+        <p>Dircksenstraße 51</p>
         <p>D-10178 Berlin</p>
 
         <h3>{t("legal.dataPrivacy.change.header")}</h3>

--- a/src/components/Static/Legal/DataPrivacy.tsx
+++ b/src/components/Static/Legal/DataPrivacy.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { PageLayout } from "@/components/Layout";
@@ -32,7 +32,6 @@ function DataPrivacy() {
         <h2>{t("legal.dataPrivacy.header")}</h2>
         <p>{t("legal.dataPrivacy.intro1")}</p>
         <p>{t("legal.dataPrivacy.intro2")}</p>
-        {/*  */}
         <h3>{t("legal.dataPrivacy.generalInfo.header")}</h3>
         <h6>{t("legal.dataPrivacy.generalInfo.responsible.header")}</h6>
         <p>{t("legal.dataPrivacy.generalInfo.responsible.title")}:</p>
@@ -44,7 +43,7 @@ function DataPrivacy() {
             {t("legal.dataPrivacy.generalInfo.responsible.address")}
             {": "}
           </strong>
-          Lindower Straße 18, 13347 Berlin
+          Lindower StraÃŸe 18, 13347 Berlin
         </p>
         <p>
           <strong>
@@ -80,7 +79,7 @@ function DataPrivacy() {
           <strong>clubdialog@ws-datenschutz.de</strong>
         </p>
         <p>WS Datenschutz GmbH</p>
-        <p>Dircksenstraße 51 </p>
+        <p>DircksenstraÃŸe 51 </p>
         <p>D-10178 Berlin</p>
         <p>
           <a href="https://webersohnundscholtz.de">https://webersohnundscholtz.de</a>
@@ -96,7 +95,7 @@ function DataPrivacy() {
         <h6>{t("legal.dataPrivacy.dataProcessing.description.header")}</h6>
         <p>{t("legal.dataPrivacy.dataProcessing.description.para1")}</p>
         <p>{t("legal.dataPrivacy.dataProcessing.description.para2")}</p>
-        <p>ALL-INKL.COM – Neue Medien Münnich, Hauptstraße 68, 02742 Friedersdorf, Deutschland.</p>
+        <p>ALL-INKL.COM â€“ Neue Medien MÃ¼nnich, HauptstraÃŸe 68, 02742 Friedersdorf, Deutschland.</p>
         <p>
           {t("legal.dataPrivacy.dataProcessing.description.para3")}{" "}
           <strong>
@@ -111,7 +110,6 @@ function DataPrivacy() {
         <p>{t("legal.dataPrivacy.dataProcessing.duration.para")}</p>
         <h6>{t("legal.dataPrivacy.dataProcessing.possibility.header")}</h6>
         <p>{t("legal.dataPrivacy.dataProcessing.possibility.para")}</p>
-        {/*  */}
         <h3>{t("legal.dataPrivacy.cookies.header")}</h3>
         <h6>{t("legal.dataPrivacy.cookies.description.header")}</h6>
         <p>{t("legal.dataPrivacy.cookies.description.para1")}</p>
@@ -141,7 +139,6 @@ function DataPrivacy() {
         <h6>{t("legal.dataPrivacy.cookies.possibility.header")}</h6>
         <p>{t("legal.dataPrivacy.cookies.possibility.para1")}</p>
         <p>{t("legal.dataPrivacy.cookies.possibility.para2")}</p>
-        {/*  */}
         <h3>{t("legal.dataPrivacy.contact.header")}</h3>
         <h6>{t("legal.dataPrivacy.contact.description.header")}</h6>
         <p>{t("legal.dataPrivacy.contact.description.para1")}</p>
@@ -154,7 +151,6 @@ function DataPrivacy() {
         <p>{t("legal.dataPrivacy.contact.duration.para")}</p>
         <h6>{t("legal.dataPrivacy.contact.possibility.header")}</h6>
         <p>{t("legal.dataPrivacy.contact.possibility.para")}</p>
-        {/*  */}
         <h3>{t("legal.dataPrivacy.social.header")}</h3>
         <p>{t("legal.dataPrivacy.social.para1")}</p>
         <p>
@@ -189,9 +185,7 @@ function DataPrivacy() {
             <strong>OK.RU{": "}</strong>https://ok.ru/privacypolicy#cmpnoscreen
           </a>
         </p>
-        {/*  */}
         <h3>{t("legal.dataPrivacy.trackers.header")}</h3>
-        {/*  */}
         <h4>{t("legal.dataPrivacy.trackers.google.header")}</h4>
         <h6>{t("legal.dataPrivacy.trackers.google.description.header")}</h6>
         <p>{t("legal.dataPrivacy.trackers.google.description.para1")}</p>
@@ -216,9 +210,7 @@ function DataPrivacy() {
         <p>{t("legal.dataPrivacy.trackers.google.duration.para")}</p>
         <h6>{t("legal.dataPrivacy.trackers.google.possibility.header")}</h6>
         <p>{t("legal.dataPrivacy.trackers.google.possibility.para")}</p>
-        {/*  */}
         <h3>{t("legal.dataPrivacy.tools.header")}</h3>
-        {/*  */}
         <h4>{t("legal.dataPrivacy.tools.google.header")}</h4>
         <h6>{t("legal.dataPrivacy.tools.google.description.header")}</h6>
         <p>{t("legal.dataPrivacy.tools.google.description.para1")}</p>
@@ -237,7 +229,6 @@ function DataPrivacy() {
         <h6>{t("legal.dataPrivacy.tools.google.possibility.header")}</h6>
         <p>{t("legal.dataPrivacy.tools.google.possibility.para1")}</p>
         <p>{t("legal.dataPrivacy.tools.google.possibility.para2")}</p>
-        {/*  */}
         <h4>{t("legal.dataPrivacy.tools.font.header")}</h4>
         <h6>{t("legal.dataPrivacy.tools.font.description.header")}</h6>
         <p>{t("legal.dataPrivacy.tools.font.description.para1")}</p>
@@ -272,7 +263,6 @@ function DataPrivacy() {
           </a>
           <span>{t("legal.dataPrivacy.tools.font.possibility.para22")}</span>
         </p>
-        {/*  */}
         <h3>{t("legal.dataPrivacy.transfer.header")}</h3>
         <p>{t("legal.dataPrivacy.transfer.para1")}</p>
         <p>
@@ -307,10 +297,8 @@ function DataPrivacy() {
           </strong>
           <span>{t("legal.dataPrivacy.transfer.bold4Text")}</span>
         </p>
-        {/*  */}
         <h3>{t("legal.dataPrivacy.rights.header")}</h3>
         <p>{t("legal.dataPrivacy.rights.para")}</p>
-        {/*  */}
         <h4>{t("legal.dataPrivacy.rights.revoke.header")}</h4>
         <p>{t("legal.dataPrivacy.rights.revoke.para")}</p>
         <h4>{t("legal.dataPrivacy.rights.information.header")}</h4>
@@ -325,7 +313,6 @@ function DataPrivacy() {
           <li>{t("legal.dataPrivacy.rights.information.bullet7")}</li>
           <li>{t("legal.dataPrivacy.rights.information.bullet8")}</li>
         </ul>
-        {/*  */}
         <h4>{t("legal.dataPrivacy.rights.correction.header")}</h4>
         <p>{t("legal.dataPrivacy.rights.correction.para1")}</p>
         <p>{t("legal.dataPrivacy.rights.correction.para2")}</p>
@@ -352,7 +339,6 @@ function DataPrivacy() {
           <li>{t("legal.dataPrivacy.rights.correction.bullet10")}</li>
           <li>{t("legal.dataPrivacy.rights.correction.bullet11")}</li>
         </ul>
-        {/*  */}
         <h4>{t("legal.dataPrivacy.rights.restriction.header")}</h4>
         <p>{t("legal.dataPrivacy.rights.restriction.para1")}</p>
         <ul>
@@ -363,11 +349,9 @@ function DataPrivacy() {
         </ul>
         <p>{t("legal.dataPrivacy.rights.restriction.para2")}</p>
         <p>{t("legal.dataPrivacy.rights.restriction.para3")}</p>
-        {/*  */}
         <h4>{t("legal.dataPrivacy.rights.information2.header")}</h4>
         <p>{t("legal.dataPrivacy.rights.information2.para1")}</p>
         <p>{t("legal.dataPrivacy.rights.information2.para2")}</p>
-        {/*  */}
         <h4>{t("legal.dataPrivacy.rights.portability.header")}</h4>
         <p>{t("legal.dataPrivacy.rights.portability.para1")}</p>
         <ul>
@@ -376,15 +360,12 @@ function DataPrivacy() {
         </ul>
         <p>{t("legal.dataPrivacy.rights.portability.para2")}</p>
         <p>{t("legal.dataPrivacy.rights.portability.para3")}</p>
-        {/*  */}
         <h4>{t("legal.dataPrivacy.rights.object.header")}</h4>
         <p>{t("legal.dataPrivacy.rights.object.para1")}</p>
         <p>{t("legal.dataPrivacy.rights.object.para2")}</p>
-        {/*  */}
         <h4>{t("legal.dataPrivacy.rights.complain.header")}</h4>
         <p>{t("legal.dataPrivacy.rights.complain.para1")}</p>
         <p>{t("legal.dataPrivacy.rights.complain.para2")}</p>
-        {/*  */}
         <h3>{t("legal.dataPrivacy.excercise.header")}</h3>
         <p>{t("legal.dataPrivacy.excercise.para1")}</p>
         <p>Kemal Webersohn von der WS Datenschutz GmbH</p>
@@ -395,10 +376,9 @@ function DataPrivacy() {
         </p>
         <p>{t("legal:dataPrivacy:excercise.para2")}</p>
         <p>WS Datenschutz GmbH</p>
-        <p>Dircksenstraße 51</p>
+        <p>DircksenstraÃŸe 51</p>
         <p>D-10178 Berlin</p>
 
-        {/*  */}
         <h3>{t("legal.dataPrivacy.change.header")}</h3>
         <p>{t("legal.dataPrivacy.change.para1")}</p>
         <p>{t("legal.dataPrivacy.change.para2")}</p>

--- a/src/components/Website/Landing/Landing.tsx
+++ b/src/components/Website/Landing/Landing.tsx
@@ -30,13 +30,11 @@ export function Landing({ lang }: { lang: Lang }) {
       />
       <Hero />
       <VolunteeringCategoriesSection />
-      {/* Transferred Components */}
       <VolunteeringOpportunitiesSection />
       <EventsSection />
       <TestimonialsSection lang={lang} />
       <ProcessStepsSection />
       <RacSection />
-      {/* Render the existing component like the previous */}
       <FooterPartnersSection />
     </AppContainer>
   );


### PR DESCRIPTION
Closes #280

Removes commented-out code leftovers flagged in the issue. No behaviour change.

Changes:
- OrganisationDetails: remove unused /* isPending */ comment from destructuring
- DataPrivacy: remove 20 empty {/*  */} placeholder comment lines
- Landing: remove two stale section label comments

How to test:
All pages render identically. Run tsc and lint to confirm no regressions.