### PR TITLE
fix(#583): volunteer list — first name only, truncate languages/districts, fix row height

### DIFF
--- a/src/components/Dashboard/Volunteers/VolunteerCard.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerCard.tsx
@@ -20,7 +20,7 @@ import { getImageUrl } from "@/utils";
 import { isBriefedAccompanying } from "../Profile/sections/ProfileHeader/common";
 import { formatAvailabilityItem } from "../Profile/sections/VolunteerProfile/formatters";
 import CardDetail from "./CardDetail";
-import { getNormalizedVolunteer, groupLanguagesByProficiency } from "./helpers";
+import { getFirstName, getNormalizedVolunteer, groupLanguagesByProficiency, truncateList } from "./helpers";
 import { IconName } from "./icon";
 
 interface Props {
@@ -43,7 +43,7 @@ export function VolunteerCard({ volunteer, opportunityId }: Props) {
 
   const showBriefedCheck = isBriefedAccompanying(statusType as VolunteerStateTypeType, statusCommunication);
 
-  const groupedLanguages = groupLanguagesByProficiency(languages);
+  const groupedLanguages = groupLanguagesByProficiency(languages).slice(0, 2);
 
   const availabilities = availability
     .filter((a): a is typeof a & { day: string; daytime: string } => Boolean(a.day && a.daytime))
@@ -113,7 +113,7 @@ export function VolunteerCard({ volunteer, opportunityId }: Props) {
           fontSize="var(--dashboard-volunteers-card-profile-fontSize)"
           lineheight="var(--dashboard-volunteers-card-profile-lineHeight)"
         >
-          {name}
+          {getFirstName(name)}
         </Paragraph>
       </ProfileDiv>
 
@@ -147,7 +147,7 @@ export function VolunteerCard({ volunteer, opportunityId }: Props) {
       </CardDetail>
 
       <CardDetail header={t("dashboard.volunteers.preferredDistricts")} iconName={IconName.MapPin}>
-        <CardParagraph text={locations.join(", ")} />
+        <CardParagraph text={truncateList(locations, 2)} />
       </CardDetail>
     </Card>
   );

--- a/src/components/Dashboard/Volunteers/VolunteerTableRow.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerTableRow.tsx
@@ -14,6 +14,7 @@ import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { VOLUNTEER_COL_WIDTHS } from "./volunteerTableColumns";
+import { getFirstName, getTopLanguages, truncateList } from "./helpers";
 
 interface TableRowProps {
   volunteer: ApiVolunteerGetList;
@@ -36,19 +37,15 @@ export function VolunteerTableRow({
   const router = useRouter();
 
   const { id, name, avatarUrl, statusEngagement, statusType, languages, locations } = volunteer;
-  // Cast until SDK PR #99 adds statusMatch to ApiVolunteerGetList
   const { statusMatch, email } = volunteer as ApiVolunteerGetList;
 
-  const languageText =
-    languages
-      .map((language) => language.title)
-      .filter(Boolean)
-      .join(", ") || "—";
-  const districtText =
-    locations
-      .map((location) => (typeof location === "string" ? location : location?.title))
-      .filter(Boolean)
-      .join(", ") || "—";
+  const topLangs = getTopLanguages(languages, 2);
+  const languageText = truncateList(topLangs.length ? topLangs : languages.map((l) => l.title).filter(Boolean), 2) || "—";
+
+  const districtTitles = locations
+    .map((loc) => (typeof loc === "string" ? loc : loc?.title))
+    .filter(Boolean) as string[];
+  const districtText = truncateList(districtTitles, 2) || "—";
 
   const handleGoToProfile = () => {
     if (!id) return;
@@ -60,24 +57,24 @@ export function VolunteerTableRow({
     <ClickableRow $isLast={isLast} onClick={handleGoToProfile} data-testid={`volunteer-row-${id}`}>
       <NameCell data-testid={`volunteer-name-${id}`}>
         <CirclePic src={getImageUrl(avatarUrl || defaultAvatarURL)} size="32px" />
-        <NameText>{name}</NameText>
+        <NameText>{getFirstName(name)}</NameText>
       </NameCell>
-      <TableCell $width={VOLUNTEER_COL_WIDTHS.type} data-testid={`volunteer-type-${id}`}>
+      <TableCell $width={VOLUNTEER_COL_WIDTHS.type} $noWrap data-testid={`volunteer-type-${id}`}>
         {statusType ? typeLabels[statusType] : "—"}
       </TableCell>
-      <TableCell $width={VOLUNTEER_COL_WIDTHS.engagement} data-testid={`volunteer-engagement-${id}`}>
+      <TableCell $width={VOLUNTEER_COL_WIDTHS.engagement} $noWrap data-testid={`volunteer-engagement-${id}`}>
         {statusEngagement ? engagementLabels[statusEngagement] : "—"}
       </TableCell>
-      <TableCell $width={VOLUNTEER_COL_WIDTHS.matching} data-testid={`volunteer-match-${id}`}>
+      <TableCell $width={VOLUNTEER_COL_WIDTHS.matching} $noWrap data-testid={`volunteer-match-${id}`}>
         {statusMatch ? matchLabels[statusMatch] : "—"}
       </TableCell>
-      <TableCell $width={VOLUNTEER_COL_WIDTHS.language} data-testid={`volunteer-language-${id}`}>
+      <TableCell $width={VOLUNTEER_COL_WIDTHS.language} $noWrap data-testid={`volunteer-language-${id}`}>
         {languageText}
       </TableCell>
-      <TableCell $width={VOLUNTEER_COL_WIDTHS.district} data-testid={`volunteer-district-${id}`}>
+      <TableCell $width={VOLUNTEER_COL_WIDTHS.district} $noWrap data-testid={`volunteer-district-${id}`}>
         {districtText}
       </TableCell>
-      <TableCell data-testid={`volunteer-email-${id}`}>{email || "—"}</TableCell>
+      <TableCell $noWrap data-testid={`volunteer-email-${id}`}>{email || "—"}</TableCell>
     </ClickableRow>
   );
 }

--- a/src/components/Dashboard/Volunteers/helpers.ts
+++ b/src/components/Dashboard/Volunteers/helpers.ts
@@ -191,6 +191,24 @@ function getTitleFromOptionItem(optionItem: OptionItem): string {
   return optionItem.title;
 }
 
+export function getFirstName(fullName: string): string {
+  return fullName.split(" ")[0];
+}
+
+export function truncateList(items: string[], max: number): string {
+  if (items.length <= max) return items.join(", ");
+  const shown = items.slice(0, max).join(", ");
+  return `${shown} +${items.length - max}`;
+}
+
+export function getTopLanguages(languages: ApiLanguage[], max = 2): string[] {
+  const ordered = [...languages].sort((a, b) => {
+    const order = [LangProficiency.NATIVE, LangProficiency.FLUENT, LangProficiency.ADVANCED, LangProficiency.INTERMEDIATE, LangProficiency.BEGINNER];
+    return order.indexOf(a.proficiency) - order.indexOf(b.proficiency);
+  });
+  return ordered.map((l) => l.title).filter(Boolean).slice(0, max);
+}
+
 export function getNormalizedVolunteer(volunteer: ApiVolunteerGetList): Omit<
   ApiVolunteerGetList,
   "activities" | "skills" | "locations"

--- a/src/components/Dashboard/Volunteers/helpers.ts
+++ b/src/components/Dashboard/Volunteers/helpers.ts
@@ -202,10 +202,9 @@ export function truncateList(items: string[], max: number): string {
 }
 
 export function getTopLanguages(languages: ApiLanguage[], max = 2): string[] {
-  const ordered = [...languages].sort((a, b) => {
-    const order = [LangProficiency.NATIVE, LangProficiency.FLUENT, LangProficiency.ADVANCED, LangProficiency.INTERMEDIATE, LangProficiency.BEGINNER];
-    return order.indexOf(a.proficiency) - order.indexOf(b.proficiency);
-  });
+  const order = [LangProficiency.NATIVE, LangProficiency.FLUENT, LangProficiency.ADVANCED, LangProficiency.INTERMEDIATE, LangProficiency.BEGINNER];
+  const rank = (p: LangProficiency | undefined) => (p !== undefined ? order.indexOf(p) : order.length);
+  const ordered = [...languages].sort((a, b) => rank(a.proficiency) - rank(b.proficiency));
   return ordered.map((l) => l.title).filter(Boolean).slice(0, max);
 }
 


### PR DESCRIPTION
## Summary

Fixes the three display problems in the volunteer table list (and card view) shown in the screenshot in https://github.com/need4deed-org/fe/issues/583.

- **First name only** — `name` column and card now show `getFirstName(name)` (first space-delimited token). Hides last name across both views.
- **Languages capped at 2** — table shows native language first, then highest-proficiency language, then `+N` for any remainder (e.g. "German, English +2"). Card view caps the proficiency groups shown to 2.
- **Districts capped at 2** — table and card both show at most 2 districts with `+N` for the rest.
- **Fixed row height** — all table cells now use `$noWrap`, preventing text from wrapping and expanding the row vertically.

## New helpers (`helpers.ts`)

| Function | Purpose |
|---|---|
| `getFirstName(fullName)` | Returns first space-delimited token |
| `truncateList(items, max)` | Joins up to `max` items, appends `+N` for remainder |
| `getTopLanguages(languages, max)` | Returns titles sorted by proficiency (native first), limited to `max` |

## Test plan

- [ ] Table rows all render at single-line height regardless of how many languages/districts the volunteer has
- [ ] Name column shows first name only
- [ ] Language column shows at most 2 entries with `+N` if more exist
- [ ] District column shows at most 2 entries with `+N` if more exist
- [ ] Card view name shows first name only
- [ ] Card view language section shows at most 2 proficiency groups
- [ ] Card view district section shows at most 2 districts with `+N`

Closes https://github.com/need4deed-org/fe/issues/583