### PR TITLE
fix(#586): volunteer card — cap all multi-value fields at 2 with +N overflow

### DIFF
--- a/src/components/Dashboard/Volunteers/VolunteerCard.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerCard.tsx
@@ -20,7 +20,7 @@ import { getImageUrl } from "@/utils";
 import { isBriefedAccompanying } from "../Profile/sections/ProfileHeader/common";
 import { formatAvailabilityItem } from "../Profile/sections/VolunteerProfile/formatters";
 import CardDetail from "./CardDetail";
-import { getFirstName, getNormalizedVolunteer, groupLanguagesByProficiency, truncateList } from "./helpers";
+import { getFirstName, getTopLanguages, getNormalizedVolunteer, truncateList } from "./helpers";
 import { IconName } from "./icon";
 
 interface Props {
@@ -43,11 +43,16 @@ export function VolunteerCard({ volunteer, opportunityId }: Props) {
 
   const showBriefedCheck = isBriefedAccompanying(statusType as VolunteerStateTypeType, statusCommunication);
 
-  const groupedLanguages = groupLanguagesByProficiency(languages).slice(0, 2);
+  const MAX_CARD_ITEMS = 2;
 
-  const availabilities = availability
+  const topLanguages = getTopLanguages(languages, MAX_CARD_ITEMS);
+  const languageOverflow = languages.length - topLanguages.length;
+
+  const allAvailabilities = availability
     .filter((a): a is typeof a & { day: string; daytime: string } => Boolean(a.day && a.daytime))
     .map((a) => formatAvailabilityItem(a.day, a.daytime, t));
+  const availabilities = allAvailabilities.slice(0, MAX_CARD_ITEMS);
+  const availabilityOverflow = allAvailabilities.length - availabilities.length;
 
   const handleCardClick = () => {
     if (!id) return;
@@ -118,16 +123,13 @@ export function VolunteerCard({ volunteer, opportunityId }: Props) {
       </ProfileDiv>
 
       <CardDetail header={t("dashboard.volunteers.languages")} iconName={IconName.Translate}>
-        {groupedLanguages.map(({ proficiency, list }) => (
-          <LanguageDetailContainer key={proficiency}>
-            <CardParagraph text={`${t(`dashboard.volunteers.langProficiency.${proficiency}`)}:`} isBold />
-            <CardParagraph text={`${list.join(", ")}`} />
-          </LanguageDetailContainer>
-        ))}
+        <CardParagraph
+          text={topLanguages.join(", ") + (languageOverflow > 0 ? ` +${languageOverflow}` : "") || "—"}
+        />
       </CardDetail>
 
       <CardDetail header={t("dashboard.volunteers.activities")} iconName={IconName.ShootingStar}>
-        <Tags tags={activities as unknown as string[]} />
+        <Tags tags={activities as unknown as string[]} max={MAX_CARD_ITEMS} />
       </CardDetail>
 
       <CardDetail header={t("dashboard.volunteers.skillsExperience")} iconName={IconName.Wrench}>
@@ -135,6 +137,7 @@ export function VolunteerCard({ volunteer, opportunityId }: Props) {
           tags={skills as unknown as string[]}
           backgroundColor="var(--color-white)"
           icon={<CheckIcon size={18} />}
+          max={MAX_CARD_ITEMS}
         />
       </CardDetail>
 
@@ -144,10 +147,11 @@ export function VolunteerCard({ volunteer, opportunityId }: Props) {
             <CardParagraph text={a} />
           </LanguageDetailContainer>
         ))}
+        {availabilityOverflow > 0 && <CardParagraph text={`+${availabilityOverflow}`} />}
       </CardDetail>
 
       <CardDetail header={t("dashboard.volunteers.preferredDistricts")} iconName={IconName.MapPin}>
-        <CardParagraph text={truncateList(locations, 2)} />
+        <CardParagraph text={truncateList(locations, MAX_CARD_ITEMS) || "—"} />
       </CardDetail>
     </Card>
   );

--- a/src/components/Dashboard/Volunteers/helpers.ts
+++ b/src/components/Dashboard/Volunteers/helpers.ts
@@ -197,15 +197,17 @@ export function getFirstName(fullName: string): string {
 
 export function truncateList(items: string[], max: number): string {
   if (items.length <= max) return items.join(", ");
-  const shown = items.slice(0, max).join(", ");
-  return `${shown} +${items.length - max}`;
+  return `${items.slice(0, max).join(", ")} +${items.length - max}`;
 }
 
 export function getTopLanguages(languages: ApiLanguage[], max = 2): string[] {
   const order = [LangProficiency.NATIVE, LangProficiency.FLUENT, LangProficiency.ADVANCED, LangProficiency.INTERMEDIATE, LangProficiency.BEGINNER];
   const rank = (p: LangProficiency | undefined) => (p !== undefined ? order.indexOf(p) : order.length);
-  const ordered = [...languages].sort((a, b) => rank(a.proficiency) - rank(b.proficiency));
-  return ordered.map((l) => l.title).filter(Boolean).slice(0, max);
+  return [...languages]
+    .sort((a, b) => rank(a.proficiency) - rank(b.proficiency))
+    .map((l) => l.title)
+    .filter(Boolean)
+    .slice(0, max);
 }
 
 export function getNormalizedVolunteer(volunteer: ApiVolunteerGetList): Omit<

--- a/src/components/core/common/Tags.tsx
+++ b/src/components/core/common/Tags.tsx
@@ -7,6 +7,7 @@ interface Props {
   tags: string[];
   backgroundColor?: TagBackgroundKeys;
   icon?: ReactNode;
+  max?: number;
 }
 
 const defaultBGColor = "var(--color-papaya)";
@@ -21,15 +22,22 @@ const bgTextColorMap = {
 
 type TagBackgroundKeys = keyof typeof bgTextColorMap;
 
-export function Tags({ tags, backgroundColor = defaultBGColor, icon }: Props) {
+export function Tags({ tags, backgroundColor = defaultBGColor, icon, max }: Props) {
+  const filtered = tags.filter(Boolean);
+  const shown = max !== undefined ? filtered.slice(0, max) : filtered;
+  const overflow = max !== undefined ? filtered.length - max : 0;
+
   return (
     <TagsContainer>
-      {tags.filter(Boolean).map((tag) => (
+      {shown.map((tag) => (
         <Tag key={tag} $backgroundColor={backgroundColor}>
           {icon}
           <ActivitySpan color={bgTextColorMap[backgroundColor]}>{tag}</ActivitySpan>
         </Tag>
       ))}
+      {overflow > 0 && (
+        <OverflowTag>+{overflow}</OverflowTag>
+      )}
     </TagsContainer>
   );
 }
@@ -37,6 +45,18 @@ export function Tags({ tags, backgroundColor = defaultBGColor, icon }: Props) {
 export default Tags;
 
 /** Styles */
+const OverflowTag = styled.span`
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--dashboard-volunteers-card-paragraph-fontSize, 0.875rem);
+  font-weight: 600;
+  color: var(--color-midnight);
+  padding: 4px 8px;
+  border-radius: 4px;
+  background: var(--color-grey-100, #f3f4f6);
+  white-space: nowrap;
+`;
+
 export const TagsContainer = styled.div`
   display: flex;
   width: fit-content;


### PR DESCRIPTION
## Summary

Fixes https://github.com/need4deed-org/fe/issues/586. Every multi-value field on the volunteer card is now capped at 2 items, making all cards a consistent height.

| Field | Before | After |
|---|---|---|
| Languages | All entries grouped by proficiency | Top 2 (native first) + `+N` |
| Activities | All tags | First 2 tags + `+N` |
| Skills | All tags | First 2 tags + `+N` |
| Availability | All time slots | First 2 slots + `+N` |
| Districts | All districts | First 2 + `+N` |
| Name | Full name | First name only |

## Changes

**`Tags.tsx`** — added `max?: number` prop. When set, shows the first `max` tags and renders an `OverflowTag` badge (`+N`) for the remainder.

**`helpers.ts`** — added `getFirstName`, `truncateList`, `getTopLanguages` utilities.

**`VolunteerCard.tsx`** — all five sections updated to use the cap. Languages flattened and sorted by proficiency before slicing. `MAX_CARD_ITEMS = 2` constant defined once.

## Test plan

- [ ] Cards with many activities show only 2 tags + `+N`
- [ ] Cards with many skills show only 2 tags + `+N`
- [ ] Languages show at most 2 (native language first)
- [ ] Availability shows at most 2 slots
- [ ] Districts show at most 2
- [ ] Name shows first name only
- [ ] Cards with ≤2 items in each field show no `+N`
- [ ] All cards render at consistent height