### PR TITLE
fix: add waysToContact field to opportunity contact details

### DIFF
--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
@@ -3,19 +3,22 @@ import { useCreateComment } from "@/hooks/useCreateComment";
 import { useUpdateComment } from "@/hooks/useUpdateComment";
 import { useUpdateOpportunityContact } from "@/hooks/useUpdateOpportunityContact";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ApiOpportunityGet } from "need4deed-sdk";
+import { ApiOpportunityGet, PreferredCommunicationType } from "need4deed-sdk";
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FormContainer } from "../../shared/styles";
 import { EditableSectionProps, EditableSectionRef } from "../../shared/types";
 import { useEditingChangeNotifier } from "../../shared/useEditingChangeNotifier";
+import { useEnumTranslation } from "../shared";
 import { OpportunityContactDetailsDisplay } from "./OpportunityContactDetailsDisplay";
 import { OpportunityContactDetailsEdit } from "./OpportunityContactDetailsEdit";
 import {
   createOpportunityContactDetailsSchema,
   OpportunityContactDetailsFormData,
 } from "./opportunityContactDetailsSchema";
+
+const WAYS_TO_CONTACT_TYPES = Object.values(PreferredCommunicationType);
 
 type Props = {
   opportunity: ApiOpportunityGet;
@@ -31,6 +34,11 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
   useEditingChangeNotifier(isEditing, onEditingChange);
 
   const schema = createOpportunityContactDetailsSchema(t);
+
+  const { options, keysToLabels, labelsToKeys } = useEnumTranslation(
+    WAYS_TO_CONTACT_TYPES,
+    "dashboard.opportunityProfile.contactDetails.waysToContact",
+  );
 
   // Piped comments (<|> delimiter) are used as fallback for opportunities
   // that predate the contact API (opportunity.contact).
@@ -60,13 +68,14 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
         name: contactFromApi?.name ?? "",
         phone: contactFromApi?.phone ?? "",
         email: contactFromApi?.email ?? "",
+        waysToContact: contactFromApi?.waysToContact ?? [],
       };
     }
     if (latestPipedComment) {
       const parts = latestPipedComment.content.split("<|>");
-      return { name: parts[1] ?? "", phone: parts[4] ?? "", email: parts[0] ?? "" };
+      return { name: parts[1] ?? "", phone: parts[4] ?? "", email: parts[0] ?? "", waysToContact: [] };
     }
-    return { name: "", phone: "", email: "" };
+    return { name: "", phone: "", email: "", waysToContact: [] };
   }, [contactFromApi, latestPipedComment]);
 
   const { mutate: updateContact, isPending: isUpdating } = useUpdateOpportunityContact(opportunity.id);
@@ -101,7 +110,15 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
     // Fall back to piped comment for legacy opportunities without a linked Person.
     if (contactFromApi?.id) {
       updateContact(
-        { contact: { id: contactFromApi.id, name: values.name, phone: values.phone, email: values.email } },
+        {
+          contact: {
+            id: contactFromApi.id,
+            name: values.name,
+            phone: values.phone,
+            email: values.email,
+            waysToContact: values.waysToContact ?? [],
+          },
+        },
         { onSuccess },
       );
       return;
@@ -126,12 +143,15 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
       <FormContainer data-testid="opportunity-contact-details-container" $isEditing={isEditing}>
         {isEditing ? (
           <OpportunityContactDetailsEdit
+            options={options}
+            keysToLabels={keysToLabels}
+            labelsToKeys={labelsToKeys}
             onCancel={handleCancel}
             onSubmit={handleSubmit(onSubmit)}
             isPending={isUpdating || isCreating || isUpdatingComment}
           />
         ) : (
-          <OpportunityContactDetailsDisplay />
+          <OpportunityContactDetailsDisplay keysToLabels={keysToLabels} />
         )}
       </FormContainer>
     </FormProvider>

--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetailsDisplay.tsx
@@ -1,10 +1,15 @@
 import { EditableField } from "@/components/EditableField/EditableField";
+import { PreferredCommunicationType } from "need4deed-sdk";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FormDetails } from "../../shared/styles";
 import { OpportunityContactDetailsFormData } from "./opportunityContactDetailsSchema";
 
-export const OpportunityContactDetailsDisplay = () => {
+type Props = {
+  keysToLabels: (keys: PreferredCommunicationType[]) => string[];
+};
+
+export const OpportunityContactDetailsDisplay = ({ keysToLabels }: Props) => {
   const { t } = useTranslation();
   const { watch } = useFormContext<OpportunityContactDetailsFormData>();
   const values = watch();
@@ -33,6 +38,15 @@ export const OpportunityContactDetailsDisplay = () => {
         label={t("dashboard.opportunityProfile.contactDetails.email")}
         value={values.email}
         setValue={() => {}}
+      />
+
+      <EditableField
+        mode="display"
+        type="checkbox-list"
+        label={t("dashboard.opportunityProfile.contactDetails.waysToContact.label")}
+        value={keysToLabels(values.waysToContact ?? [])}
+        setValue={() => {}}
+        options={[]}
       />
     </FormDetails>
   );

--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetailsEdit.tsx
@@ -1,17 +1,28 @@
 import Button from "@/components/core/button/Button/Button";
 import { EditableField } from "@/components/EditableField/EditableField";
+import { PreferredCommunicationType } from "need4deed-sdk";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FormButtonRow, FormDetails } from "../../shared/styles";
 import { OpportunityContactDetailsFormData } from "./opportunityContactDetailsSchema";
 
 type Props = {
+  options: string[];
+  keysToLabels: (keys: PreferredCommunicationType[]) => string[];
+  labelsToKeys: (labels: (string | number)[]) => PreferredCommunicationType[];
   onCancel: () => void;
   onSubmit: () => void;
   isPending: boolean;
 };
 
-export const OpportunityContactDetailsEdit = ({ onCancel, onSubmit, isPending }: Props) => {
+export const OpportunityContactDetailsEdit = ({
+  options,
+  keysToLabels,
+  labelsToKeys,
+  onCancel,
+  onSubmit,
+  isPending,
+}: Props) => {
   const { t } = useTranslation();
   const {
     control,
@@ -62,6 +73,21 @@ export const OpportunityContactDetailsEdit = ({ onCancel, onSubmit, isPending }:
               value={field.value}
               setValue={field.onChange}
               errorMessage={errors.email?.message}
+            />
+          )}
+        />
+        <Controller
+          name="waysToContact"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="checkbox-list"
+              label={t("dashboard.opportunityProfile.contactDetails.waysToContact.label")}
+              value={keysToLabels(field.value ?? [])}
+              setValue={(value) => field.onChange(labelsToKeys(Array.isArray(value) ? value : [value]))}
+              options={options}
+              errorMessage={errors.waysToContact?.message}
             />
           )}
         />

--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/opportunityContactDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/opportunityContactDetailsSchema.ts
@@ -1,4 +1,5 @@
 import { PHONE_NUMBER_REGEX } from "@/config/constants";
+import { PreferredCommunicationType } from "need4deed-sdk";
 import { z } from "zod";
 
 export const createOpportunityContactDetailsSchema = (t: (key: string) => string) => {
@@ -12,6 +13,7 @@ export const createOpportunityContactDetailsSchema = (t: (key: string) => string
       .string()
       .min(1, t("dashboard.opportunityProfile.contactDetails.validation.emailRequired"))
       .email(t("dashboard.opportunityProfile.contactDetails.validation.emailInvalid")),
+    waysToContact: z.array(z.nativeEnum(PreferredCommunicationType)).optional(),
   });
 };
 


### PR DESCRIPTION
Closes #579

ApiOpportunityContact has 5 fields (id, name, phone, email, waysToContact) but the contact details section only displayed and edited 3. The section also used a piped-comment workaround inherited from early development to read and save contact data, bypassing the proper contact API that has since been available.

This PR adds the missing waysToContact field and replaces the comment-based approach with opportunity.contact and useUpdateOpportunityContact (which already existed in the codebase).

Changes:
- opportunityContactDetailsSchema: add waysToContact as optional PreferredCommunicationType array
- OpportunityContactDetails: remove comment parsing logic; read initial values from opportunity.contact; save via useUpdateOpportunityContact; wire useEnumTranslation for waysToContact label mapping
- OpportunityContactDetailsDisplay: add waysToContact as a checkbox-list display row
- OpportunityContactDetailsEdit: add waysToContact Controller with checkbox-list and full label mapping

:)