### PR TITLE
perf(volunteers): send listType so backend loads only needed relations

### DIFF
--- a/src/components/Dashboard/Volunteers/VolunteerListController.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerListController.tsx
@@ -44,6 +44,9 @@ export function VolunteerListController({
     limit,
     page: currentPage,
     sortOrder,
+    // Table renders only languages + locations; card renders all collections.
+    // Tell the backend so it loads (and returns) only the needed relations.
+    listType: isListView ? "table" : "card",
     filter: serializedFilter,
   };
   const { data, count, isLoading } = useGetQuery<ApiVolunteerGetList[]>({


### PR DESCRIPTION
## What

`VolunteerListController` now sends `listType` on `GET /volunteer`:
- table view → `listType=table`
- card view → `listType=card`

The backend uses this to load (and return) only the relations each view renders — the table needs just languages + locations, so it no longer over-fetches activities/skills/availability.

## Why

Part of the `GET /volunteer` performance fix (was ~18-20s). Backend: need4deed-org/be#634.

## ⚠️ Deploy ordering

Requires **be#634 to be deployed first** — that backend's query schema uses `additionalProperties: false`, so an old backend would reject the `listType` param with a 400. Once be#634 is live, `listType` defaults to `card` server-side if absent, so there's no hard coupling beyond ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)