### PR TITLE
fix: read opportunity contact from BE response instead of piped comment

### DIFF
--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCreateComment } from "@/hooks/useCreateComment";
 import { useUpdateComment } from "@/hooks/useUpdateComment";
+import { useUpdateOpportunityContact } from "@/hooks/useUpdateOpportunityContact";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ApiOpportunityGet } from "need4deed-sdk";
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from "react";
@@ -31,8 +32,8 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
 
   const schema = createOpportunityContactDetailsSchema(t);
 
-  // All comments that use the <|> delimiter (structural: 5+ parts) sorted oldest-first.
-  // The oldest is the system comment from the public form; any newer one is a coordinator override.
+  // Piped comments (<|> delimiter) are used as fallback for opportunities
+  // that predate the contact API (opportunity.contact).
   const pipedComments = useMemo(
     () =>
       [...opportunity.comments]
@@ -41,32 +42,40 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
     [opportunity.comments],
   );
 
-  // The most recent <|> comment is the active contact data.
   const latestPipedComment = pipedComments.at(-1);
-
-  // When 2+ <|> comments exist the newest is the coordinator's override — PATCH it on save.
-  // When only 1 exists (system comment) POST a new comment instead.
   const coordinatorCommentId = pipedComments.length > 1 ? (pipedComments.at(-1)?.id ?? null) : null;
-
-  // Preserve address/plz from the original system comment so they survive coordinator edits.
   const originalParts = (pipedComments[0]?.content ?? "").split("<|>");
   const originalAddress = originalParts[2] ?? "";
   const originalPlz = originalParts[3] ?? "";
 
-  const { mutate: createComment, isPending: isCreating } = useCreateComment(opportunity.id, "opportunity");
-  const { mutate: updateComment, isPending: isUpdating } = useUpdateComment(
-    opportunity.id,
-    coordinatorCommentId ?? 0,
-    "opportunity",
-  );
+  // opportunity.contact is provided by the BE for all opportunities since the
+  // contact API was introduced. Use it as the primary source; fall back to the
+  // piped comment for older opportunities that have no contact Person linked.
+  const contactFromApi = opportunity.contact;
+  const hasApiContact = !!(contactFromApi?.name || contactFromApi?.phone || contactFromApi?.email);
 
-  const initialFormValues = useMemo(() => {
+  const initialFormValues = useMemo((): OpportunityContactDetailsFormData => {
+    if (hasApiContact) {
+      return {
+        name: contactFromApi?.name ?? "",
+        phone: contactFromApi?.phone ?? "",
+        email: contactFromApi?.email ?? "",
+      };
+    }
     if (latestPipedComment) {
       const parts = latestPipedComment.content.split("<|>");
       return { name: parts[1] ?? "", phone: parts[4] ?? "", email: parts[0] ?? "" };
     }
     return { name: "", phone: "", email: "" };
-  }, [latestPipedComment]);
+  }, [hasApiContact, contactFromApi, latestPipedComment]);
+
+  const { mutate: updateContact, isPending: isUpdating } = useUpdateOpportunityContact(opportunity.id);
+  const { mutate: createComment, isPending: isCreating } = useCreateComment(opportunity.id, "opportunity");
+  const { mutate: updateComment, isPending: isUpdatingComment } = useUpdateComment(
+    opportunity.id,
+    coordinatorCommentId ?? 0,
+    "opportunity",
+  );
 
   const methods = useForm<OpportunityContactDetailsFormData>({
     resolver: zodResolver(schema),
@@ -86,9 +95,19 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
   };
 
   const onSubmit = (values: OpportunityContactDetailsFormData) => {
-    const text = `${values.email}<|>${values.name}<|>${originalAddress}<|>${originalPlz}<|>${values.phone}`;
     const onSuccess = () => setIsEditing(false);
 
+    // Use the contact API when a Person is linked (contactFromApi.id exists).
+    // Fall back to piped comment for legacy opportunities without a linked Person.
+    if (contactFromApi?.id) {
+      updateContact(
+        { contact: { id: contactFromApi.id, name: values.name, phone: values.phone, email: values.email } },
+        { onSuccess },
+      );
+      return;
+    }
+
+    const text = `${values.email}<|>${values.name}<|>${originalAddress}<|>${originalPlz}<|>${values.phone}`;
     if (coordinatorCommentId !== null) {
       updateComment({ text }, { onSuccess });
     } else {
@@ -109,7 +128,7 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
           <OpportunityContactDetailsEdit
             onCancel={handleCancel}
             onSubmit={handleSubmit(onSubmit)}
-            isPending={isCreating || isUpdating}
+            isPending={isUpdating || isCreating || isUpdatingComment}
           />
         ) : (
           <OpportunityContactDetailsDisplay />

--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
@@ -67,7 +67,7 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
       return { name: parts[1] ?? "", phone: parts[4] ?? "", email: parts[0] ?? "" };
     }
     return { name: "", phone: "", email: "" };
-  }, [hasApiContact, contactFromApi, latestPipedComment]);
+  }, [contactFromApi, latestPipedComment]);
 
   const { mutate: updateContact, isPending: isUpdating } = useUpdateOpportunityContact(opportunity.id);
   const { mutate: createComment, isPending: isCreating } = useCreateComment(opportunity.id, "opportunity");


### PR DESCRIPTION
## Problem

Since yesterday's deploy, the BE returns `opportunity.contact` (name, phone, email) in the `GET /opportunity/:id` response via `getOpportunityContact()`. The FE was ignoring this field entirely and only reading from piped comments (`<|>` delimiter). Since no piped comments were being written, the contact section showed empty for all opportunities.

## Fix

`OpportunityContactDetails.tsx` now reads contact data in this priority:

1. **`opportunity.contact`** (the BE API field) — used when the BE provides name/phone/email
2. **Piped comment fallback** — for older opportunities that have no linked Person yet

Save also uses priority order:
1. `useUpdateOpportunityContact` (PATCH `/opportunity/:id`) — when `contact.id` exists
2. Piped comment fallback — for legacy opportunities with no linked Person

## Backward compatibility

Opportunities that already have piped comments but no `opportunity.contact` data will continue to show the piped comment data. The new approach activates only when the BE actually provides contact data.