### PR TITLE
🐛 fix(opportunity): source contact details from .contact object

### DIFF
--- a/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/opportunity/OpportunityContactDetails.tsx
@@ -1,6 +1,5 @@
 "use client";
-import { useCreateComment } from "@/hooks/useCreateComment";
-import { useUpdateComment } from "@/hooks/useUpdateComment";
+import { useUpdateOpportunityContact } from "@/hooks/useUpdateOpportunityContact";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ApiOpportunityGet } from "need4deed-sdk";
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from "react";
@@ -31,42 +30,18 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
 
   const schema = createOpportunityContactDetailsSchema(t);
 
-  // All comments that use the <|> delimiter (structural: 5+ parts) sorted oldest-first.
-  // The oldest is the system comment from the public form; any newer one is a coordinator override.
-  const pipedComments = useMemo(
-    () =>
-      [...opportunity.comments]
-        .filter((c) => c.content.split("<|>").length >= 5)
-        .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()),
-    [opportunity.comments],
+  const { contact } = opportunity;
+
+  const { mutate: updateContact, isPending } = useUpdateOpportunityContact(opportunity.id);
+
+  const initialFormValues = useMemo(
+    (): OpportunityContactDetailsFormData => ({
+      name: contact?.name ?? "",
+      phone: contact?.phone ?? "",
+      email: contact?.email ?? "",
+    }),
+    [contact],
   );
-
-  // The most recent <|> comment is the active contact data.
-  const latestPipedComment = pipedComments.at(-1);
-
-  // When 2+ <|> comments exist the newest is the coordinator's override — PATCH it on save.
-  // When only 1 exists (system comment) POST a new comment instead.
-  const coordinatorCommentId = pipedComments.length > 1 ? (pipedComments.at(-1)?.id ?? null) : null;
-
-  // Preserve address/plz from the original system comment so they survive coordinator edits.
-  const originalParts = (pipedComments[0]?.content ?? "").split("<|>");
-  const originalAddress = originalParts[2] ?? "";
-  const originalPlz = originalParts[3] ?? "";
-
-  const { mutate: createComment, isPending: isCreating } = useCreateComment(opportunity.id, "opportunity");
-  const { mutate: updateComment, isPending: isUpdating } = useUpdateComment(
-    opportunity.id,
-    coordinatorCommentId ?? 0,
-    "opportunity",
-  );
-
-  const initialFormValues = useMemo(() => {
-    if (latestPipedComment) {
-      const parts = latestPipedComment.content.split("<|>");
-      return { name: parts[1] ?? "", phone: parts[4] ?? "", email: parts[0] ?? "" };
-    }
-    return { name: "", phone: "", email: "" };
-  }, [latestPipedComment]);
 
   const methods = useForm<OpportunityContactDetailsFormData>({
     resolver: zodResolver(schema),
@@ -86,14 +61,23 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
   };
 
   const onSubmit = (values: OpportunityContactDetailsFormData) => {
-    const text = `${values.email}<|>${values.name}<|>${originalAddress}<|>${originalPlz}<|>${values.phone}`;
-    const onSuccess = () => setIsEditing(false);
-
-    if (coordinatorCommentId !== null) {
-      updateComment({ text }, { onSuccess });
-    } else {
-      createComment({ text, entityType: "opportunity", entityId: opportunity.id }, { onSuccess });
-    }
+    updateContact(
+      {
+        contact: {
+          id: contact?.id,
+          name: values.name,
+          phone: values.phone,
+          email: values.email,
+          waysToContact: contact?.waysToContact,
+        },
+      },
+      {
+        onSuccess: () => {
+          reset(values);
+          setIsEditing(false);
+        },
+      },
+    );
   };
 
   useEffect(() => {
@@ -109,7 +93,7 @@ export const OpportunityContactDetails = forwardRef<EditableSectionRef, Props>(f
           <OpportunityContactDetailsEdit
             onCancel={handleCancel}
             onSubmit={handleSubmit(onSubmit)}
-            isPending={isCreating || isUpdating}
+            isPending={isPending}
           />
         ) : (
           <OpportunityContactDetailsDisplay />


### PR DESCRIPTION
## What

`OpportunityContactDetails` now sources contact name/phone/email from the fetched `ApiOpportunityGet.contact` object instead of parsing `<|>`-delimited strings out of the `comments` array.

## Why

The opportunity GET response already exposes a proper `contact` object (`{ id, name, phone, email, waysToContact }`). The section was ignoring it and instead reverse-engineering the values from a legacy system comment, then saving via comment create/update.

## Changes

- Read initial form values directly from `opportunity.contact`.
- Persist edits through the existing (previously unused) `useUpdateOpportunityContact` hook, which `PATCH`es the opportunity. `contact.id` and `contact.waysToContact` are preserved; only the three edited fields are overwritten.
- Removed all `<|>` comment-parsing logic and the `useCreateComment` / `useUpdateComment` usage from this section. Verified no other reader/writer of the `<|>` delimiter remains in `src/`.

## Checks

- `yarn typecheck` ✅
- `yarn lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)