### PR TITLE
fix: show accompanying activity as inline detail on opportunity card

### DIFF
--- a/src/components/Dashboard/Opportunities/OpportunityCard.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityCard.tsx
@@ -125,11 +125,16 @@ export function OpportunityCard({ opportunity, volunteerId, activitiesList, dist
         )}
       </CardDetail>
 
-      {activityTitles.length > 0 && (
-        <CardDetail header={t("dashboard.volunteers.activities")} iconName={IconName.ShootingStar}>
-          <Tags tags={activityTitles} />
-        </CardDetail>
-      )}
+      {activityTitles.length > 0 &&
+        (isAccompanying ? (
+          <CardDetail header={t("dashboard.opportunities.type.accompanying")} iconName={IconName.PersonSimpleWalk}>
+            <CardParagraph text={activityTitles.join(", ")} />
+          </CardDetail>
+        ) : (
+          <CardDetail header={t("dashboard.volunteers.activities")} iconName={IconName.ShootingStar}>
+            <Tags tags={activityTitles} />
+          </CardDetail>
+        ))}
 
       <CardDetail header={t("dashboard.opportunities.dateOfAppointment")} iconName={IconName.CalendarDots}>
         {scheduleText && <CardParagraph text={scheduleText} />}

--- a/src/components/Dashboard/Volunteers/icon.tsx
+++ b/src/components/Dashboard/Volunteers/icon.tsx
@@ -1,4 +1,11 @@
-import { CalendarDotsIcon, MapPinIcon, ShootingStarIcon, TranslateIcon, WrenchIcon } from "@phosphor-icons/react";
+import {
+  CalendarDotsIcon,
+  MapPinIcon,
+  PersonSimpleWalkIcon,
+  ShootingStarIcon,
+  TranslateIcon,
+  WrenchIcon,
+} from "@phosphor-icons/react";
 import { JSX } from "react";
 
 export enum IconName {
@@ -7,6 +14,7 @@ export enum IconName {
   Wrench = "wrench",
   CalendarDots = "calendarDots",
   MapPin = "mapPin",
+  PersonSimpleWalk = "personSimpleWalk",
 }
 
 type IconMap = {
@@ -19,4 +27,5 @@ export const iconNameMap: IconMap = {
   [IconName.Wrench]: <WrenchIcon />,
   [IconName.CalendarDots]: <CalendarDotsIcon />,
   [IconName.MapPin]: <MapPinIcon />,
+  [IconName.PersonSimpleWalk]: <PersonSimpleWalkIcon />,
 };


### PR DESCRIPTION
Closes #588

On accompanying opportunity cards, the activity name (e.g. "Accompanying to government appointments") was rendering as a full-width orange tag inside the Activities section. Long activity strings break the tag layout, resulting in a single oversized tag that dominates the card body and is redundant with the "Accompanying" badge already shown in the header.

This fix detects when volunteerType is ACCOMPANYING and replaces the Tags block with a plain CardParagraph row, using the same visual style as the Date of Appointment and District rows. Regular (non-accompanying) cards are unchanged.

Changes:
- Added PersonSimpleWalk to the IconName enum and iconNameMap in icon.tsx
- In OpportunityCard.tsx, conditionally render the activity as a CardDetail with CardParagraph text (accompanying) or the existing Tags component (all other types)

