### PR TITLE
fix(#607): rename Agent → NGO in all user-facing dashboard labels

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -447,7 +447,7 @@
         "home": "Startseite",
         "volunteers": "Freiwillige",
         "opportunities": "Möglichkeiten",
-        "agents": "NGOs",
+        "agents": "Einrichtungen/Projekte",
         "racs": "RACs",
         "posts": "Beiträge",
         "calendar": "Kalender",
@@ -664,7 +664,7 @@
       }
     },
     "agents": {
-      "agents": "NGO-Verzeichnis",
+      "agents": "Einrichtungs-/Projektverzeichnis",
       "table": {
         "title": "Name",
         "type": "Typ",
@@ -796,7 +796,7 @@
         "district": "Bezirk",
         "schedule": "Zeitplan",
         "volunteersNeeded": "Anzahl der Freiwilligen",
-        "agentName": "NGO"
+        "agentName": "Einrichtung/Projekt"
       },
 
       "card": {
@@ -961,7 +961,7 @@
       "deleteConfirmText": "\"{{entryType}}\" Anerkennungseintrag wird dauerhaft gelöscht."
     },
     "agentProfile": {
-      "agentProfile": "NGO-Profil",
+      "agentProfile": "Einrichtungs-/Projektprofil",
       "registeredSince": "Registriert seit",
       "engagementStatus": "Engagement-Status",
       "serviceType": "Dienstleistungsart",
@@ -1004,14 +1004,14 @@
         "title": "Engagement-Status ändern",
         "options": {
           "unresponsive": "Nicht erreichbar",
-          "unresponsive_description": "Diese NGO antwortet nicht.",
+          "unresponsive_description": "Diese Einrichtung/dieses Projekt antwortet nicht.",
           "inactive": "Inaktiv",
-          "inactive_description": "Diese NGO arbeitet nicht mehr mit der Organisation zusammen."
+          "inactive_description": "Diese Einrichtung/dieses Projekt arbeitet nicht mehr mit der Organisation zusammen."
         },
         "cancel": "Abbrechen",
         "save": "Speichern"
       },
-      "statusUpdateSuccess": "NGO-Status erfolgreich aktualisiert",
+      "statusUpdateSuccess": "Status der Einrichtung/des Projekts erfolgreich aktualisiert",
       "contactDetails": {
         "title": "Kontaktdaten",
         "fullName": "Name",
@@ -1085,7 +1085,7 @@
       "postedOn": "Veröffentlicht am",
       "currentStatus": "Aktueller Status",
       "matchingStatus": "Matching-Status",
-      "agent": "NGO",
+      "agent": "Einrichtung/Projekt",
       "status": {
         "new": "Neu",
         "active": "Aktiv",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -447,7 +447,7 @@
         "home": "Startseite",
         "volunteers": "Freiwillige",
         "opportunities": "Möglichkeiten",
-        "agents": "Akteure",
+        "agents": "NGOs",
         "racs": "RACs",
         "posts": "Beiträge",
         "calendar": "Kalender",
@@ -664,7 +664,7 @@
       }
     },
     "agents": {
-      "agents": "RAC-Verzeichnis",
+      "agents": "NGO-Verzeichnis",
       "table": {
         "title": "Name",
         "type": "Typ",
@@ -796,7 +796,7 @@
         "district": "Bezirk",
         "schedule": "Zeitplan",
         "volunteersNeeded": "Anzahl der Freiwilligen",
-        "agentName": "Agent"
+        "agentName": "NGO"
       },
 
       "card": {
@@ -961,7 +961,7 @@
       "deleteConfirmText": "\"{{entryType}}\" Anerkennungseintrag wird dauerhaft gelöscht."
     },
     "agentProfile": {
-      "agentProfile": "Profil des Agenten",
+      "agentProfile": "NGO-Profil",
       "registeredSince": "Registriert seit",
       "engagementStatus": "Engagement-Status",
       "serviceType": "Dienstleistungsart",
@@ -1004,14 +1004,14 @@
         "title": "Engagement-Status ändern",
         "options": {
           "unresponsive": "Nicht erreichbar",
-          "unresponsive_description": "Dieser Agent antwortet nicht.",
+          "unresponsive_description": "Diese NGO antwortet nicht.",
           "inactive": "Inaktiv",
-          "inactive_description": "Dieser Agent arbeitet nicht mehr mit der Organisation zusammen."
+          "inactive_description": "Diese NGO arbeitet nicht mehr mit der Organisation zusammen."
         },
         "cancel": "Abbrechen",
         "save": "Speichern"
       },
-      "statusUpdateSuccess": "Agent-Status erfolgreich aktualisiert",
+      "statusUpdateSuccess": "NGO-Status erfolgreich aktualisiert",
       "contactDetails": {
         "title": "Kontaktdaten",
         "fullName": "Name",
@@ -1085,7 +1085,7 @@
       "postedOn": "Veröffentlicht am",
       "currentStatus": "Aktueller Status",
       "matchingStatus": "Matching-Status",
-      "agent": "Träger",
+      "agent": "NGO",
       "status": {
         "new": "Neu",
         "active": "Aktiv",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -447,7 +447,7 @@
         "home": "Home",
         "volunteers": "Volunteers",
         "opportunities": "Opportunities",
-        "agents": "Agents",
+        "agents": "NGOs",
         "racs": "RAC's",
         "posts": "Posts",
         "calendar": "Calendar",
@@ -707,7 +707,7 @@
       }
     },
     "agents": {
-      "agents": "RAC Directory",
+      "agents": "NGO Directory",
       "table": {
         "title": "Name",
         "type": "Type",
@@ -839,7 +839,7 @@
         "district": "District",
         "schedule": "Schedule",
         "volunteersNeeded": "Volunteers Needed",
-        "agentName": "Agent"
+        "agentName": "NGO"
       },
       "card": {
         "mainCommunication": "Main communication",
@@ -959,7 +959,7 @@
       "deleteConfirmText": "\"{{entryType}}\" appreciation entry will be permanently deleted."
     },
     "agentProfile": {
-      "agentProfile": "Agent's profile",
+      "agentProfile": "NGO Profile",
       "registeredSince": "Registered since",
       "engagementStatus": "Engagement status",
       "serviceType": "Service Type",
@@ -1002,14 +1002,14 @@
         "title": "Change engagement status",
         "options": {
           "unresponsive": "Unresponsive",
-          "unresponsive_description": "This agent does not respond.",
+          "unresponsive_description": "This NGO does not respond.",
           "inactive": "Inactive",
-          "inactive_description": "This agent does not work with the organization anymore."
+          "inactive_description": "This NGO does not work with the organization anymore."
         },
         "cancel": "Cancel",
         "save": "Save"
       },
-      "statusUpdateSuccess": "Agent status updated successfully",
+      "statusUpdateSuccess": "NGO status updated successfully",
       "contactDetails": {
         "title": "Contact details",
         "fullName": "Name",
@@ -1083,7 +1083,7 @@
       "postedOn": "Posted on",
       "currentStatus": "Current status",
       "matchingStatus": "Matching status",
-      "agent": "Agent",
+      "agent": "NGO",
       "status": {
         "new": "New",
         "active": "Active",


### PR DESCRIPTION
## Summary

Replaces all user-visible occurrences of "Agent" with "NGO" in the dashboard. Translation keys and code identifiers are unchanged — only the displayed strings change.

**English changes:**
- Sidebar nav: `"Agents"` → `"NGOs"`
- NGO directory header: `"RAC Directory"` → `"NGO Directory"`
- Opportunities table column: `"Agent"` → `"NGO"`
- Profile page title: `"Agent's profile"` → `"NGO Profile"`
- Status descriptions: `"This agent does not respond"` → `"This NGO does not respond"` etc.
- Status toast: `"Agent status updated successfully"` → `"NGO status updated successfully"`
- Opportunity profile label: `"Agent"` → `"NGO"`

**German changes:** equivalent updates in `de/translations.json`

Closes https://github.com/need4deed-org/fe/issues/607