### PR TITLE
fix: add 'use client' to new opportunity page

### DIFF
--- a/src/app/[lang]/dashboard/opportunities/new/page.tsx
+++ b/src/app/[lang]/dashboard/opportunities/new/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { DashboardLayout } from "@/components/Layout";
 import { NewOpportunity } from "@/components/Dashboard/NewOpportunity";
 


### PR DESCRIPTION
## Problem

Deploy failed with:

```
NavigationBar.tsx uses usePathname/useRouter which only work in a Client Component.
Import trace: NavigationBar → DashboardLayout → new/page.tsx
```

The new opportunity page (`/dashboard/opportunities/new`) was a server component (no `"use client"`). All other pages using `DashboardLayout` are client components, so `NavigationBar`'s use of `usePathname`/`useRouter` was never an issue before.

## Fix

Add `"use client"` to `src/app/[lang]/dashboard/opportunities/new/page.tsx`.