### PR TITLE
chore(sdk): bump need4deed-sdk to 0.0.99

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "^0.0.95",
+    "need4deed-sdk": "0.0.99",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/src/components/Dashboard/Profile/sections/Comments/common/Autocomplete.tsx
+++ b/src/components/Dashboard/Profile/sections/Comments/common/Autocomplete.tsx
@@ -87,7 +87,7 @@ export default function Autocomplete({
     handleTagAdd(userId, fullName.replaceAll(/ /g, ""));
   };
 
-  const resolvedAvatarUrl = (url: string) => {
+  const resolvedAvatarUrl = (url: string | null | undefined) => {
     return getImageUrl(url || defaultAvatarVolunteerProfile);
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,10 +2412,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@^0.0.95:
-  version "0.0.95"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.95.tgz#5ec9da926e280ca625b91500e849fe8ce85af38e"
-  integrity sha512-/Nefb2VgH/2FOYIuqti23DL2AraQsMWpCOTDH+2myAV3aDgmJsRp+DWNecA0o6nsp40MvuEF2JJVmz+I6opjkA==
+need4deed-sdk@0.0.99:
+  version "0.0.99"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.99.tgz#dfef959872d390ae187e07ce3c4b9d7a3b1bdf29"
+  integrity sha512-OUnQs+cL2ROLuj+NSpUFMJWKXv9XYPWgqQ/3MPaXSv4lUiCuAm6NDnMdXHDZtZLakPAlykvRzm17xssn1VjuZA==
 
 next@15.3.8:
   version "15.3.8"


### PR DESCRIPTION
Aligns the FE with the BE bump (need4deed-org/be#642), so both run `need4deed-sdk@0.0.99`.

0.0.99 widens `ApiUserGet.avatarUrl` to voidable, which surfaced one typecheck error in `Autocomplete.tsx`. Fixed by widening the local `resolvedAvatarUrl(url)` param to `string | null | undefined` — it already falls back to the default avatar, so no behavior change.

Additive SDK change (new `ApiVolunteerOpportunityGet.communication` field on the BE side), so no functional FE change here. `typecheck` clean; `lint` shows only pre-existing `react-hooks/exhaustive-deps` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)