### PR TITLE
guard district abbreviation against empty hyphen parts

### DIFF
--- a/src/components/Dashboard/Volunteers/VolunteerTableRow.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerTableRow.tsx
@@ -62,6 +62,7 @@ export function VolunteerTableRow({
     if (title.includes("-")) {
       const abbreviation = title
         .split("-")
+        .filter((word) => word.trim())
         .map((word) => word.trim()[0])
         .join("-");
       return abbreviation.toUpperCase();


### PR DESCRIPTION
  ## Description
  Follow-up to @nadavosa's review comment on #610. The district abbreviation breaks on a trailing or double hyphen (e.g. `Steglitz-Zehlendorf-`, `Marzahn--Hellersdorf`). The empty part turns into `undefined`, so the abbreviation comes out with a stray dash. This drops the empty parts before mapping

  ## Related Issues
  No issue  addresses @nadavosa's review comment on #610

  ## Changes
  - Filter empty/whitespace-only segments after `split("-")` before mapping to first letters, so trailing/double/leading hyphens no longer produce malformed abbreviations.

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

