### PR TITLE
Agent self-registration wizard + pending-join moderation

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "0.0.99",
+    "need4deed-sdk": "0.0.103",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -762,7 +762,15 @@
       "schedule": "Zeitplan",
       "district": "Stadtviertel",
       "dateOfAppointment": "Termindatum",
-      "description": "Beschreibung"
+      "description": "Beschreibung",
+      "pendingMemberships": {
+        "title": "Ausstehende Beitrittsanfragen ({{count}})",
+        "requestsToJoin": "möchte {{org}} beitreten",
+        "approve": "Genehmigen",
+        "reject": "Ablehnen",
+        "approved": "Beitrittsanfrage genehmigt",
+        "rejected": "Beitrittsanfrage abgelehnt"
+      }
     },
     "opportunities": {
       "opportunities": "Möglichkeiten",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -804,7 +804,6 @@
         "volunteersNeeded": "Anzahl der Freiwilligen",
         "agentName": "Einrichtung/Projekt"
       },
-
       "card": {
         "mainCommunication": "Hauptkommunikation",
         "residentsSpeak": "Bewohner sprechen",
@@ -1912,7 +1911,8 @@
     "errors": {
       "passwordTooShort": "Das Passwort muss mindestens 8 Zeichen lang sein",
       "passwordMismatch": "Die Passwörter stimmen nicht überein",
-      "emailDomainNotAllowed": "Ihre E-Mail-Domain ist nicht auf unserer genehmigten NGO-Liste. Bitte verwenden Sie die E-Mail-Adresse Ihrer Organisation."
+      "emailDomainNotAllowed": "Ihre E-Mail-Domain ist nicht auf unserer genehmigten NGO-Liste. Bitte verwenden Sie die E-Mail-Adresse Ihrer Organisation.",
+      "missingToken": "Dein Registrierungslink ist ungültig oder abgelaufen. Bitte verwende den Link aus deiner Bestätigungs-E-Mail."
     },
     "success": {
       "title": "Registrierung erfolgreich!",
@@ -1928,7 +1928,14 @@
       "matchFound": "Wir haben eine Organisation gefunden, die zu dieser Adresse passt: {{name}}. Möchten Sie diese verwenden?",
       "useThisOrg": "Ja, diese verwenden",
       "skip": "Nein, manuell eingeben",
-      "matched": "Organisation gefunden: {{name}}"
+      "matched": "Organisation gefunden: {{name}}",
+      "titleTaken": "Eine Organisation mit diesem Namen existiert bereits.",
+      "joinInstead": "Stattdessen beitreten",
+      "requestToJoin": "Beitritt anfragen"
+    },
+    "pending": {
+      "title": "Beitrittsanfrage gesendet",
+      "description": "Ein Administrator prüft deine Anfrage, dieser Organisation beizutreten. Nach der Freigabe erhältst du Zugriff."
     }
   }
 }

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -805,7 +805,15 @@
       "schedule": "Schedule",
       "district": "District",
       "dateOfAppointment": "Date Of Appointment",
-      "description": "Description"
+      "description": "Description",
+      "pendingMemberships": {
+        "title": "Pending join requests ({{count}})",
+        "requestsToJoin": "requests to join {{org}}",
+        "approve": "Approve",
+        "reject": "Reject",
+        "approved": "Join request approved",
+        "rejected": "Join request rejected"
+      }
     },
     "opportunities": {
       "opportunities": "Opportunities",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1543,7 +1543,8 @@
     "errors": {
       "passwordTooShort": "Password must be at least 8 characters",
       "passwordMismatch": "Passwords do not match",
-      "emailDomainNotAllowed": "Your email domain is not on our approved NGO list. Please use your organisation email address."
+      "emailDomainNotAllowed": "Your email domain is not on our approved NGO list. Please use your organisation email address.",
+      "missingToken": "Your registration link is invalid or has expired. Please use the link from your verification email."
     },
     "success": {
       "title": "Registration successful!",
@@ -1559,7 +1560,14 @@
       "matchFound": "We found an organisation matching this address: {{name}}. Would you like to use it?",
       "useThisOrg": "Yes, use this",
       "skip": "No, enter manually",
-      "matched": "Organisation matched: {{name}}"
+      "matched": "Organisation matched: {{name}}",
+      "titleTaken": "An organisation with this name already exists.",
+      "joinInstead": "Join it instead",
+      "requestToJoin": "Request to join"
+    },
+    "pending": {
+      "title": "Join request submitted",
+      "description": "An administrator will review your request to join this organisation. You'll get access once it's approved."
     }
   }
 }

--- a/src/app/[lang]/verify-email/[token]/page.tsx
+++ b/src/app/[lang]/verify-email/[token]/page.tsx
@@ -26,7 +26,9 @@ export default function Page() {
           const pendingRole = getCookie("n4d_pending_role");
           if (pendingRole === "agent") {
             document.cookie = "n4d_pending_role=; path=/; max-age=0";
-            router.push(`/${lang}/register/agent/complete`);
+            // Forward the verify token — the agent form uses it as the
+            // querystring auth for POST /agent/register.
+            router.push(`/${lang}/register/agent/complete?token=${encodeURIComponent(token)}`);
           } else {
             router.push(`/${lang}/dashboard`);
           }

--- a/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
+++ b/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
@@ -1,11 +1,12 @@
 "use client";
 import { Button } from "@/components/core/button";
 import { FormInput } from "@/components/core/common";
-import { apiPathAgent, apiPathOption, LOGGED_IN_COOKIE } from "@/config/constants";
-import { useGetQuery, useMutationQuery } from "@/hooks";
+import { apiPathAgentRegister, apiPathOption, LOGGED_IN_COOKIE } from "@/config/constants";
+import { useGetQuery } from "@/hooks";
+import axios from "axios";
 import i18next from "i18next";
-import { ApiAgentGet, ApiOptionLists } from "need4deed-sdk";
-import { useRouter } from "next/navigation";
+import { AgentMembershipStatus, ApiAgentRegister, ApiAgentRegisterNew, ApiOptionLists } from "need4deed-sdk";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { validateCompletionStep } from "../helpers";
@@ -23,51 +24,54 @@ import {
   PageTitle,
   StepDescription,
   StepTitle,
+  SuccessText,
+  SuccessTitle,
+  SuccessWrapper,
   Wrapper,
 } from "../styled";
 import { defaultProfileCompletionData, ProfileCompletionData, TOTAL_COMPLETION_STEPS } from "../types";
 import { CheckMark, MatchBanner, MatchActions, SmallButton } from "./styled";
 import { useAgentAddressLookup } from "./useAgentAddressLookup";
 
-type CreateAgentBody = {
-  title: string;
-  type?: string;
-  info?: string;
-  website?: string;
-  services?: string[];
-  addressStreet?: string;
-  addressPostcode?: string;
-  districtId?: number;
-  languages?: number[];
-};
+function buildNewAgent(formData: ProfileCompletionData): ApiAgentRegisterNew {
+  return {
+    title: formData.organizationName,
+    // `info`/`languages: number[]` follow the registration contract — these
+    // deliberately differ from the agent PATCH shape (`about`/`OptionById[]`).
+    type: formData.organizationType || undefined,
+    info: formData.about || undefined,
+    website: formData.website || undefined,
+    services: formData.services.length > 0 ? formData.services : undefined,
+    addressStreet: formData.addressStreet || undefined,
+    addressPostcode: formData.addressPostcode || undefined,
+    districtId: formData.districtId ?? undefined,
+    languages: formData.clientLanguageIds.length > 0 ? formData.clientLanguageIds : undefined,
+  };
+}
 
 export function ProfileCompletion() {
   const { t } = useTranslation();
   const router = useRouter();
+  const token = useSearchParams().get("token");
+
   const [step, setStep] = useState(1);
   const [formData, setFormData] = useState<ProfileCompletionData>(defaultProfileCompletionData);
   const [errors, setErrors] = useState<Partial<Record<keyof ProfileCompletionData, string>>>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [pending, setPending] = useState(false);
+  // When a CREATE collides with an existing title, the API returns its id so we
+  // can offer to JOIN it instead.
+  const [titleConflictAgentId, setTitleConflictAgentId] = useState<number | null>(null);
 
   const { data: optionLists } = useGetQuery<ApiOptionLists>({
     queryKey: ["options"],
     apiPath: apiPathOption,
   });
 
-  const { matched, isMatch, showBanner, confirmMatch, dismissMatch } = useAgentAddressLookup(formData.addressStreet);
-
-  const {
-    mutate: createAgent,
-    isPending,
-    error: mutationError,
-  } = useMutationQuery<CreateAgentBody, { message: string; data: ApiAgentGet }>({
-    apiPath: `${apiPathAgent}/`,
-    method: "post",
-    queryKeyToInvalidate: ["agents"],
-    onSuccessCallback: () => {
-      document.cookie = LOGGED_IN_COOKIE;
-      router.push(`/${i18next.language}/dashboard`);
-    },
-  });
+  const { matched, selectedAgentId, isMatch, showBanner, confirmMatch, dismissMatch } = useAgentAddressLookup(
+    formData.addressStreet,
+  );
 
   const update = (fields: Partial<ProfileCompletionData>) => {
     setFormData((prev) => ({ ...prev, ...fields }));
@@ -81,14 +85,49 @@ export function ProfileCompletion() {
     }
   };
 
-  const handleMatchAccept = () => {
-    if (!matched) return;
-    confirmMatch();
-    update({
-      organizationName: matched.title,
-      organizationType: matched.type,
-      districtId: matched.district?.id != null ? Number(matched.district.id) : null,
-    });
+  const submit = async (body: ApiAgentRegister) => {
+    if (!token) {
+      setSubmitError(t("agentRegistration.errors.missingToken"));
+      return;
+    }
+    setSubmitError(null);
+    setIsSubmitting(true);
+    try {
+      const { data } = await axios.post(`${apiPathAgentRegister}?token=${encodeURIComponent(token)}`, body);
+      const status = data?.data?.membershipStatus as AgentMembershipStatus | undefined;
+      if (status === AgentMembershipStatus.PENDING) {
+        setPending(true);
+        return;
+      }
+      document.cookie = LOGGED_IN_COOKIE;
+      router.push(`/${i18next.language}/dashboard`);
+    } catch (err) {
+      if (axios.isAxiosError(err) && err.response?.status === 409) {
+        const conflictAgentId = (err.response.data as { agentId?: number })?.agentId;
+        setTitleConflictAgentId(conflictAgentId ?? null);
+        return;
+      }
+      setSubmitError(t("message.errorGeneric"));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // JOIN an existing agent (picked from the street lookup, or accepted from a
+  // title conflict). Membership lands ACTIVE on email-domain match, else PENDING.
+  const submitJoin = (agentId: number) => submit({ agentId });
+
+  const handleSubmit = () => {
+    const stepErrors = validateCompletionStep(step, formData, t);
+    if (Object.keys(stepErrors).length > 0) {
+      setErrors(stepErrors);
+      return;
+    }
+    if (selectedAgentId) {
+      submitJoin(selectedAgentId);
+      return;
+    }
+    submit({ agent: buildNewAgent(formData) });
   };
 
   const handleNext = () => {
@@ -106,26 +145,22 @@ export function ProfileCompletion() {
     setStep((s) => s - 1);
   };
 
-  const handleSubmit = () => {
-    const stepErrors = validateCompletionStep(step, formData, t);
-    if (Object.keys(stepErrors).length > 0) {
-      setErrors(stepErrors);
-      return;
-    }
+  if (pending) {
+    return (
+      <Wrapper>
+        <Card>
+          <SuccessWrapper>
+            <SuccessTitle>{t("agentRegistration.pending.title")}</SuccessTitle>
+            <SuccessText>{t("agentRegistration.pending.description")}</SuccessText>
+          </SuccessWrapper>
+        </Card>
+      </Wrapper>
+    );
+  }
 
-    createAgent({
-      title: formData.organizationName,
-      type: formData.organizationType || undefined,
-      info: formData.about || undefined,
-      website: formData.website || undefined,
-      services: formData.services.length > 0 ? formData.services : undefined,
-      addressStreet: formData.addressStreet || undefined,
-      addressPostcode: formData.addressPostcode || undefined,
-      districtId: formData.districtId ?? undefined,
-      languages: formData.clientLanguageIds.length > 0 ? formData.clientLanguageIds : undefined,
-    });
-  };
-
+  // A picked agent (or accepted title conflict) is a JOIN: submit the membership
+  // request directly without the create-only org/services steps.
+  const isJoining = !!selectedAgentId;
   const isLastStep = step === TOTAL_COMPLETION_STEPS;
 
   return (
@@ -134,9 +169,23 @@ export function ProfileCompletion() {
         <PageTitle>{t("agentRegistration.completion.title")}</PageTitle>
         <PageSubtitle>{t("agentRegistration.completion.subtitle")}</PageSubtitle>
 
-        <ProgressBar currentStep={step} totalSteps={TOTAL_COMPLETION_STEPS} />
+        {!isJoining && <ProgressBar currentStep={step} totalSteps={TOTAL_COMPLETION_STEPS} />}
 
-        {mutationError && <ErrorBanner>{t("message.errorGeneric")}</ErrorBanner>}
+        {submitError && <ErrorBanner>{submitError}</ErrorBanner>}
+
+        {titleConflictAgentId !== null && (
+          <MatchBanner $matched={false}>
+            <span>{t("agentRegistration.completion.titleTaken")}</span>
+            <MatchActions>
+              <SmallButton $primary onClick={() => submitJoin(titleConflictAgentId)}>
+                {t("agentRegistration.completion.joinInstead")}
+              </SmallButton>
+              <SmallButton onClick={() => setTitleConflictAgentId(null)}>
+                {t("agentRegistration.completion.skip")}
+              </SmallButton>
+            </MatchActions>
+          </MatchBanner>
+        )}
 
         {step === 1 && (
           <div>
@@ -154,7 +203,7 @@ export function ProfileCompletion() {
                 <MatchBanner $matched={false}>
                   <span>{t("agentRegistration.completion.matchFound", { name: matched!.title })}</span>
                   <MatchActions>
-                    <SmallButton $primary onClick={handleMatchAccept}>
+                    <SmallButton $primary onClick={confirmMatch}>
                       {t("agentRegistration.completion.useThisOrg")}
                     </SmallButton>
                     <SmallButton onClick={dismissMatch}>{t("agentRegistration.completion.skip")}</SmallButton>
@@ -168,34 +217,37 @@ export function ProfileCompletion() {
                 </MatchBanner>
               )}
             </FieldWrapper>
-            <AddressStep data={formData} onChange={update} errors={errors} optionLists={optionLists} hideStreet />
+            {/* Joining an existing org: address is theirs, no need to re-enter the rest. */}
+            {!isJoining && (
+              <AddressStep data={formData} onChange={update} errors={errors} optionLists={optionLists} hideStreet />
+            )}
           </div>
         )}
 
-        {step === 2 && <OrgInfoStep data={formData} onChange={update} errors={errors} />}
-        {step === 3 && <ServicesStep data={formData} onChange={update} optionLists={optionLists} />}
+        {!isJoining && step === 2 && <OrgInfoStep data={formData} onChange={update} errors={errors} />}
+        {!isJoining && step === 3 && <ServicesStep data={formData} onChange={update} optionLists={optionLists} />}
 
         <Actions>
-          {step > 1 ? (
+          {!isJoining && step > 1 ? (
             <Button
               text={t("agentRegistration.back")}
               backgroundcolor="var(--color-white)"
               textColor="var(--color-aubergine)"
               border="1px solid var(--color-aubergine)"
               onClick={handleBack}
-              disabled={isPending}
+              disabled={isSubmitting}
             />
           ) : (
             <div />
           )}
 
-          {isLastStep ? (
+          {isJoining || isLastStep ? (
             <Button
-              text={t("agentRegistration.submit")}
+              text={isJoining ? t("agentRegistration.completion.requestToJoin") : t("agentRegistration.submit")}
               backgroundcolor="var(--color-aubergine)"
               textColor="var(--color-white)"
               onClick={handleSubmit}
-              disabled={isPending}
+              disabled={isSubmitting}
             />
           ) : (
             <Button

--- a/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
+++ b/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
@@ -71,6 +71,7 @@ export function ProfileCompletion() {
 
   const { matched, selectedAgentId, isMatch, showBanner, confirmMatch, dismissMatch } = useAgentAddressLookup(
     formData.addressStreet,
+    token,
   );
 
   const update = (fields: Partial<ProfileCompletionData>) => {

--- a/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
+++ b/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
@@ -5,7 +5,13 @@ import { apiPathAgentRegister, apiPathOption, LOGGED_IN_COOKIE } from "@/config/
 import { useGetQuery } from "@/hooks";
 import axios from "axios";
 import i18next from "i18next";
-import { AgentMembershipStatus, ApiAgentRegister, ApiAgentRegisterNew, ApiOptionLists } from "need4deed-sdk";
+import {
+  AgentMembershipStatus,
+  ApiAgentRegister,
+  ApiAgentRegisterNew,
+  ApiAgentRegisterResponse,
+  ApiOptionLists,
+} from "need4deed-sdk";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -94,8 +100,11 @@ export function ProfileCompletion() {
     setSubmitError(null);
     setIsSubmitting(true);
     try {
-      const { data } = await axios.post(`${apiPathAgentRegister}?token=${encodeURIComponent(token)}`, body);
-      const status = data?.data?.membershipStatus as AgentMembershipStatus | undefined;
+      const { data } = await axios.post<{ message: string; data: ApiAgentRegisterResponse }>(
+        `${apiPathAgentRegister}?token=${encodeURIComponent(token)}`,
+        body,
+      );
+      const status = data?.data?.membershipStatus;
       if (status === AgentMembershipStatus.PENDING) {
         setPending(true);
         return;

--- a/src/components/AgentRegistration/ProfileCompletion/useAgentAddressLookup.ts
+++ b/src/components/AgentRegistration/ProfileCompletion/useAgentAddressLookup.ts
@@ -4,6 +4,9 @@ import { useGetQuery } from "@/hooks";
 import { ApiAgentGetList } from "need4deed-sdk";
 import { useState } from "react";
 
+// Powers the self-registration picker: as the user types their street, look up
+// existing agents at a matching address so they can JOIN their org instead of
+// creating a duplicate. Backed by GET /agent?filter[street]=.
 export function useAgentAddressLookup(addressStreet: string) {
   const [selectedAgentId, setSelectedAgentId] = useState<number | null>(null);
   const [dismissedAddress, setDismissedAddress] = useState<string | null>(null);
@@ -12,12 +15,12 @@ export function useAgentAddressLookup(addressStreet: string) {
   const enabled = debouncedAddress.length >= 5;
 
   const { data: matches, isLoading } = useGetQuery<ApiAgentGetList[]>({
-    queryKey: ["agents", "address-lookup", debouncedAddress],
+    queryKey: ["agents", "street-lookup", debouncedAddress],
     apiPath: `${apiPathAgent}/`,
     params: {
       limit: 10,
       page: 1,
-      filter: { search: debouncedAddress },
+      filter: { street: debouncedAddress },
     },
     staleTime: cacheTTL,
     enabled,
@@ -39,5 +42,14 @@ export function useAgentAddressLookup(addressStreet: string) {
     setSelectedAgentId(null);
   };
 
-  return { matched, isMatch, showBanner, isLoading: enabled && isLoading, confirmMatch, dismissMatch };
+  return {
+    matched,
+    matches: enabled ? (matches ?? []) : [],
+    selectedAgentId,
+    isMatch,
+    showBanner,
+    isLoading: enabled && isLoading,
+    confirmMatch,
+    dismissMatch,
+  };
 }

--- a/src/components/AgentRegistration/ProfileCompletion/useAgentAddressLookup.ts
+++ b/src/components/AgentRegistration/ProfileCompletion/useAgentAddressLookup.ts
@@ -1,27 +1,26 @@
-import { apiPathAgent, cacheTTL } from "@/config/constants";
+import { apiPathAgentRegister, cacheTTL } from "@/config/constants";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useGetQuery } from "@/hooks";
-import { ApiAgentGetList } from "need4deed-sdk";
 import { useState } from "react";
+
+type AgentSearchMatch = { id: number; title: string };
 
 // Powers the self-registration picker: as the user types their street, look up
 // existing agents at a matching address so they can JOIN their org instead of
-// creating a duplicate. Backed by GET /agent?filter[street]=.
-export function useAgentAddressLookup(addressStreet: string) {
+// creating a duplicate. Backed by the token-gated GET /agent/register/search
+// (the COORDINATOR-only GET /agent is not available to a registrant).
+export function useAgentAddressLookup(addressStreet: string, token: string | null) {
   const [selectedAgentId, setSelectedAgentId] = useState<number | null>(null);
   const [dismissedAddress, setDismissedAddress] = useState<string | null>(null);
   const debouncedAddress = useDebounce(addressStreet.trim(), 400);
 
-  const enabled = debouncedAddress.length >= 5;
+  const enabled = debouncedAddress.length >= 3 && !!token;
 
-  const { data: matches, isLoading } = useGetQuery<ApiAgentGetList[]>({
-    queryKey: ["agents", "street-lookup", debouncedAddress],
-    apiPath: `${apiPathAgent}/`,
-    params: {
-      limit: 10,
-      page: 1,
-      filter: { street: debouncedAddress },
-    },
+  const { data: matches } = useGetQuery<AgentSearchMatch[]>({
+    queryKey: ["agent-register-search", debouncedAddress],
+    apiPath: `${apiPathAgentRegister}/search?token=${encodeURIComponent(
+      token ?? "",
+    )}&street=${encodeURIComponent(debouncedAddress)}`,
     staleTime: cacheTTL,
     enabled,
     addLang: false,
@@ -48,7 +47,6 @@ export function useAgentAddressLookup(addressStreet: string) {
     selectedAgentId,
     isMatch,
     showBanner,
-    isLoading: enabled && isLoading,
     confirmMatch,
     dismissMatch,
   };

--- a/src/components/Dashboard/Agents/Agents.tsx
+++ b/src/components/Dashboard/Agents/Agents.tsx
@@ -2,6 +2,7 @@
 
 import { DashboardLayout } from "@/components/Layout";
 import { AgentListController } from "./AgentListController";
+import { PendingMemberships } from "./PendingMemberships";
 import { AgentsContainer, ContentRow } from "./styles";
 import CardsHeader from "../common/CardsHeader/CardsHeader";
 import { useTranslation } from "react-i18next";
@@ -87,6 +88,7 @@ export const Agents = () => {
           activeFilters={activeFilters}
           onClearAllFilters={handleClearAllFilters}
         />
+        <PendingMemberships />
         <ContentRow>
           <AgentListController
             setNumOfAgents={setNumOfAgents}

--- a/src/components/Dashboard/Agents/PendingMemberships/PendingMemberships.tsx
+++ b/src/components/Dashboard/Agents/PendingMemberships/PendingMemberships.tsx
@@ -2,8 +2,9 @@
 import { Button } from "@/components/core/button";
 import { apiPathAgentMembership } from "@/config/constants";
 import { useGetQuery, useMutationQuery } from "@/hooks";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 import axios from "axios";
-import { AgentMembershipStatus, ApiAgentMembership } from "need4deed-sdk";
+import { AgentMembershipStatus, ApiAgentMembership, UserRole } from "need4deed-sdk";
 import { useTranslation } from "react-i18next";
 import { Actions, Meta, Panel, Row, Title } from "./styled";
 
@@ -15,10 +16,16 @@ const PENDING_KEY = ["agent-memberships", "pending"];
 export function PendingMemberships() {
   const { t } = useTranslation();
 
+  // Moderation is COORDINATOR/ADMIN-only on the backend — gate the fetch by role
+  // so non-privileged viewers of the Agents page don't trigger a 401 + toast.
+  const user = useCurrentUser(true);
+  const canModerate = user?.role === UserRole.COORDINATOR || user?.role === UserRole.ADMIN;
+
   const { data } = useGetQuery<ApiAgentMembership[]>({
     queryKey: PENDING_KEY,
     apiPath: `${apiPathAgentMembership}?status=${AgentMembershipStatus.PENDING}`,
     addLang: false,
+    enabled: canModerate,
   });
 
   const approve = useMutationQuery<number, unknown>({
@@ -35,7 +42,7 @@ export function PendingMemberships() {
   });
 
   const memberships = data ?? [];
-  if (memberships.length === 0) return null;
+  if (!canModerate || memberships.length === 0) return null;
 
   const busy = approve.isPending || reject.isPending;
 

--- a/src/components/Dashboard/Agents/PendingMemberships/PendingMemberships.tsx
+++ b/src/components/Dashboard/Agents/PendingMemberships/PendingMemberships.tsx
@@ -1,0 +1,76 @@
+"use client";
+import { Button } from "@/components/core/button";
+import { apiPathAgentMembership } from "@/config/constants";
+import { useGetQuery, useMutationQuery } from "@/hooks";
+import axios from "axios";
+import { AgentMembershipStatus, ApiAgentMembership } from "need4deed-sdk";
+import { useTranslation } from "react-i18next";
+import { Actions, Meta, Panel, Row, Title } from "./styled";
+
+const PENDING_KEY = ["agent-memberships", "pending"];
+
+// Admin-fallback surface: joins that didn't pass email-domain match land here as
+// PENDING for an ADMIN/COORDINATOR to approve or reject. Renders nothing when the
+// queue is empty, so it's a no-op on the Agents page in the common case.
+export function PendingMemberships() {
+  const { t } = useTranslation();
+
+  const { data } = useGetQuery<ApiAgentMembership[]>({
+    queryKey: PENDING_KEY,
+    apiPath: `${apiPathAgentMembership}?status=${AgentMembershipStatus.PENDING}`,
+    addLang: false,
+  });
+
+  const approve = useMutationQuery<number, unknown>({
+    mutationFn: (id) =>
+      axios.patch(`${apiPathAgentMembership}/${id}`, { status: AgentMembershipStatus.ACTIVE }).then((r) => r.data),
+    successMessage: "dashboard.agents.pendingMemberships.approved",
+    queryKeyToInvalidate: PENDING_KEY,
+  });
+
+  const reject = useMutationQuery<number, unknown>({
+    mutationFn: (id) => axios.delete(`${apiPathAgentMembership}/${id}`).then((r) => r.data),
+    successMessage: "dashboard.agents.pendingMemberships.rejected",
+    queryKeyToInvalidate: PENDING_KEY,
+  });
+
+  const memberships = data ?? [];
+  if (memberships.length === 0) return null;
+
+  const busy = approve.isPending || reject.isPending;
+
+  return (
+    <Panel data-testid="pending-memberships">
+      <Title>{t("dashboard.agents.pendingMemberships.title", { count: memberships.length })}</Title>
+      {memberships.map((m) => {
+        const name = `${m.person?.firstName ?? ""} ${m.person?.lastName ?? ""}`.trim();
+        return (
+          <Row key={m.id}>
+            <Meta>
+              <strong>{name || m.person?.email}</strong>
+              <span>{t("dashboard.agents.pendingMemberships.requestsToJoin", { org: m.agentTitle })}</span>
+              <span>{m.person?.email}</span>
+            </Meta>
+            <Actions>
+              <Button
+                text={t("dashboard.agents.pendingMemberships.approve")}
+                backgroundcolor="var(--color-aubergine)"
+                textColor="var(--color-white)"
+                onClick={() => approve.mutate(m.id)}
+                disabled={busy}
+              />
+              <Button
+                text={t("dashboard.agents.pendingMemberships.reject")}
+                backgroundcolor="var(--color-white)"
+                textColor="var(--color-aubergine)"
+                border="1px solid var(--color-aubergine)"
+                onClick={() => reject.mutate(m.id)}
+                disabled={busy}
+              />
+            </Actions>
+          </Row>
+        );
+      })}
+    </Panel>
+  );
+}

--- a/src/components/Dashboard/Agents/PendingMemberships/index.ts
+++ b/src/components/Dashboard/Agents/PendingMemberships/index.ts
@@ -1,0 +1,1 @@
+export { PendingMemberships } from "./PendingMemberships";

--- a/src/components/Dashboard/Agents/PendingMemberships/styled.ts
+++ b/src/components/Dashboard/Agents/PendingMemberships/styled.ts
@@ -1,0 +1,47 @@
+import styled from "styled-components";
+
+export const Panel = styled.section`
+  width: 100%;
+  border: 1px solid var(--color-aubergine);
+  border-radius: 12px;
+  padding: 16px 20px;
+  margin-bottom: 16px;
+  background: var(--color-white);
+`;
+
+export const Title = styled.h3`
+  margin: 0 0 12px;
+  font-size: 1rem;
+  color: var(--color-midnight);
+`;
+
+export const Row = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 0;
+  border-top: 1px solid var(--color-light-grey, #e5e5e5);
+
+  &:first-of-type {
+    border-top: none;
+  }
+`;
+
+export const Meta = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.875rem;
+  color: var(--color-midnight);
+
+  span {
+    color: var(--color-grey, #6b6b6b);
+  }
+`;
+
+export const Actions = styled.div`
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+`;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -14,6 +14,7 @@ export const apiPathAuthEmailDomain = `/${apiPrefix}/auth-email-domain/`;
 export const apiPathOpportunity = `/${apiPrefix}/opportunity`;
 export const apiPathAgent = `/${apiPrefix}/agent`;
 export const apiPathAgentMe = `/${apiPrefix}/agent/me`;
+export const apiPathAgentRegister = `/${apiPrefix}/agent/register`;
 export const apiPathOption = `/${apiPrefix}/option`;
 export const apiPathOpportunityVolunteer = `/${apiPrefix}/opportunity-volunteer`;
 export const apiPathUser = `/${apiPrefix}/user`;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -15,6 +15,7 @@ export const apiPathOpportunity = `/${apiPrefix}/opportunity`;
 export const apiPathAgent = `/${apiPrefix}/agent`;
 export const apiPathAgentMe = `/${apiPrefix}/agent/me`;
 export const apiPathAgentRegister = `/${apiPrefix}/agent/register`;
+export const apiPathAgentMembership = `/${apiPrefix}/agent/membership`;
 export const apiPathOption = `/${apiPrefix}/option`;
 export const apiPathOpportunityVolunteer = `/${apiPrefix}/opportunity-volunteer`;
 export const apiPathUser = `/${apiPrefix}/user`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,10 +2412,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.99:
-  version "0.0.99"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.99.tgz#dfef959872d390ae187e07ce3c4b9d7a3b1bdf29"
-  integrity sha512-OUnQs+cL2ROLuj+NSpUFMJWKXv9XYPWgqQ/3MPaXSv4lUiCuAm6NDnMdXHDZtZLakPAlykvRzm17xssn1VjuZA==
+need4deed-sdk@0.0.103:
+  version "0.0.103"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.103.tgz#836fa46e8cfe03288c7536f4e7b9c0b6a2f7a713"
+  integrity sha512-MdYk9AMWD0X5sOVYShQSRgwkbZm+GvoGi37O7xuwFkY+BQ6MbkuNK77wgFKm1x53sr62O4MWZQr6W+zrTDgr/Q==
 
 next@15.3.8:
   version "15.3.8"


### PR DESCRIPTION
Frontend for agent self-registration. Depends on `need4deed-sdk@0.0.103` (sdk#123, merged) and the backend endpoints (be#601).

## Flow
1. Account step → `POST /user` (existing) sends the verification email.
2. The verify-email page now **forwards the token** → `…/register/agent/complete?token=`.
3. The agent form uses that token as the querystring auth for `POST /agent/register`:
   - **street search** (token-gated `GET /agent/register/search`) → offer to **join** an existing org, else **create** a new one.
   - submits one `{ agentId }` (join) or `{ agent }` (create) call, typed by SDK `ApiAgentRegister` (`info` + `languages: number[]`).
   - handles **PENDING** ("awaiting admin approval") and **409** ("name taken → join instead", using the returned `agentId`).

## Dashboard
- `PendingMemberships` panel on the Agents page: lists PENDING join requests with **approve** (PATCH) / **reject** (DELETE). Renders nothing when the queue is empty.

## i18n
- en/de strings added for the new states and the moderation panel.

Typecheck + lint green. The wizard rework + picker were exercised against the live backend during be#601 smoke testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)