### PR TITLE
Fix agent-registration join: working CTA + clear confirmation

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1940,7 +1940,11 @@
       "matched": "Organisation gefunden: {{name}}",
       "titleTaken": "Eine Organisation mit diesem Namen existiert bereits.",
       "joinInstead": "Stattdessen beitreten",
-      "requestToJoin": "Beitritt anfragen"
+      "requestToJoin": "Beitritt anfragen",
+      "joinTitle": "Einer bestehenden Organisation beitreten",
+      "joiningOrg": "Du beantragst den Beitritt zu {{name}}.",
+      "joinDescription": "Wenn deine Arbeits-E-Mail zu dieser Organisation passt, erhältst du sofort Zugriff; andernfalls prüft ein Administrator deine Anfrage.",
+      "createInstead": "Nicht deine Organisation? Neue erstellen"
     },
     "pending": {
       "title": "Beitrittsanfrage gesendet",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1572,7 +1572,11 @@
       "matched": "Organisation matched: {{name}}",
       "titleTaken": "An organisation with this name already exists.",
       "joinInstead": "Join it instead",
-      "requestToJoin": "Request to join"
+      "requestToJoin": "Request to join",
+      "joinTitle": "Join an existing organisation",
+      "joiningOrg": "You're requesting to join {{name}}.",
+      "joinDescription": "If your work email matches this organisation you'll get access right away; otherwise an administrator will review your request.",
+      "createInstead": "Not your organisation? Create a new one"
     },
     "pending": {
       "title": "Join request submitted",

--- a/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
+++ b/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
@@ -75,7 +75,7 @@ export function ProfileCompletion() {
     apiPath: apiPathOption,
   });
 
-  const { matched, selectedAgentId, isMatch, showBanner, confirmMatch, dismissMatch } = useAgentAddressLookup(
+  const { matched, selectedAgent, showBanner, confirmMatch, dismissMatch } = useAgentAddressLookup(
     formData.addressStreet,
     token,
   );
@@ -131,8 +131,8 @@ export function ProfileCompletion() {
     // Joining an existing agent submits only { agentId } — the create-form
     // (street/postcode/org) validation must not run, or the missing postcode
     // blocks the join.
-    if (selectedAgentId) {
-      submitJoin(selectedAgentId);
+    if (selectedAgent) {
+      submitJoin(selectedAgent.id);
       return;
     }
     const stepErrors = validateCompletionStep(step, formData, t);
@@ -173,7 +173,7 @@ export function ProfileCompletion() {
 
   // A picked agent (or accepted title conflict) is a JOIN: submit the membership
   // request directly without the create-only org/services steps.
-  const isJoining = !!selectedAgentId;
+  const isJoining = !!selectedAgent;
   const isLastStep = step === TOTAL_COMPLETION_STEPS;
 
   return (
@@ -200,42 +200,48 @@ export function ProfileCompletion() {
           </MatchBanner>
         )}
 
-        {step === 1 && (
-          <div>
-            <StepTitle>{t("agentRegistration.steps.address.title")}</StepTitle>
-            <StepDescription>{t("agentRegistration.steps.address.description")}</StepDescription>
-            <FieldWrapper>
-              <FieldLabel>{t("agentRegistration.fields.addressStreet")}</FieldLabel>
-              <FormInput
-                value={formData.addressStreet}
-                onInputChange={(v) => update({ addressStreet: v })}
-                placeHolder={t("agentRegistration.fields.addressStreet")}
-                errors={errors.addressStreet ? [errors.addressStreet] : []}
-              />
-              {showBanner && (
-                <MatchBanner $matched={false}>
-                  <span>{t("agentRegistration.completion.matchFound", { name: matched!.title })}</span>
-                  <MatchActions>
-                    <SmallButton $primary onClick={confirmMatch}>
-                      {t("agentRegistration.completion.useThisOrg")}
-                    </SmallButton>
-                    <SmallButton onClick={dismissMatch}>{t("agentRegistration.completion.skip")}</SmallButton>
-                  </MatchActions>
-                </MatchBanner>
-              )}
-              {isMatch && (
-                <MatchBanner $matched>
-                  <CheckMark>✓</CheckMark>
-                  <span>{t("agentRegistration.completion.matched", { name: matched?.title })}</span>
-                </MatchBanner>
-              )}
-            </FieldWrapper>
-            {/* Joining an existing org: address is theirs, no need to re-enter the rest. */}
-            {!isJoining && (
+        {step === 1 &&
+          (isJoining ? (
+            // Picked an existing org: this is a membership request, not an edit.
+            // Show a clear read-only confirmation + an undo back to creating.
+            <div>
+              <StepTitle>{t("agentRegistration.completion.joinTitle")}</StepTitle>
+              <MatchBanner $matched>
+                <CheckMark>✓</CheckMark>
+                <span>{t("agentRegistration.completion.joiningOrg", { name: selectedAgent?.title })}</span>
+              </MatchBanner>
+              <StepDescription>{t("agentRegistration.completion.joinDescription")}</StepDescription>
+              <MatchActions>
+                <SmallButton onClick={dismissMatch}>{t("agentRegistration.completion.createInstead")}</SmallButton>
+              </MatchActions>
+            </div>
+          ) : (
+            <div>
+              <StepTitle>{t("agentRegistration.steps.address.title")}</StepTitle>
+              <StepDescription>{t("agentRegistration.steps.address.description")}</StepDescription>
+              <FieldWrapper>
+                <FieldLabel>{t("agentRegistration.fields.addressStreet")}</FieldLabel>
+                <FormInput
+                  value={formData.addressStreet}
+                  onInputChange={(v) => update({ addressStreet: v })}
+                  placeHolder={t("agentRegistration.fields.addressStreet")}
+                  errors={errors.addressStreet ? [errors.addressStreet] : []}
+                />
+                {showBanner && (
+                  <MatchBanner $matched={false}>
+                    <span>{t("agentRegistration.completion.matchFound", { name: matched!.title })}</span>
+                    <MatchActions>
+                      <SmallButton $primary onClick={confirmMatch}>
+                        {t("agentRegistration.completion.useThisOrg")}
+                      </SmallButton>
+                      <SmallButton onClick={dismissMatch}>{t("agentRegistration.completion.skip")}</SmallButton>
+                    </MatchActions>
+                  </MatchBanner>
+                )}
+              </FieldWrapper>
               <AddressStep data={formData} onChange={update} errors={errors} optionLists={optionLists} hideStreet />
-            )}
-          </div>
-        )}
+            </div>
+          ))}
 
         {!isJoining && step === 2 && <OrgInfoStep data={formData} onChange={update} errors={errors} />}
         {!isJoining && step === 3 && <ServicesStep data={formData} onChange={update} optionLists={optionLists} />}

--- a/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
+++ b/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
@@ -128,13 +128,16 @@ export function ProfileCompletion() {
   const submitJoin = (agentId: number) => submit({ agentId });
 
   const handleSubmit = () => {
+    // Joining an existing agent submits only { agentId } — the create-form
+    // (street/postcode/org) validation must not run, or the missing postcode
+    // blocks the join.
+    if (selectedAgentId) {
+      submitJoin(selectedAgentId);
+      return;
+    }
     const stepErrors = validateCompletionStep(step, formData, t);
     if (Object.keys(stepErrors).length > 0) {
       setErrors(stepErrors);
-      return;
-    }
-    if (selectedAgentId) {
-      submitJoin(selectedAgentId);
       return;
     }
     submit({ agent: buildNewAgent(formData) });

--- a/src/components/AgentRegistration/ProfileCompletion/useAgentAddressLookup.ts
+++ b/src/components/AgentRegistration/ProfileCompletion/useAgentAddressLookup.ts
@@ -10,7 +10,7 @@ type AgentSearchMatch = { id: number; title: string };
 // creating a duplicate. Backed by the token-gated GET /agent/register/search
 // (the COORDINATOR-only GET /agent is not available to a registrant).
 export function useAgentAddressLookup(addressStreet: string, token: string | null) {
-  const [selectedAgentId, setSelectedAgentId] = useState<number | null>(null);
+  const [selectedAgent, setSelectedAgent] = useState<AgentSearchMatch | null>(null);
   const [dismissedAddress, setDismissedAddress] = useState<string | null>(null);
   const debouncedAddress = useDebounce(addressStreet.trim(), 400);
 
@@ -29,22 +29,22 @@ export function useAgentAddressLookup(addressStreet: string, token: string | nul
   const matched = enabled && matches && matches.length > 0 ? matches[0] : null;
 
   const isDismissed = dismissedAddress === debouncedAddress;
-  const isMatch = !!matched && selectedAgentId === matched.id;
+  const isMatch = !!matched && selectedAgent?.id === matched.id;
   const showBanner = !!matched && !isMatch && !isDismissed;
 
   const confirmMatch = () => {
-    if (matched) setSelectedAgentId(matched.id);
+    if (matched) setSelectedAgent(matched);
   };
 
   const dismissMatch = () => {
     setDismissedAddress(debouncedAddress);
-    setSelectedAgentId(null);
+    setSelectedAgent(null);
   };
 
   return {
     matched,
     matches: enabled ? (matches ?? []) : [],
-    selectedAgentId,
+    selectedAgent,
     isMatch,
     showBanner,
     confirmMatch,


### PR DESCRIPTION
Fixes issues found in local testing of the registration wizard (#620).

## #1 — join CTA did nothing (bug)
`handleSubmit` ran the create-form validation (street **and** postcode required) *before* the join branch. A joiner never enters a postcode, so validation failed and "Request to join" silently returned. Now a picked agent submits `{ agentId }` immediately, bypassing create-form validation.

## #2 / #3 — confusing pick state (UX)
The original "pre-fill + edit everything but address + edit-CLA" was intentionally dropped in the security pivot (a self-registering user must not edit/overwrite an existing center's record — a pick is a *membership request*, not an edit). The remaining UX was just a thin banner, which read as "nothing happened."

Replaces it with a clear, read-only confirmation:
- **"You're requesting to join \<Org\>"** card + short note on approval (instant on email-domain match, else admin review).
- **"Not your organisation? Create a new one"** undo → returns to the create flow (this is the "edit-CLA" equivalent, without re-introducing org editing).

The lookup hook now exposes the selected agent **object** so the title stays stable across re-searches.

## Notes
- No backend change. Honors the membership-not-edit model from #601.
- Typecheck + lint green. Please re-test the pick → join path locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)