### PR TITLE
fix: wrap volunteer form in Suspense to prevent hydration crash

### DIFF
--- a/src/app/[lang]/forms/volunteer/page.tsx
+++ b/src/app/[lang]/forms/volunteer/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from "react";
 import BecomeVolunteer from "@/components/forms/BecomeVolunteer/BecomeVolunteer";
 
 export default function VolunteerPage() {
-  return <BecomeVolunteer />;
+  return (
+    <Suspense>
+      <BecomeVolunteer />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Summary
- Wraps `<BecomeVolunteer />` in `<Suspense>` in the page component
- One-line change: adds `import { Suspense }` and the wrapper

## Root cause
`BecomeVolunteer` calls `useSearchParams()` to read `?id` and `?title` from the URL and conditionally renders a subtitle when `title` is present. Without a `<Suspense>` boundary, Next.js 15 App Router renders the page on the server (where search params are unavailable → `title = ""`), then React hydrates on the client (where `?title=Some Opportunity` is present → subtitle rendered). This server/client mismatch causes:

> Application error: a client-side exception has occurred while loading app.need4deed.org

Only volunteers arriving via an **opportunity-specific link** (with `?title=` in the URL) were affected — those navigating within the app via client-side routing never hit SSR so no mismatch occurred.

## Test plan
- [ ] Visit `https://app.need4deed.org/de/forms/volunteer?id=123&title=TestOpportunity` directly (fresh load) → form loads without error, subtitle visible
- [ ] Visit `https://app.need4deed.org/de/forms/volunteer` directly → form loads without error, no subtitle
- [ ] Submit the form → works as before

Resolves https://github.com/need4deed-org/fe/issues/628

🤖 Generated with [Claude Code](https://claude.com/claude-code)