### PR TITLE
feat: make whole accordion header clickable in filters panel

### DIFF
--- a/src/components/Dashboard/common/CardsFilter/AccordionFilter.tsx
+++ b/src/components/Dashboard/common/CardsFilter/AccordionFilter.tsx
@@ -31,9 +31,9 @@ export default function AccordionFilter({ header, items, groupedItems, groupedIt
 
   return (
     <FilterContainer>
-      <FilterHeaderContainer>
+      <FilterHeaderContainer type="button" aria-expanded={isOpen} onClick={() => setIsOpen(!isOpen)}>
         <Heading4 color="var(--color-midnight)">{header}</Heading4>
-        <CircleArrow direction={isOpen ? "up" : "down"} color="orchid" isFilled onClick={() => setIsOpen(!isOpen)} />
+        <CircleArrow direction={isOpen ? "up" : "down"} color="orchid" isFilled />
       </FilterHeaderContainer>
 
       {isOpen && items && (
@@ -90,10 +90,15 @@ const FilterContainer = styled.div`
   gap: var(--opportunities-filters-content-filter-container-gap);
 `;
 
-const FilterHeaderContainer = styled.div`
+const FilterHeaderContainer = styled.button`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
   border-top: var(--opportunities-filters-content-accordion-header-border-top) solid var(--color-orchid);
   padding-top: var(--opportunities-filters-content-accordion-header-padding-top);
 `;

--- a/src/components/Dashboard/common/CardsFilter/AccordionFilter.tsx
+++ b/src/components/Dashboard/common/CardsFilter/AccordionFilter.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import styled from "styled-components";
-import { Heading4, Paragraph } from "@/components/styled/text";
+import { ButtonSpan, Paragraph } from "@/components/styled/text";
 import CircleArrow from "@/components/svg/CircleArrow";
 import { Checkbox, CheckboxProps, CheckButton } from "@/components/core/button";
 
@@ -32,7 +32,9 @@ export default function AccordionFilter({ header, items, groupedItems, groupedIt
   return (
     <FilterContainer>
       <FilterHeaderContainer type="button" aria-expanded={isOpen} onClick={() => setIsOpen(!isOpen)}>
-        <Heading4 color="var(--color-midnight)">{header}</Heading4>
+        <ButtonSpan color="var(--color-midnight)" fontSize="20px" fontWeight={600}>
+          {header}
+        </ButtonSpan>
         <CircleArrow direction={isOpen ? "up" : "down"} color="orchid" isFilled />
       </FilterHeaderContainer>
 


### PR DESCRIPTION
Closes #605

## What

The accordion sections in the filters panel (Volunteer type, Engagement,
District, Languages, ...) could only be toggled via the small chevron
button. Now the whole header row toggles the section.

## How

- `FilterHeaderContainer` is a `styled.button` (was `styled.div`) and
  carries the toggle `onClick`; the `CircleArrow` is decorative now.
- Standard button resets keep the visuals unchanged.
- `type="button"` + `aria-expanded` make the header focusable and
  keyboard-operable (the bare SVG `onClick` was neither).
