### PR TITLE
fix(#597): cap opportunity card activities at 2 with +N overflow

### DIFF
--- a/src/components/Dashboard/Opportunities/OpportunityCard.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityCard.tsx
@@ -132,7 +132,7 @@ export function OpportunityCard({ opportunity, volunteerId, activitiesList, dist
           </CardDetail>
         ) : (
           <CardDetail header={t("dashboard.volunteers.activities")} iconName={IconName.ShootingStar}>
-            <Tags tags={activityTitles} />
+            <Tags tags={activityTitles} max={2} />
           </CardDetail>
         ))}
 


### PR DESCRIPTION
## Description

Opportunity cards with many activities stacked all tags vertically, making cards arbitrarily tall. Activities are now capped at 2 tags with a `+N` badge — the same pattern as the volunteer card fix (#586). The `max` prop already existed on `<Tags>`, so the change is a single line.

## Related Issues

Closes #597

## Scope

Per the discussion in #597, the table-view part of the issue is left out: PR #618 (closes #612) drops the activities column and makes the remaining rows single-line, so `+N` truncation in the table would be obsolete and would conflict with that PR.