### PR TITLE
fix(#638): wrap opportunity card status tags within card boundary

### DIFF
--- a/src/components/Dashboard/Opportunities/styles.ts
+++ b/src/components/Dashboard/Opportunities/styles.ts
@@ -43,6 +43,7 @@ export const Card = styled(BaseCard)`
 export const StatusTagsDiv = styled.div`
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   gap: var(--dashboard-volunteers-card-status-tags-div-gap);
   margin-top: var(--dashboard-volunteers-card-status-tags-div-margin-top);
 `;


### PR DESCRIPTION
## Description

The status/type tag row on opportunity cards (`StatusTagsDiv`) is a flex row without `flex-wrap`, while the card has a fixed width (320px). With three tags (status + match status + type) the row extends past the card boundary — up to ~74px in English and on every tested combination in German, where even the shortest labels overflow.

Adding `flex-wrap: wrap` lets tags wrap to the next line inside the card. The card already uses `min-height`, so it grows naturally with the extra row. Cards with few or short tags keep a single row. Cards in the same grid row keep equal heights (the grid stretches them), so rows stay flush — only the vertical start of the content varies with the number of tag lines.

## Related Issues

Closes #638

## Scope

- The volunteer card has its own copy of the same styled components (`VolunteerCard.tsx`) with the same missing `flex-wrap` — left out here to keep the PR card-only; happy to follow up.
