### PR TITLE
adds auth view for opp profile

### DIFF
--- a/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
@@ -12,12 +12,14 @@ import { createVolunteerTypeLabelMap, EditButton, HeaderCard, IconContainer, Sta
 import { ChangeOpportunityStatusDialog } from "./ChangeOpportunityStatusDialog";
 import { createOpportunityStatusLabelMap } from "./constants";
 import { useOpportunityStatusDialog } from "./useOpportunityStatusDialog";
+import { useAuth } from "@/hooks/useAuth";
 
 type Props = {
   opportunity: ApiOpportunityGet;
 };
 
 export const OpportunityHeader = ({ opportunity }: Props) => {
+  const { isAuthorized } = useAuth();
   const { t, i18n } = useTranslation();
   const dialog = useOpportunityStatusDialog(opportunity);
   const statusLabelMap = createOpportunityStatusLabelMap(t);
@@ -43,7 +45,11 @@ export const OpportunityHeader = ({ opportunity }: Props) => {
         title={t("dashboard.opportunityProfile.currentStatus")}
         status={dialog.selected}
         label={statusLabelMap[dialog.selected]}
-        action={<EditButton onClick={dialog.openDialog}>{t("dashboard.opportunityProfile.change_status")}</EditButton>}
+        action={
+          isAuthorized && (
+            <EditButton onClick={dialog.openDialog}>{t("dashboard.opportunityProfile.change_status")}</EditButton>
+          )
+        }
       />
 
       <StatusRowField

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,24 @@
+import { Id, UserRole } from "need4deed-sdk";
+import { useCurrentUser } from "./useCurrentUser";
+import { useEffect, useState } from "react";
+
+export const useAuth = (contactPersonId?: Id) => {
+  const [isAuthorized, setIsAuthorized] = useState<boolean>(false);
+  const [isOwnProfile, setIsOwnProfile] = useState<boolean>(false);
+
+  const user = useCurrentUser();
+
+  useEffect(() => {
+    const userIsAuthorized = user?.role === UserRole.ADMIN || user?.role === UserRole.COORDINATOR;
+    const personId = user?.personId;
+    if (userIsAuthorized) setIsAuthorized(true);
+    if (contactPersonId && personId === contactPersonId) {
+      setIsOwnProfile(true);
+    } else {
+      setIsOwnProfile(false);
+    }
+    return () => setIsAuthorized(false);
+  }, [user, contactPersonId]);
+
+  return { isAuthorized, isOwnProfile };
+};

--- a/src/hooks/useOpportunityProfileSections.tsx
+++ b/src/hooks/useOpportunityProfileSections.tsx
@@ -15,11 +15,14 @@ import { ApiOpportunityGet, OpportunityVolunteerStatusType, VolunteerStateTypeTy
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useAuth } from "./useAuth";
 
 export const useOpportunityProfileSections = (opportunity: ApiOpportunityGet | undefined) => {
   const { t, i18n } = useTranslation();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { isAuthorized, isOwnProfile } = useAuth(opportunity?.contact.id);
+  const hasEditingRights = isAuthorized || isOwnProfile;
 
   const opportunityContactDetailsRef = useRef<EditableSectionRef>(null);
   const racRef = useRef<EditableSectionRef>(null);
@@ -65,10 +68,11 @@ export const useOpportunityProfileSections = (opportunity: ApiOpportunityGet | u
     {
       iconName: IconName.Wrench,
       title: t("dashboard.opportunityProfile.opportunityDetails.title"),
-      ...(!isOppDetailsEditing && {
-        headerButtonName: t("dashboard.opportunityProfile.editButtonName"),
-        onHeaderButtonClick: () => opportunityDetailsRef.current?.handleEditClick(),
-      }),
+      ...(!isOppDetailsEditing &&
+        hasEditingRights && {
+          headerButtonName: t("dashboard.opportunityProfile.editButtonName"),
+          onHeaderButtonClick: () => opportunityDetailsRef.current?.handleEditClick(),
+        }),
       subComponent: (
         <OpportunityDetails
           ref={opportunityDetailsRef}
@@ -78,76 +82,85 @@ export const useOpportunityProfileSections = (opportunity: ApiOpportunityGet | u
       ),
     },
     {
-      iconName: IconName.ChatsCircle,
-      title: t("dashboard.opportunityProfile.contactDetailsTitle"),
-      ...(!isContactEditing && {
-        headerButtonName: t("dashboard.opportunityProfile.editButtonName"),
-        onHeaderButtonClick: () => opportunityContactDetailsRef.current?.handleEditClick(),
-      }),
-      subComponent: (
-        <ContactDetails
-          ref={opportunityContactDetailsRef}
-          opportunity={opportunity}
-          onEditingChange={handleContactEditingChange}
-        />
-      ),
-    },
-    {
       iconName: IconName.House,
       title: t("dashboard.opportunityProfile.racTitle"),
-      ...(!isRacEditing && {
-        headerButtonName: t("dashboard.opportunityProfile.editButtonName"),
-        onHeaderButtonClick: () => racRef.current?.handleEditClick(),
-      }),
+      ...(!isRacEditing &&
+        hasEditingRights && {
+          headerButtonName: t("dashboard.opportunityProfile.editButtonName"),
+          onHeaderButtonClick: () => racRef.current?.handleEditClick(),
+        }),
       subComponent: (
         <RefugeeAccommodationCentre ref={racRef} opportunity={opportunity} onEditingChange={handleRacEditingChange} />
       ),
     },
-    {
-      iconName: IconName.Users,
-      title: t("dashboard.opportunityProfile.accompanyingDetailsTitle"),
-      ...(isAccompanyingType &&
-        !isAccompanyingEditing && {
+  ];
+
+  if (hasEditingRights) {
+    sections.push(
+      {
+        iconName: IconName.Users,
+        title: t("dashboard.opportunityProfile.accompanyingDetailsTitle"),
+        ...(isAccompanyingType &&
+          !isAccompanyingEditing && {
+            headerButtonName: t("dashboard.opportunityProfile.editButtonName"),
+            onHeaderButtonClick: () => accompanyingDetailsRef.current?.handleEditClick?.(),
+          }),
+        subComponent: (
+          <AccompanyingDetails
+            ref={accompanyingDetailsRef}
+            opportunity={opportunity}
+            onEditingChange={handleAccompanyingEditingChange}
+          />
+        ),
+      },
+      {
+        iconName: IconName.UsersThree,
+        title: t("dashboard.opportunityProfile.volunteersSec.title"),
+        headerButtonName: volunteerId
+          ? t("dashboard.opportunityProfile.volunteersSec.suggestButtonName")
+          : t("dashboard.opportunityProfile.volunteersSec.findVolunteers"),
+        onHeaderButtonClick: volunteerId
+          ? () => setIsSuggestDialogOpen(true)
+          : () => router.push(`/${i18n.language}/dashboard/volunteers?opportunity=${opportunity.id}`),
+        subComponent: (
+          <>
+            <OpportunityVolunteers opportunityId={opportunity.id} />
+            {isSuggestDialogOpen && (
+              <SuggestDialog
+                opportunityName={opportunity.title}
+                volunteerName={volunteer?.name}
+                onCancel={() => setIsSuggestDialogOpen(false)}
+                onConfirm={handleSuggestConfirm}
+              />
+            )}
+          </>
+        ),
+      },
+      {
+        iconName: IconName.ChatsCircle,
+        title: t("dashboard.opportunityProfile.contactDetailsTitle"),
+        ...(!isContactEditing && {
           headerButtonName: t("dashboard.opportunityProfile.editButtonName"),
-          onHeaderButtonClick: () => accompanyingDetailsRef.current?.handleEditClick?.(),
+          onHeaderButtonClick: () => opportunityContactDetailsRef.current?.handleEditClick(),
         }),
-      subComponent: (
-        <AccompanyingDetails
-          ref={accompanyingDetailsRef}
-          opportunity={opportunity}
-          onEditingChange={handleAccompanyingEditingChange}
-        />
-      ),
-    },
-    {
-      iconName: IconName.UsersThree,
-      title: t("dashboard.opportunityProfile.volunteersSec.title"),
-      headerButtonName: volunteerId
-        ? t("dashboard.opportunityProfile.volunteersSec.suggestButtonName")
-        : t("dashboard.opportunityProfile.volunteersSec.findVolunteers"),
-      onHeaderButtonClick: volunteerId
-        ? () => setIsSuggestDialogOpen(true)
-        : () => router.push(`/${i18n.language}/dashboard/volunteers?opportunity=${opportunity.id}`),
-      subComponent: (
-        <>
-          <OpportunityVolunteers opportunityId={opportunity.id} />
-          {isSuggestDialogOpen && (
-            <SuggestDialog
-              opportunityName={opportunity.title}
-              volunteerName={volunteer?.name}
-              onCancel={() => setIsSuggestDialogOpen(false)}
-              onConfirm={handleSuggestConfirm}
-            />
-          )}
-        </>
-      ),
-    },
-    {
+        subComponent: (
+          <ContactDetails
+            ref={opportunityContactDetailsRef}
+            opportunity={opportunity}
+            onEditingChange={handleContactEditingChange}
+          />
+        ),
+      },
+    );
+  }
+
+  if (isAuthorized) {
+    sections.push({
       iconName: IconName.ChatCircleDots,
       title: `${t("dashboard.volunteerProfile.coordinatorComments")} • ${commentsCount}`,
       subComponent: <Comments opportunity={opportunity} />,
-    },
-  ];
+    });
+  }
 
   return {
     sections,


### PR DESCRIPTION
## Description
Adds auth view to Opportunity profile

1. Related-NGO view (who created opportunity)
2. Unrelated-NGO view & Volunteer view
3. Admin/Coordinator view

## Related Issues
Closes #575, #574, #633

## Changes
- Bullet list of meaningful changes (optional)

## Screenshots / Demos
1. Related-NGO view (who created opportunity)
<img width="296" height="582" alt="image" src="https://github.com/user-attachments/assets/29c9b8ec-711a-4211-9126-0266821366c0" />

2. Unrelated-NGO view & other unauthorised users
<img width="560" height="660" alt="image" src="https://github.com/user-attachments/assets/319fd4a5-2c39-402e-aa9d-337c24367ff9" />

3. Admin/Coordinator view
<img width="274" height="703" alt="image" src="https://github.com/user-attachments/assets/6e6d3004-88f9-4464-bd4f-cb0d0dd1f668" />


## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

