### PR TITLE
#569: NGO view:  restrict contact columns on volunteer list

### DIFF
--- a/src/components/Dashboard/Volunteers/VolunteerListController.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerListController.tsx
@@ -3,13 +3,14 @@ import { useEffect } from "react";
 import { DashboardListLoading } from "@/components/Dashboard/common/DashboardListLoading";
 import { apiPathVolunteer, cacheTTL, CARD_COLUMNS, CARD_LIMIT, CARD_ROWS, TABLE_LIMIT } from "@/config/constants";
 import { useGetQuery, usePageParam } from "@/hooks";
-import { ApiOptionLists, ApiVolunteerGetList, SortOrder } from "need4deed-sdk";
+import { ApiOptionLists, ApiVolunteerGetList, SortOrder, UserRole } from "need4deed-sdk";
 import { CardsFilter } from "./Filters/types";
 import { serializeFilters } from "./helpers";
 import { VolunteerCardList } from "./VolunteerCardList";
 import { VolunteerTableList } from "./VolunteerTableList";
 import { ViewMode } from "../common/types";
 import { useCopyVolunteerEmails } from "@/hooks/useCopyVolunteerEmails";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 interface VolunteerListControllerProps {
   setNumOfVols: (numOfVols: number) => void;
@@ -58,6 +59,8 @@ export function VolunteerListController({
   });
   const volunteers = data || [];
   const { handleCopyEmails, isCopying } = useCopyVolunteerEmails(serializedFilter);
+  const user = useCurrentUser();
+  const canSeeContactColumns = user?.role === UserRole.COORDINATOR || user?.role === UserRole.ADMIN;
 
   useEffect(() => {
     setNumOfVols(count);
@@ -76,6 +79,7 @@ export function VolunteerListController({
         opportunityId={opportunityId}
         onCopyEmails={handleCopyEmails}
         isCopying={isCopying}
+        canSeeContactColumns={canSeeContactColumns}
       />
     );
   }

--- a/src/components/Dashboard/Volunteers/VolunteerTableList.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerTableList.tsx
@@ -22,6 +22,7 @@ interface TableListProps {
   opportunityId?: string;
   onCopyEmails: () => void;
   isCopying: boolean;
+  canSeeContactColumns: boolean;
 }
 
 export function VolunteerTableList({
@@ -33,6 +34,7 @@ export function VolunteerTableList({
   opportunityId,
   onCopyEmails,
   isCopying,
+  canSeeContactColumns,
 }: TableListProps) {
   const { t } = useTranslation();
   const engagementLabels = useMemo(() => createEngagementStatusLabelMap(t), [t]);
@@ -46,8 +48,8 @@ export function VolunteerTableList({
         ariaLabel={t("dashboard.volunteers.copyEmails.tooltip")}
       />
     );
-    return createVolunteerTableColumns(t, copyButton);
-  }, [t, onCopyEmails, isCopying]);
+    return createVolunteerTableColumns(t, copyButton, canSeeContactColumns);
+  }, [t, onCopyEmails, isCopying, canSeeContactColumns]);
   const matchLabels = useMemo(() => createMatchStatusLabelMap(t), [t]);
 
   return (
@@ -63,6 +65,7 @@ export function VolunteerTableList({
           typeLabels={typeLabels}
           matchLabels={matchLabels}
           opportunityId={opportunityId}
+          canSeeContactColumns={canSeeContactColumns}
         />
       )}
       count={count}

--- a/src/components/Dashboard/Volunteers/VolunteerTableRow.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerTableRow.tsx
@@ -12,7 +12,7 @@ import { getImageUrl } from "@/utils";
 import { ApiVolunteerGetList } from "need4deed-sdk";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
-import { VOLUNTEER_COL_WIDTHS } from "./volunteerTableColumns";
+import { getVolunteerColWidths } from "./volunteerTableColumns";
 import { getFirstName, getTopLanguages, truncateList } from "./helpers";
 import { CopyEmail } from "../common/CopyEmail";
 import { CheckCircleIcon } from "@phosphor-icons/react";
@@ -25,6 +25,7 @@ interface TableRowProps {
   typeLabels: ReturnType<typeof createStatusLabelMap>;
   matchLabels: ReturnType<typeof createMatchStatusLabelMap>;
   opportunityId?: string;
+  canSeeContactColumns: boolean;
 }
 
 export function VolunteerTableRow({
@@ -34,9 +35,11 @@ export function VolunteerTableRow({
   typeLabels,
   matchLabels,
   opportunityId,
+  canSeeContactColumns,
 }: TableRowProps) {
   const { i18n } = useTranslation();
   const router = useRouter();
+  const VOLUNTEER_COL_WIDTHS = getVolunteerColWidths(canSeeContactColumns);
 
   const {
     id,
@@ -102,15 +105,17 @@ export function VolunteerTableRow({
       <TableCell $width={VOLUNTEER_COL_WIDTHS.district} $noWrap data-testid={`volunteer-district-${id}`}>
         <TruncatedText>{districtText}</TruncatedText>
       </TableCell>
-      <TableCell
-        $width={VOLUNTEER_COL_WIDTHS.email}
-        $noWrap
-        $align="space-between"
-        data-testid={`volunteer-email-${id}`}
-      >
-        <TruncatedText>{email || "—"}</TruncatedText>
-        {email && <CopyEmail email={email} name={name} />}
-      </TableCell>
+      {canSeeContactColumns && (
+        <TableCell
+          $width={VOLUNTEER_COL_WIDTHS.email}
+          $noWrap
+          $align="space-between"
+          data-testid={`volunteer-email-${id}`}
+        >
+          <TruncatedText>{email || "—"}</TruncatedText>
+          {email && <CopyEmail email={email} name={name} />}
+        </TableCell>
+      )}
     </ClickableRow>
   );
 }

--- a/src/components/Dashboard/Volunteers/volunteerTableColumns.ts
+++ b/src/components/Dashboard/Volunteers/volunteerTableColumns.ts
@@ -3,7 +3,7 @@ import { Column } from "../common/EntityTableList";
 import { COLUMN_WIDTH } from "../common/EntityTableList/columnWidths";
 import { ReactNode } from "react";
 
-export const VOLUNTEER_COL_WIDTHS = {
+const FULL_WIDTHS = {
   name: COLUMN_WIDTH.SM,
   type: COLUMN_WIDTH.LG,
   engagement: COLUMN_WIDTH.LG,
@@ -12,22 +12,46 @@ export const VOLUNTEER_COL_WIDTHS = {
   district: COLUMN_WIDTH.SM,
   email: COLUMN_WIDTH.XXXL,
 };
+const RESTRICTED_WIDTHS = {
+  ...FULL_WIDTHS,
+  name: COLUMN_WIDTH.LG,
+  type: COLUMN_WIDTH.XXXL,
+  engagement: COLUMN_WIDTH.XXXL,
+  matching: COLUMN_WIDTH.XXL,
+  language: COLUMN_WIDTH.LG,
+};
 
-export const createVolunteerTableColumns = (t: TFunction, copyButton: ReactNode): Column[] => [
-  { key: "name", label: t("dashboard.volunteers.table.name"), width: VOLUNTEER_COL_WIDTHS.name },
-  { key: "type", label: t("dashboard.volunteers.table.type"), width: VOLUNTEER_COL_WIDTHS.type },
-  {
-    key: "engagement",
-    label: t("dashboard.volunteers.table.engagementStatus"),
-    width: VOLUNTEER_COL_WIDTHS.engagement,
-  },
-  { key: "matching", label: t("dashboard.volunteers.table.matchingStatus"), width: VOLUNTEER_COL_WIDTHS.matching },
-  { key: "language", label: t("dashboard.volunteers.table.language"), width: VOLUNTEER_COL_WIDTHS.language },
-  { key: "district", label: t("dashboard.volunteers.table.district"), width: VOLUNTEER_COL_WIDTHS.district },
-  {
-    key: "email",
-    label: t("dashboard.volunteers.table.email"),
-    width: VOLUNTEER_COL_WIDTHS.email,
-    headerAction: copyButton,
-  },
-];
+export const getVolunteerColWidths = (canSeeContactColumns: boolean) =>
+  canSeeContactColumns ? FULL_WIDTHS : RESTRICTED_WIDTHS;
+
+export const createVolunteerTableColumns = (
+  t: TFunction,
+  copyButton: ReactNode,
+  canSeeContactColumns: boolean,
+): Column[] => {
+  const VOLUNTEER_COL_WIDTHS = getVolunteerColWidths(canSeeContactColumns);
+
+  const columns: Column[] = [
+    { key: "name", label: t("dashboard.volunteers.table.name"), width: VOLUNTEER_COL_WIDTHS.name },
+    { key: "type", label: t("dashboard.volunteers.table.type"), width: VOLUNTEER_COL_WIDTHS.type },
+    {
+      key: "engagement",
+      label: t("dashboard.volunteers.table.engagementStatus"),
+      width: VOLUNTEER_COL_WIDTHS.engagement,
+    },
+    { key: "matching", label: t("dashboard.volunteers.table.matchingStatus"), width: VOLUNTEER_COL_WIDTHS.matching },
+    { key: "language", label: t("dashboard.volunteers.table.language"), width: VOLUNTEER_COL_WIDTHS.language },
+    { key: "district", label: t("dashboard.volunteers.table.district"), width: VOLUNTEER_COL_WIDTHS.district },
+  ];
+
+  if (canSeeContactColumns) {
+    columns.push({
+      key: "email",
+      label: t("dashboard.volunteers.table.email"),
+      width: VOLUNTEER_COL_WIDTHS.email,
+      headerAction: copyButton,
+    });
+  }
+
+  return columns;
+};


### PR DESCRIPTION
## Description
Restricts the volunteer list for NGO/agent and volunteer roles to hide contact data. The email column and both copy actions (copy-all header and per-row) are gated behind an allowlist (`canSeeContactColumns = role === COORDINATOR || ADMIN`), so non-staff can't see or export volunteer emails. Last name is already hidden (first name only). Coordinator/admin views are unchanged.

## Related Issues
Closes #569 

## Changes
 - Hide email column for NGO/agent and volunteer roles
 - Remaining columns rebalance to restricted widths when email is dropped
 - Coordinator/admin views unchanged

**Open questions for @nadavosa** (raised in the issue, surfacing here):
- **Matching column**  currently still shown. Your spec lists only specific columns, and Matching isn't one. Hide it for the NGO, or keep it?
- **Activities and Schedule**  in your spec, but the table doesn't have that data (BE only sends it for the card view). Keep them out for now, or should they be added?

## Screenshots / Demos
<img width="1354" height="725" alt="Screenshot from 2026-06-14 07-51-16" src="https://github.com/user-attachments/assets/e42ea200-d854-4113-b0d5-e2d83877f947" />


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

