### PR TITLE
fix: make entire search field focusable, not just the input

### DIFF
--- a/src/components/core/common/Search.tsx
+++ b/src/components/core/common/Search.tsx
@@ -18,6 +18,7 @@ const SearchContainer = styled.div<SearchContainerProps>`
   border-radius: var(--search-container-border-radius);
   align-items: center;
   padding: var(--search-container-padding);
+  cursor: text;
 `;
 
 const StyledInput = styled.input`
@@ -48,6 +49,7 @@ export function Search({
   debounceTime = 500,
 }: Props) {
   const [inputValue, setInputValue] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Use useCallback to ensure the debounced function is stable
@@ -87,8 +89,8 @@ export function Search({
   }, []);
 
   return (
-    <SearchContainer width={width} $backgroundColor={backgroundColor}>
-      <StyledInput placeholder={placeHolder} value={inputValue} onChange={handleInputChange} />
+    <SearchContainer width={width} $backgroundColor={backgroundColor} onClick={() => inputRef.current?.focus()}>
+      <StyledInput ref={inputRef} placeholder={placeHolder} value={inputValue} onChange={handleInputChange} />
       <MagnifyingGlassIcon size={32} />
     </SearchContainer>
   );


### PR DESCRIPTION
## Summary
The search bar on the volunteers and opportunities lists only focused its
`<input>`; the container padding and the magnifier icon were dead zones.

Adds a ref-based `onClick` on the container that focuses the input, plus
`cursor: text`, so clicking anywhere in the field focuses it. Single shared
component, so both lists are covered.

Closes #662
