### PR TITLE
feat: add show/hide toggle to password fields

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1950,5 +1950,9 @@
       "title": "Beitrittsanfrage gesendet",
       "description": "Ein Administrator prüft deine Anfrage, dieser Organisation beizutreten. Nach der Freigabe erhältst du Zugriff."
     }
+  },
+  "formInput": {
+    "showPassword": "Passwort anzeigen",
+    "hidePassword": "Passwort verbergen"
   }
 }

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1582,5 +1582,9 @@
       "title": "Join request submitted",
       "description": "An administrator will review your request to join this organisation. You'll get access once it's approved."
     }
+  },
+  "formInput": {
+    "showPassword": "Show password",
+    "hidePassword": "Hide password"
   }
 }

--- a/src/components/core/common/FormInput.tsx
+++ b/src/components/core/common/FormInput.tsx
@@ -1,7 +1,8 @@
 import { Paragraph } from "@/components/styled/text";
-import { WarningCircleIcon } from "@phosphor-icons/react";
+import { EyeIcon, EyeSlashIcon, WarningCircleIcon } from "@phosphor-icons/react";
 import { ValidationError } from "@tanstack/react-form";
-import { ChangeEvent } from "react";
+import { ChangeEvent, useState } from "react";
+import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 
 const FormInputContainer = styled.div`
@@ -22,6 +23,7 @@ interface StyledInputProps {
   width?: string;
   $backgroundColor?: string;
   $errorsExist?: boolean;
+  $hasToggle?: boolean;
 }
 
 const StyledInput = styled.input<StyledInputProps>`
@@ -32,12 +34,34 @@ const StyledInput = styled.input<StyledInputProps>`
   background-color: ${(props) => props.$backgroundColor || "var(--color-white)"};
   border-radius: var(--form-input-container-border-radius);
   padding: var(--form-input-container-padding);
+  ${(props) => props.$hasToggle && "padding-right: 48px;"}
   border: ${(props) => `var(--form-input-container-border${props.$errorsExist ? "-error" : ""})`};
 
   &:focus {
     outline: none;
     border: var(--form-input-container-border-focus);
   }
+`;
+
+const InputRow = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+`;
+
+const ToggleButton = styled.button`
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: var(--color-midnight);
 `;
 
 interface Props {
@@ -59,23 +83,40 @@ export function FormInput({
   backgroundColor,
   errors,
 }: Props) {
+  const { t } = useTranslation();
+  const [showPassword, setShowPassword] = useState(false);
+
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     onInputChange(e.target.value);
   };
 
   const errorsExist = errors && errors.length > 0;
+  const isPassword = type === "password";
+  const inputType = isPassword && showPassword ? "text" : type;
 
   return (
     <FormInputContainer>
-      <StyledInput
-        placeholder={placeHolder}
-        value={value}
-        onChange={handleInputChange}
-        type={type}
-        width={width}
-        $backgroundColor={backgroundColor}
-        $errorsExist={errorsExist}
-      />
+      <InputRow>
+        <StyledInput
+          placeholder={placeHolder}
+          value={value}
+          onChange={handleInputChange}
+          type={inputType}
+          width={width}
+          $backgroundColor={backgroundColor}
+          $errorsExist={errorsExist}
+          $hasToggle={isPassword}
+        />
+        {isPassword && (
+          <ToggleButton
+            type="button"
+            onClick={() => setShowPassword((prev) => !prev)}
+            aria-label={t(showPassword ? "formInput.hidePassword" : "formInput.showPassword")}
+          >
+            {showPassword ? <EyeSlashIcon size={20} /> : <EyeIcon size={20} />}
+          </ToggleButton>
+        )}
+      </InputRow>
 
       {errorsExist &&
         errors.map((error) => (


### PR DESCRIPTION
## Summary
Password fields had no way to reveal the entered value before submitting.

Adds an eye / eye-slash toggle inside the shared `FormInput`, rendered only
for `type="password"`. Covers the login form and agent registration (password
and confirm password). The toggle is a `type="button"` (so it never submits the
form) with an i18n `aria-label` (new `formInput.showPassword` / `hidePassword`
keys in en and de).

Closes #663
