### PR TITLE
fix(#673): pre-fill matched org address on confirm

### DIFF
--- a/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
+++ b/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
@@ -78,6 +78,7 @@ export function ProfileCompletion() {
   const { matched, selectedAgent, showBanner, confirmMatch, dismissMatch } = useAgentAddressLookup(
     formData.addressStreet,
     token,
+    (m) => update({ addressStreet: m.title }),
   );
 
   const update = (fields: Partial<ProfileCompletionData>) => {

--- a/src/components/AgentRegistration/ProfileCompletion/useAgentAddressLookup.ts
+++ b/src/components/AgentRegistration/ProfileCompletion/useAgentAddressLookup.ts
@@ -9,7 +9,11 @@ type AgentSearchMatch = { id: number; title: string };
 // existing agents at a matching address so they can JOIN their org instead of
 // creating a duplicate. Backed by the token-gated GET /agent/register/search
 // (the COORDINATOR-only GET /agent is not available to a registrant).
-export function useAgentAddressLookup(addressStreet: string, token: string | null) {
+export function useAgentAddressLookup(
+  addressStreet: string,
+  token: string | null,
+  onConfirm?: (matched: AgentSearchMatch) => void,
+) {
   const [selectedAgent, setSelectedAgent] = useState<AgentSearchMatch | null>(null);
   const [dismissedAddress, setDismissedAddress] = useState<string | null>(null);
   const debouncedAddress = useDebounce(addressStreet.trim(), 400);
@@ -33,7 +37,9 @@ export function useAgentAddressLookup(addressStreet: string, token: string | nul
   const showBanner = !!matched && !isMatch && !isDismissed;
 
   const confirmMatch = () => {
-    if (matched) setSelectedAgent(matched);
+    if (!matched) return;
+    setSelectedAgent(matched);
+    onConfirm?.(matched);
   };
 
   const dismissMatch = () => {


### PR DESCRIPTION
Closes #673

## Problem
On `/register/agent/complete` (Step 1), typing a partial street (e.g. "elen")
surfaces a matching org banner. After clicking "Yes, use this", the address
field still held the partial typed text instead of the full matched value, so
the user never saw what was actually selected.

## Fix
- `useAgentAddressLookup`: `confirmMatch` now invokes an optional `onConfirm`
  callback with the full match.
- `ProfileCompletion`: passes `(m) => update({ addressStreet: m.title })` so the
  address field is replaced with the matched org's full title on selection.

The matched value may be a full street or a full org title (the lookup searches
both); either way the whole value is now surfaced.

No BE changes.

## Test plan
- [x] `yarn typecheck`, `yarn lint` green
- [ ] Reviewer: type a partial street, confirm match, verify field shows the
      full matched value
