### PR TITLE
fix: surface registration token errors and block form on bad token (#674)

### DIFF
--- a/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
+++ b/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
@@ -13,7 +13,7 @@ import {
   ApiOptionLists,
 } from "need4deed-sdk";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { validateCompletionStep } from "../helpers";
 import { ProgressBar } from "../ProgressBar";
@@ -69,6 +69,7 @@ export function ProfileCompletion() {
   // When a CREATE collides with an existing title, the API returns its id so we
   // can offer to JOIN it instead.
   const [titleConflictAgentId, setTitleConflictAgentId] = useState<number | null>(null);
+  const errorBannerRef = useRef<HTMLDivElement>(null);
 
   const { data: optionLists } = useGetQuery<ApiOptionLists>({
     queryKey: ["options"],
@@ -79,6 +80,17 @@ export function ProfileCompletion() {
     formData.addressStreet,
     token,
   );
+
+  const showSubmitError = useCallback((message: string) => {
+    setSubmitError(message);
+    requestAnimationFrame(() => {
+      errorBannerRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!token) showSubmitError(t("agentRegistration.errors.missingToken"));
+  }, [token, t, showSubmitError]);
 
   const update = (fields: Partial<ProfileCompletionData>) => {
     setFormData((prev) => ({ ...prev, ...fields }));
@@ -94,7 +106,7 @@ export function ProfileCompletion() {
 
   const submit = async (body: ApiAgentRegister) => {
     if (!token) {
-      setSubmitError(t("agentRegistration.errors.missingToken"));
+      showSubmitError(t("agentRegistration.errors.missingToken"));
       return;
     }
     setSubmitError(null);
@@ -117,7 +129,7 @@ export function ProfileCompletion() {
         setTitleConflictAgentId(conflictAgentId ?? null);
         return;
       }
-      setSubmitError(t("message.errorGeneric"));
+      showSubmitError(t("message.errorGeneric"));
     } finally {
       setIsSubmitting(false);
     }
@@ -175,6 +187,7 @@ export function ProfileCompletion() {
   // request directly without the create-only org/services steps.
   const isJoining = !!selectedAgent;
   const isLastStep = step === TOTAL_COMPLETION_STEPS;
+  const tokenMissing = !token;
 
   return (
     <Wrapper>
@@ -184,7 +197,7 @@ export function ProfileCompletion() {
 
         {!isJoining && <ProgressBar currentStep={step} totalSteps={TOTAL_COMPLETION_STEPS} />}
 
-        {submitError && <ErrorBanner>{submitError}</ErrorBanner>}
+        {submitError && <ErrorBanner ref={errorBannerRef}>{submitError}</ErrorBanner>}
 
         {titleConflictAgentId !== null && (
           <MatchBanner $matched={false}>
@@ -266,7 +279,7 @@ export function ProfileCompletion() {
               backgroundcolor="var(--color-aubergine)"
               textColor="var(--color-white)"
               onClick={handleSubmit}
-              disabled={isSubmitting}
+              disabled={isSubmitting || tokenMissing}
             />
           ) : (
             <Button
@@ -274,6 +287,7 @@ export function ProfileCompletion() {
               backgroundcolor="var(--color-aubergine)"
               textColor="var(--color-white)"
               onClick={handleNext}
+              disabled={tokenMissing}
             />
           )}
         </Actions>


### PR DESCRIPTION
Closes #674

## Problem

On `/register/agent/complete`, a null or expired token made every submit fail silently: `setSubmitError()` fired but the ErrorBanner sits at the top of the card, often out of view, so the "Request to Join" button looked dead. The user could also fill in the whole form and only hit the failure at the final submit.

## Changes

`src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx`

- Show the missing-token error on mount, not just after a click.
- Add `showSubmitError`, which sets the error and scrolls the banner into view via `requestAnimationFrame` on every error, so a repeat click with an identical message still re-scrolls.
- Disable "Next" and "Submit / Request to Join" while the token is missing, so the form cannot be worked through only to fail at the end.
- The `finally` block in `submit()` already re-enables the button on every failure path; verified, left unchanged.

Uses the existing `agentRegistration.errors.missingToken` and `message.errorGeneric` translation keys. No new strings, no BE changes.
