### PR TITLE
Redirect on Agent Profile for NGO and Volunteers

### DIFF
--- a/src/app/[lang]/dashboard/agents/[id]/page.tsx
+++ b/src/app/[lang]/dashboard/agents/[id]/page.tsx
@@ -1,7 +1,19 @@
 import ProfileLayout from "@/components/Dashboard/Profile/ProfileLayout";
+import { getServerUserRole } from "@/hooks/api/getUserRole";
 import { RouteParams } from "@/types";
+import { UserRole } from "need4deed-sdk";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 
 export default async function DashboardAgentPage({ params }: RouteParams) {
   const { id } = await params;
+
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore.toString();
+  const userRole = await getServerUserRole(cookieHeader);
+
+  if (!userRole || (userRole !== UserRole.COORDINATOR && userRole !== UserRole.ADMIN)) {
+    redirect(`/dashboard/agents`);
+  }
   return <ProfileLayout entityId={id} entityType="agent" />;
 }

--- a/src/hooks/api/getUserRole.ts
+++ b/src/hooks/api/getUserRole.ts
@@ -1,0 +1,27 @@
+import { fetchFn } from "@/hooks/api/utils";
+import { UserRole } from "need4deed-sdk";
+import { apiPathMe } from "@/config/constants";
+
+export interface ApiResponse<T> {
+  message: string;
+  data: T;
+  count: number;
+}
+
+export const getServerUserRole = async (cookieHeader: string): Promise<UserRole | null> => {
+  try {
+    const urlPath = apiPathMe.replace("/api/", "");
+    const response = await fetchFn<ApiResponse<{ role: UserRole }>>({
+      url: `${process.env.URL_API}/${urlPath}`,
+      options: {
+        method: "GET",
+        headers: { Cookie: cookieHeader },
+        cache: "no-store",
+      },
+    });
+    return response.data.role;
+  } catch (error) {
+    console.error("Failed to fetch server user role:", error);
+    return null;
+  }
+};


### PR DESCRIPTION
## Description
Adds a redirect on `/agent/[id]` for users who aren't `ADMIN` or `COORDINATOR`

## Related Issues
Closes #576 , cooicides with [PR 641](https://github.com/need4deed-org/fe/pull/641) which adds unclickable links and restricted-list views

## Changes
To reproduce:

1. Login as `AGENT` or `VOLUNTEER`
2. Navigate to `.../dashbaord/agents/1`
3. You should be redirected to `.../dashboard/agents`
4. Change role as either `ADMIN` or `COORDINATOR`
5. Navigate to `.../dashbaord/agents/1`
6. You should not be redirected and will see profile

## Screenshots / Demos
If UI-related, add before/after or GIFs.

## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

