### PR TITLE
fix: wrap volunteer card status tags within card boundary

### DIFF
--- a/src/components/Dashboard/Volunteers/VolunteerCard.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerCard.tsx
@@ -229,6 +229,7 @@ const Card = styled(BaseCard)`
 const StatusTagsDiv = styled.div`
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   gap: var(--dashboard-volunteers-card-status-tags-div-gap);
   margin-top: var(--dashboard-volunteers-card-status-tags-div-margin-top);
 `;


### PR DESCRIPTION
## What

Adds `flex-wrap: wrap` to `StatusTagsDiv` in `VolunteerCard`, so its status tags wrap inside the card boundary instead of overflowing.

## Why

Follow-up to #643, where @DarrellRoberts asked whether the same overflow fix could be applied to the volunteer cards: https://github.com/need4deed-org/fe/pull/643#issuecomment-4688885573

`VolunteerCard` has its own copy of `StatusTagsDiv` (not shared with the opportunity card) that was missing the same `flex-wrap`, so it had the identical overflow. As agreed in that discussion, this is the minimal one-line fix only; the shared-component refactor was intentionally left out (the card needs a broader refactor separately).

## Test plan

- [ ] Volunteer card with many status tags wraps within the card boundary at all viewport sizes
- [ ] Cards with few or no tags are unaffected

cc @DarrellRoberts