### PR TITLE
fix(#682): stale is_logged_in cookie causes /me 401 to /refresh 400 loop

### DIFF
--- a/src/components/AgentRegistration/AgentRegistration.tsx
+++ b/src/components/AgentRegistration/AgentRegistration.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Button } from "@/components/core/button";
-import { apiPathUser, LOGGED_IN_COOKIE } from "@/config/constants";
+import { apiPathUser } from "@/config/constants";
 import axios from "axios";
 import { UserRole } from "need4deed-sdk";
 import { useState } from "react";
@@ -71,7 +71,6 @@ export function AgentRegistration() {
         },
       });
 
-      document.cookie = LOGGED_IN_COOKIE;
       document.cookie = PENDING_ROLE_COOKIE;
       setIsSuccess(true);
     } catch (err) {

--- a/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
+++ b/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { Button } from "@/components/core/button";
 import { FormInput } from "@/components/core/common";
-import { apiPathAgentRegister, apiPathOption, LOGGED_IN_COOKIE } from "@/config/constants";
+import { apiPathAgentRegister, apiPathOption } from "@/config/constants";
 import { useGetQuery } from "@/hooks";
 import axios from "axios";
 import i18next from "i18next";
@@ -38,6 +38,7 @@ import {
 import { defaultProfileCompletionData, ProfileCompletionData, TOTAL_COMPLETION_STEPS } from "../types";
 import { CheckMark, MatchBanner, MatchActions, SmallButton } from "./styled";
 import { useAgentAddressLookup } from "./useAgentAddressLookup";
+import { setAuthHint } from "@/utils/helpers";
 
 function buildNewAgent(formData: ProfileCompletionData): ApiAgentRegisterNew {
   return {
@@ -122,7 +123,7 @@ export function ProfileCompletion() {
         setPending(true);
         return;
       }
-      document.cookie = LOGGED_IN_COOKIE;
+      setAuthHint();
       router.push(`/${i18next.language}/dashboard`);
     } catch (err) {
       if (axios.isAxiosError(err) && err.response?.status === 409) {

--- a/src/components/Login/LoginController.tsx
+++ b/src/components/Login/LoginController.tsx
@@ -4,7 +4,7 @@ import { UserRole } from "need4deed-sdk";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { LoginForm } from "./LoginForm";
-import { LOGGED_IN_COOKIE } from "@/config/constants";
+import { setAuthHint } from "@/utils/helpers";
 
 export function LoginController() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -22,7 +22,7 @@ export function LoginController() {
   return (
     <LoginForm
       onLoginSuccess={() => {
-        document.cookie = LOGGED_IN_COOKIE;
+        setAuthHint();
         setIsLoggedIn(true);
       }}
     />

--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { toast } from "react-toastify";
+import { clearAuthHint } from "@/utils/helpers";
 import { apiPathAuthRefresh } from "./constants";
 
 let isRefreshing = false;
@@ -66,6 +67,8 @@ axios.interceptors.response.use(
     } catch (refreshError: unknown) {
       // If refresh fails, process queue with error and redirect to login
       processQueue(refreshError, null);
+
+      clearAuthHint();
 
       // Only redirect if we aren't already on the login page to avoid loops
       if (!(window.location.pathname.includes("login") || window.location.pathname.includes("forms"))) {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -77,7 +77,9 @@ export const MAX_DESCRIPTION_LENGTH = 500;
 
 export const PHONE_NUMBER_REGEX = /^[+\d\s\-()/]+$/;
 
-export const LOGGED_IN_COOKIE = "is_logged_in=true; path=/; max-age=6000; SameSite=Lax; Secure";
+export const AUTH_HINT_COOKIE_NAME = "is_logged_in";
+export const AUTH_HINT_COOKIE_ATTRS = "path=/; SameSite=Lax; Secure";
+export const AUTH_HINT_MAX_AGE = 6000;
 
 export const TABLE_LIMIT = 20;
 export const CARD_COLUMNS = 3;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,10 @@
-import { cloudfrontURL, supportedLangs } from "@/config/constants";
+import {
+  AUTH_HINT_COOKIE_ATTRS,
+  AUTH_HINT_COOKIE_NAME,
+  AUTH_HINT_MAX_AGE,
+  cloudfrontURL,
+  supportedLangs,
+} from "@/config/constants";
 
 export function isEnumValue<E>(enumObject: object, value: E) {
   return typeof enumObject === "object" ? Object.values(enumObject).includes(value) : false;
@@ -27,4 +33,12 @@ export const getCookie = (name: string): string | undefined => {
   const parts = value.split(`; ${name}=`);
   if (parts.length === 2) return parts.pop()?.split(";").shift();
   return undefined;
+};
+
+export const setAuthHint = (): void => {
+  document.cookie = `${AUTH_HINT_COOKIE_NAME}=true; max-age=${AUTH_HINT_MAX_AGE}; ${AUTH_HINT_COOKIE_ATTRS}`;
+};
+
+export const clearAuthHint = (): void => {
+  document.cookie = `${AUTH_HINT_COOKIE_NAME}=; max-age=0; ${AUTH_HINT_COOKIE_ATTRS}`;
 };


### PR DESCRIPTION
Fixes #682. Part of #675.

## Problem
After an agent registers and the org membership lands PENDING, the
`is_logged_in` auth hint lies. It gates `/user/me` and `/agent/me`, but was
set right after `POST /user` (account created, no session yet) and was never
cleared anywhere. The false hint keeps firing `/user/me` 401, the interceptor
runs a refresh that returns 400, and `refetchOnWindowFocus` retriggers the
pair on every window focus. On `login`/`forms` paths the interceptor redirect
is suppressed by design, so nothing ever breaks the loop.

## Fix
Two independent layers, one source of truth for the cookie.

- `config/constants.ts`: replace the single `LOGGED_IN_COOKIE` string with
  shared building blocks (`AUTH_HINT_COOKIE_NAME`, `AUTH_HINT_COOKIE_ATTRS`,
  `AUTH_HINT_MAX_AGE`) so set and clear cannot drift apart. Deleting a cookie
  requires the same name and attributes as setting it, otherwise the clear is
  a no-op.
- `utils/helpers.ts`: add `setAuthHint()` / `clearAuthHint()` built from those
  constants. One definition shared by axios and login.
- `AgentRegistration.tsx`: stop setting the hint on account creation. No
  session exists at that point, this was the root cause.
- `LoginController.tsx` / `ProfileCompletion.tsx`: set the hint via
  `setAuthHint()` only where the backend established a session (the
  ProfileCompletion call sits after the PENDING early return).
- `config/axios.ts`: call `clearAuthHint()` in `catch (refreshError)` before
  the redirect, so a failed refresh self-heals and queries stop refiring.

## Known limitation
The `catch (refreshError)` block catches every refresh failure, not just an
auth rejection. So a transient `/auth/refresh` 500 or a network error also
clears the hint and logs the user out, same as a real 400. This is acceptable
for now only because all refresh failures funnel through this one catch-all
handler. Distinguishing transient server errors from real auth failures is a
separate follow-up, out of scope here.