### PR TITLE
feat: Opportunities table, green "matched" badge and matched volunteer name

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "0.0.103",
+    "need4deed-sdk": "0.0.107",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/src/components/Dashboard/Opportunities/OpportunityTableRow.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityTableRow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ApiVolunteerOpportunityGetList, OptionItem } from "need4deed-sdk";
-import { LangPurpose, ProfileVolunteeringType } from "need4deed-sdk";
+import { LangPurpose, OpportunityMatchStatusType, ProfileVolunteeringType } from "need4deed-sdk";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { ClickableRow, TableCell, TruncatedText, WrappedText } from "@/components/core/common/Table";
@@ -42,14 +42,10 @@ export function OpportunityTableRow({ opportunity, isLast, districtsList }: Tabl
       : null;
 
   const mainCommunication = getLanguagesByPurpose(languages, LangPurpose.GENERAL);
-  // the BE list returns "opp-vol-no-matches"
-  // for every opportunity. `volunteerNames` is correct
-  // so matched is derived it from it. Switch to statusMatch once fixed.
-  const isMatched = (volunteerNames?.length ?? 0) > 0;
-  const matchedNames = (volunteerNames ?? [])
-    .map((name) => name.split(" ")[0])
-    .filter(Boolean)
-    .join(", ");
+  const isMatched = statusMatch === OpportunityMatchStatusType.MATCHED;
+  const firstNames = (volunteerNames ?? []).map((name) => name.split(" ")[0]).filter(Boolean);
+  const matchedNames = firstNames.length > 1 ? `${firstNames[0]} +${firstNames.length - 1}` : (firstNames[0] ?? "");
+  const statusLabel = t(`dashboard.opportunities.matchStatus.${statusMatch}`);
 
   const handleGoToProfile = () => {
     if (!id) return;
@@ -65,11 +61,7 @@ export function OpportunityTableRow({ opportunity, isLast, districtsList }: Tabl
         <WrappedText>{scheduleText || "—"}</WrappedText>
       </TableCell>
       <TableCell $noWrap $width={OPPORTUNITY_COL_WIDTHS.statusMatch} data-testid={`opportunity-status-match-${id}`}>
-        {isMatched ? (
-          <MatchedBadge>{t("dashboard.opportunities.matchStatus.opp-vol-matched")}</MatchedBadge>
-        ) : (
-          <TruncatedText>{t(`dashboard.opportunities.matchStatus.${statusMatch}`)}</TruncatedText>
-        )}
+        {isMatched ? <MatchedBadge>{statusLabel}</MatchedBadge> : <TruncatedText>{statusLabel}</TruncatedText>}
       </TableCell>
       <TableCell $noWrap $width={OPPORTUNITY_COL_WIDTHS.languages} data-testid={`opportunity-languages-${id}`}>
         <TruncatedText>{mainCommunication || "—"}</TruncatedText>

--- a/src/components/Dashboard/Opportunities/OpportunityTableRow.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityTableRow.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import { ClickableRow, TableCell, TruncatedText, WrappedText } from "@/components/core/common/Table";
 import { OPPORTUNITY_COL_WIDTHS } from "./opportunitiesTableColumns";
 import { formatAccompanyingDate, formatSchedule, getLanguagesByPurpose } from "./helpers";
+import { MatchedBadge } from "./styles";
 
 interface TableRowProps {
   opportunity: ApiVolunteerOpportunityGetList;
@@ -29,6 +30,7 @@ export function OpportunityTableRow({ opportunity, isLast, districtsList }: Tabl
     district,
     agentTitle,
     numberOfVolunteers,
+    volunteerNames,
   } = opportunity;
   const districtTitle = district?.id ? (districtsList?.find((d) => d.id === district.id)?.title ?? null) : null;
 
@@ -40,6 +42,12 @@ export function OpportunityTableRow({ opportunity, isLast, districtsList }: Tabl
       : null;
 
   const mainCommunication = getLanguagesByPurpose(languages, LangPurpose.GENERAL);
+  const isMatched = (volunteerNames?.length ?? 0) > 0;
+  const matchedNames = (volunteerNames ?? [])
+    .map((name) => name.split(" ")[0])
+    .filter(Boolean)
+    .join(", ");
+
   const handleGoToProfile = () => {
     if (!id) return;
     router.push(`/${i18n.language}/dashboard/opportunities/${id}`);
@@ -54,7 +62,11 @@ export function OpportunityTableRow({ opportunity, isLast, districtsList }: Tabl
         <WrappedText>{scheduleText || "—"}</WrappedText>
       </TableCell>
       <TableCell $noWrap $width={OPPORTUNITY_COL_WIDTHS.statusMatch} data-testid={`opportunity-status-match-${id}`}>
-        <TruncatedText>{t(`dashboard.opportunities.matchStatus.${statusMatch}`)}</TruncatedText>
+        {isMatched ? (
+          <MatchedBadge>{t("dashboard.opportunities.matchStatus.opp-vol-matched")}</MatchedBadge>
+        ) : (
+          <TruncatedText>{t(`dashboard.opportunities.matchStatus.${statusMatch}`)}</TruncatedText>
+        )}
       </TableCell>
       <TableCell $noWrap $width={OPPORTUNITY_COL_WIDTHS.languages} data-testid={`opportunity-languages-${id}`}>
         <TruncatedText>{mainCommunication || "—"}</TruncatedText>
@@ -63,11 +75,10 @@ export function OpportunityTableRow({ opportunity, isLast, districtsList }: Tabl
         <TruncatedText>{districtTitle || "—"}</TruncatedText>
       </TableCell>
       <TableCell
-        $noWrap
         $width={OPPORTUNITY_COL_WIDTHS.numberOfVolunteers}
         data-testid={`opportunity-number-of-volunteers-${id}`}
       >
-        {numberOfVolunteers ?? "—"}
+        <WrappedText>{isMatched ? matchedNames : (numberOfVolunteers ?? "—")}</WrappedText>
       </TableCell>
       <TableCell $noWrap $width={OPPORTUNITY_COL_WIDTHS.agentTitle} data-testid={`opportunity-agent-${id}`}>
         <TruncatedText>{agentTitle || "—"}</TruncatedText>

--- a/src/components/Dashboard/Opportunities/OpportunityTableRow.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityTableRow.tsx
@@ -42,6 +42,9 @@ export function OpportunityTableRow({ opportunity, isLast, districtsList }: Tabl
       : null;
 
   const mainCommunication = getLanguagesByPurpose(languages, LangPurpose.GENERAL);
+  // the BE list returns "opp-vol-no-matches"
+  // for every opportunity. `volunteerNames` is correct
+  // so matched is derived it from it. Switch to statusMatch once fixed.
   const isMatched = (volunteerNames?.length ?? 0) > 0;
   const matchedNames = (volunteerNames ?? [])
     .map((name) => name.split(" ")[0])

--- a/src/components/Dashboard/Opportunities/opportunitiesTableColumns.ts
+++ b/src/components/Dashboard/Opportunities/opportunitiesTableColumns.ts
@@ -5,10 +5,10 @@ import { COLUMN_WIDTH } from "../common/EntityTableList/columnWidths";
 export const OPPORTUNITY_COL_WIDTHS = {
   title: COLUMN_WIDTH.LG,
   schedule: COLUMN_WIDTH.LG,
-  statusMatch: COLUMN_WIDTH.MD,
+  statusMatch: COLUMN_WIDTH.SM,
   languages: COLUMN_WIDTH.MD,
   district: COLUMN_WIDTH.XL,
-  numberOfVolunteers: COLUMN_WIDTH.XXS,
+  numberOfVolunteers: COLUMN_WIDTH.XS,
   agentTitle: COLUMN_WIDTH.XL,
 };
 

--- a/src/components/Dashboard/Opportunities/styles.ts
+++ b/src/components/Dashboard/Opportunities/styles.ts
@@ -86,3 +86,12 @@ export const LanguageRow = styled.div`
   flex-direction: row;
   gap: var(--dashboard-volunteers-card-detail-gap);
 `;
+
+export const MatchedBadge = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-8);
+  background: var(--color-green-100);
+  border-radius: var(--border-radius-xs);
+  padding: var(--spacing-12);
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,10 +2412,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.103:
-  version "0.0.103"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.103.tgz#836fa46e8cfe03288c7536f4e7b9c0b6a2f7a713"
-  integrity sha512-MdYk9AMWD0X5sOVYShQSRgwkbZm+GvoGi37O7xuwFkY+BQ6MbkuNK77wgFKm1x53sr62O4MWZQr6W+zrTDgr/Q==
+need4deed-sdk@0.0.107:
+  version "0.0.107"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.107.tgz#3b9e0b42970a9ef6a21045cf522bbca1cdeee902"
+  integrity sha512-UrHmAnlCg2jfBdM6oVYMESfg5H/U9dAAvIN14zWJBHP82NNtScFEqvojdZD9GlCgUxtDqW1chcWsRY/Zzm7Jvg==
 
 next@15.3.8:
   version "15.3.8"


### PR DESCRIPTION
## Description
When an opportunity is matched, show a green **"Matched"** badge on the status math cell and the matched volunteer's **name** in place of the "volunteers needed" number, so coordinators can scan the table and instantly see what's matched. 

## Related Issues
Closes #684 

## Changes
  - Green "Matched" badge in the matching-status cell (green-100, matches the profile's matched style)
  - Matched volunteer first name(s) shown in place of the "volunteers needed" number
  - `isMatched` is derived from `volunteerNames.length` (matched-only) since the status match is only returning no matches.
  - SDK bump to 0.0.107 (for `volunteerNames`)
  - Column width tweaks (statusMatch, numberOfVolunteers) to allow more space for names


## Screenshots / Demos
<img width="1357" height="699" alt="Screenshot from 2026-06-15 22-06-04" src="https://github.com/user-attachments/assets/2442099a-4521-4ce2-8b52-8488fbbcbc8c" />


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

