### PR TITLE
fix: show full address and wire up street/PLZ editing in OrganisationDetails

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1082,7 +1082,9 @@
           "required": "Dieses Feld ist erforderlich",
           "websiteInvalid": "Webseite muss mit http:// oder https:// beginnen",
           "clientLanguagesRequired": "Mindestens eine Sprache ist erforderlich"
-        }
+        },
+        "addressStreet": "Straße",
+        "addressPostcode": "PLZ"
       },
       "opportunitiesSec": {
         "postOpportunity": "Möglichkeit posten",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1081,7 +1081,9 @@
           "required": "This field is required",
           "websiteInvalid": "Website must start with http:// or https://",
           "clientLanguagesRequired": "At least one language is required"
-        }
+        },
+        "addressStreet": "Street",
+        "addressPostcode": "Postcode"
       },
       "opportunitiesSec": {
         "postOpportunity": "Post opportunity",

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from "react-i18next";
 import { FormContainer } from "../shared/styles";
 import { EditableSectionProps, EditableSectionRef } from "../shared/types";
 import { useEditingChangeNotifier } from "../shared/useEditingChangeNotifier";
-import { apiLanguagesToFormValues, toLanguagesForForm } from "./formatters";
+import { apiLanguagesToFormValues, parseAddress, toLanguagesForForm } from "./formatters";
 import { OrganisationDetailsDisplay } from "./OrganisationDetailsDisplay";
 import { OrganisationDetailsEdit } from "./OrganisationDetailsEdit";
 import { createOrganisationDetailsSchema, OrganisationDetailsFormData } from "./organisationDetailsSchema";
@@ -33,11 +33,14 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
   const languagesForForm = toLanguagesForForm(apiLanguages, i18n.language);
   const schema = createOrganisationDetailsSchema(t);
 
+  const { street, postcode } = parseAddress(details?.address || "");
   const initialFormValues = {
     ...details,
     website: details?.website || "",
     operator: details?.operator || agent.operator || "",
     clientLanguages: apiLanguagesToFormValues(details?.clientLanguages),
+    addressStreet: street,
+    addressPostcode: postcode,
   };
 
   const methods = useForm<OrganisationDetailsFormData>({
@@ -59,7 +62,12 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
 
   const onSubmit = (values: OrganisationDetailsFormData) => {
     updateOrganization(
-      { about: values.about, website: values.website },
+      {
+        about: values.about,
+        website: values.website,
+        addressStreet: values.addressStreet,
+        addressPostcode: values.addressPostcode,
+      },
       {
         onSuccess: () => {
           reset(values);
@@ -79,7 +87,7 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
             onSubmit={handleSubmit(onSubmit)}
           />
         ) : (
-          <OrganisationDetailsDisplay rawClientLanguages={details?.clientLanguages} />
+          <OrganisationDetailsDisplay rawClientLanguages={details?.clientLanguages} address={details?.address} />
         )}
       </FormContainer>
     </FormProvider>

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsDisplay.tsx
@@ -9,9 +9,10 @@ const i18nPrefix = "dashboard.agentProfile.organisationDetails";
 
 type Props = {
   rawClientLanguages?: Array<{ id: number; title: string }>;
+  address?: string;
 };
 
-export const OrganisationDetailsDisplay = ({ rawClientLanguages }: Props) => {
+export const OrganisationDetailsDisplay = ({ rawClientLanguages, address }: Props) => {
   const { t } = useTranslation();
   const { watch } = useFormContext<OrganisationDetailsFormData>();
   const values = watch();
@@ -36,7 +37,7 @@ export const OrganisationDetailsDisplay = ({ rawClientLanguages }: Props) => {
         mode="display"
         type="text"
         label={t(`${i18nPrefix}.address`)}
-        value={values.address}
+        value={address ?? ""}
         setValue={() => {}}
       />
       <EditableField

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsEdit.tsx
@@ -55,16 +55,30 @@ export const OrganisationDetailsEdit = ({ languagesForForm, onCancel, onSubmit }
           )}
         />
         <Controller
-          name="address"
+          name="addressStreet"
           control={control}
           render={({ field }) => (
             <EditableField
               mode="edit"
               type="text"
-              label={t(`${i18nPrefix}.address`)}
-              value={field.value}
+              label={t(`${i18nPrefix}.addressStreet`)}
+              value={field.value ?? ""}
               setValue={field.onChange}
-              errorMessage={errors.address?.message}
+              errorMessage={errors.addressStreet?.message}
+            />
+          )}
+        />
+        <Controller
+          name="addressPostcode"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t(`${i18nPrefix}.addressPostcode`)}
+              value={field.value ?? ""}
+              setValue={field.onChange}
+              errorMessage={errors.addressPostcode?.message}
             />
           )}
         />

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/formatters.ts
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/formatters.ts
@@ -15,3 +15,8 @@ export const apiLanguagesToFormValues = (langs?: Array<{ id: number; title: stri
 
 export const clientLanguagesToDisplay = (langs?: Array<{ id: number; title: string }>): string =>
   langs?.map((lang) => lang.title).join(", ") ?? "";
+
+export function parseAddress(formatted: string): { street: string; postcode: string } {
+  const match = formatted.match(/^(.+),\s*(\d{5})/);
+  return match ? { street: match[1].trim(), postcode: match[2] } : { street: "", postcode: "" };
+}

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/organisationDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/organisationDetailsSchema.ts
@@ -21,7 +21,8 @@ export const createOrganisationDetailsSchema = (t: (key: string) => string) => {
       .refine((val) => urlRegex.test(val), {
         message: t(`${i18nPrefix}.websiteInvalid`),
       }),
-    address: z.string().min(1, required),
+    addressStreet: z.string(),
+    addressPostcode: z.string(),
     organizationType: z.enum(AgentType),
     operator: z.string().min(1, required),
     services: z.string().min(1, required),

--- a/src/hooks/useUpdateOrganizationDetails.ts
+++ b/src/hooks/useUpdateOrganizationDetails.ts
@@ -3,11 +3,11 @@ import { apiPathAgent } from "@/config/constants";
 import { useMutationQuery } from "@/hooks";
 import { ApiAgentPatch } from "need4deed-sdk";
 
-// Patches agent-level org details (about, website) via the agent endpoint.
-// Note: address and district require the organization's numeric ID which is not
-// currently exposed in the agent API response — those fields need a BE change.
 export const useUpdateOrganization = (agentId: string) => {
-  return useMutationQuery<Pick<ApiAgentPatch, "about" | "website">, ApiAgentProfileGet>({
+  return useMutationQuery<
+    Pick<ApiAgentPatch, "about" | "website" | "addressStreet" | "addressPostcode">,
+    ApiAgentProfileGet
+  >({
     apiPath: `${apiPathAgent}/${agentId}`,
     method: "patch",
     successMessage: "dashboard.agentProfile.organisationDetails.saveSuccess",


### PR DESCRIPTION
## Summary

Closes https://github.com/need4deed-org/fe/issues/627

- The address field in the edit form existed in the schema but was **never saved** — `useUpdateOrganization` only patched `about` and `website`
- Split edit into `addressStreet` + `addressPostcode` fields, both wired to `PATCH /agent/:id` (the BE already accepts these)
- On load, parses the formatted address string (e.g. `"Heerstr. 110, 14055 Berlin"`) to pre-populate both fields
- Display reads `agentDetails.address` directly (the pre-formatted string from the BE) rather than form state
- Added `addressStreet` / `addressPostcode` i18n keys in DE and EN

## Test plan
- [ ] Open an agent profile that has a full address — display shows `"Heerstr. 110, 14055 Berlin"` (not just `"Berlin"`)
- [ ] Click Edit → Street and PLZ fields are pre-populated from the existing address
- [ ] Edit street or PLZ, save → display updates with new full address
- [ ] Agent with no address set → both edit fields empty, display shows `"Berlin"` fallback
- [ ] Cancel edit → form resets to original values

🤖 Generated with [Claude Code](https://claude.com/claude-code)