### PR TITLE
feat: add phone number field to agent registration form

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1905,6 +1905,7 @@
       "email": "E-Mail-Adresse",
       "password": "Passwort",
       "confirmPassword": "Passwort bestätigen",
+      "phone": "Telefonnummer",
       "organizationName": "Name der Organisation",
       "organizationType": "Art der Organisation",
       "selectOrganizationType": "Typ auswählen…",
@@ -1921,6 +1922,7 @@
     "errors": {
       "passwordTooShort": "Das Passwort muss mindestens 8 Zeichen lang sein",
       "passwordMismatch": "Die Passwörter stimmen nicht überein",
+      "phoneTooShort": "Die Telefonnummer muss mindestens 7 Zeichen lang sein",
       "emailDomainNotAllowed": "Ihre E-Mail-Domain ist nicht auf unserer genehmigten NGO-Liste. Bitte verwenden Sie die E-Mail-Adresse Ihrer Organisation.",
       "missingToken": "Dein Registrierungslink ist ungültig oder abgelaufen. Bitte verwende den Link aus deiner Bestätigungs-E-Mail."
     },

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1537,6 +1537,7 @@
       "email": "Email address",
       "password": "Password",
       "confirmPassword": "Confirm password",
+      "phone": "Phone number",
       "organizationName": "Organisation name",
       "organizationType": "Organisation type",
       "selectOrganizationType": "Select type…",
@@ -1553,6 +1554,7 @@
     "errors": {
       "passwordTooShort": "Password must be at least 8 characters",
       "passwordMismatch": "Passwords do not match",
+      "phoneTooShort": "Phone number must be at least 7 characters",
       "emailDomainNotAllowed": "Your email domain is not on our approved NGO list. Please use your organisation email address.",
       "missingToken": "Your registration link is invalid or has expired. Please use the link from your verification email."
     },

--- a/src/components/AgentRegistration/AgentRegistration.tsx
+++ b/src/components/AgentRegistration/AgentRegistration.tsx
@@ -68,6 +68,7 @@ export function AgentRegistration() {
         person: {
           firstName: formData.firstName,
           lastName: formData.lastName,
+          phone: formData.phone,
         },
       });
 

--- a/src/components/AgentRegistration/helpers.ts
+++ b/src/components/AgentRegistration/helpers.ts
@@ -45,6 +45,8 @@ export function validateStep(
     if (!data.confirmPassword) errors.confirmPassword = required;
     else if (data.password !== data.confirmPassword)
       errors.confirmPassword = t("agentRegistration.errors.passwordMismatch");
+    if (!data.phone.trim()) errors.phone = required;
+    else if (data.phone.trim().length < 7) errors.phone = t("agentRegistration.errors.phoneTooShort");
   }
 
   return errors;

--- a/src/components/AgentRegistration/steps/AccountStep.tsx
+++ b/src/components/AgentRegistration/steps/AccountStep.tsx
@@ -70,6 +70,17 @@ export function AccountStep({ data, onChange, errors }: Props) {
           errors={errors.confirmPassword ? [errors.confirmPassword] : []}
         />
       </FieldWrapper>
+
+      <FieldWrapper>
+        <FieldLabel>{t("agentRegistration.fields.phone")}</FieldLabel>
+        <FormInput
+          type="tel"
+          value={data.phone}
+          onInputChange={(v) => onChange({ phone: v })}
+          placeHolder={t("agentRegistration.fields.phone")}
+          errors={errors.phone ? [errors.phone] : []}
+        />
+      </FieldWrapper>
     </div>
   );
 }

--- a/src/components/AgentRegistration/types.ts
+++ b/src/components/AgentRegistration/types.ts
@@ -6,6 +6,7 @@ export interface AgentRegistrationData {
   email: string;
   password: string;
   confirmPassword: string;
+  phone: string;
 }
 
 export const defaultAgentRegistrationData: AgentRegistrationData = {
@@ -14,6 +15,7 @@ export const defaultAgentRegistrationData: AgentRegistrationData = {
   email: "",
   password: "",
   confirmPassword: "",
+  phone: "",
 };
 
 export const TOTAL_STEPS = 1;


### PR DESCRIPTION
## Summary
- Adds required phone input to `AccountStep` after the confirm-password field
- Validates minimum 7 characters (matches `person.phone` BE constraint)
- Sends `phone` inside the `person` object on `POST /user` (already accepted by BE)
- Adds `agentRegistration.fields.phone` and `agentRegistration.errors.phoneTooShort` keys to EN and DE translations

Closes https://github.com/need4deed-org/fe/issues/676
Depends on https://github.com/need4deed-org/be/issues/685 (merged via BE PR #693)

## Test plan
- [ ] Fill registration form — phone field appears after "Confirm password"
- [ ] Submit with empty phone — required error shown
- [ ] Submit with phone shorter than 7 chars — too-short error shown
- [ ] Submit with valid phone — user created, `person.phone` set in DB
- [ ] German locale shows correct labels and error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)