### PR TITLE
fix: restore agent table title column width so header and rows align

### DIFF
--- a/src/components/Dashboard/Agents/agentsTableColumns.ts
+++ b/src/components/Dashboard/Agents/agentsTableColumns.ts
@@ -20,7 +20,7 @@ export const AGENT_READ_ONLY_COL_WIDTHS = {
 };
 
 export const createAgentTableColumns = (t: TFunction, copyButton: ReactNode): Column[] => [
-  { key: "title", label: t("dashboard.agents.table.title") },
+  { key: "title", label: t("dashboard.agents.table.title"), width: AGENT_COL_WIDTHS.title },
   { key: "type", label: t("dashboard.agents.table.type"), width: AGENT_COL_WIDTHS.type },
   {
     key: "volunteerSearch",


### PR DESCRIPTION
## Description
The admin agent table's title column was missing a width, so the header (which flexes when it has no width) and the rows (fixed width) didn't line up. Restored width: AGENT_COL_WIDTHS.title to align them. 
Is isolated to the admin view; the NGO read-only view uses separate widths and is unaffected.

## Changes
- Add width: AGENT_COL_WIDTHS.title to the admin agent table's title column header

## Screenshots / Demos
before:
<img width="1357" height="699" alt="before" src="https://github.com/user-attachments/assets/162d3c51-a961-43e0-91bb-2716e4c70197" />

after: 
<img width="1357" height="699" alt="after" src="https://github.com/user-attachments/assets/9f9540ce-18ca-49ae-89f3-8ce699986258" />
<img width="1357" height="699" alt="Screenshot from 2026-06-16 18-32-34" src="https://github.com/user-attachments/assets/29013c53-9d92-4155-b390-a750a9c34ab5" />



## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

