### PR TITLE
feat: /dashboard/profile page for NGO users

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -973,6 +973,10 @@
       "deleteConfirmTitle": "Anerkennung löschen?",
       "deleteConfirmText": "\"{{entryType}}\" Anerkennungseintrag wird dauerhaft gelöscht."
     },
+    "profile": {
+      "loading": "Profil wird geladen...",
+      "notSetUp": "Ihr Organisationsprofil ist noch nicht eingerichtet — bitte schließen Sie die Registrierung ab."
+    },
     "agentProfile": {
       "agentProfile": "Einrichtungs-/Projektprofil",
       "registeredSince": "Registriert seit",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -972,6 +972,10 @@
       "deleteConfirmTitle": "Delete appreciation?",
       "deleteConfirmText": "\"{{entryType}}\" appreciation entry will be permanently deleted."
     },
+    "profile": {
+      "loading": "Loading profile...",
+      "notSetUp": "Your organisation profile is not set up yet — please complete registration."
+    },
     "agentProfile": {
       "agentProfile": "NGO Profile",
       "registeredSince": "Registered since",

--- a/src/app/[lang]/dashboard/profile/page.tsx
+++ b/src/app/[lang]/dashboard/profile/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+import CenteredWrapper from "@/components/core/common/CenteredWrapper";
+import { AgentProfileController } from "@/components/Dashboard/Profile/AgentProfileController";
+import { Paragraph } from "@/components/styled/text";
+import { useGetCurrentAgent } from "@/hooks/useGetCurrentAgent";
+import { useTranslation } from "react-i18next";
+
+export default function DashboardProfilePage() {
+  const { t } = useTranslation();
+  const { agentId, isLoading } = useGetCurrentAgent();
+
+  if (isLoading) {
+    return (
+      <CenteredWrapper>
+        <Paragraph>{t("dashboard.profile.loading")}</Paragraph>
+      </CenteredWrapper>
+    );
+  }
+
+  if (!agentId) {
+    return (
+      <CenteredWrapper>
+        <Paragraph>{t("dashboard.profile.notSetUp")}</Paragraph>
+      </CenteredWrapper>
+    );
+  }
+
+  return <AgentProfileController entityId={String(agentId)} />;
+}

--- a/src/hooks/useGetCurrentAgent.ts
+++ b/src/hooks/useGetCurrentAgent.ts
@@ -1,19 +1,28 @@
-import { apiPathAgentMe, cacheTTL } from "@/config/constants";
+import { apiPathAgent, apiPathMe, cacheTTL } from "@/config/constants";
 import { useGetQuery } from "@/hooks";
 import { getCookie } from "@/utils/helpers";
-import { ApiAgentGet } from "need4deed-sdk";
+import { ApiAgentGet, ApiUserGet } from "need4deed-sdk";
 
-// Requires BE: GET /api/agent/me — returns the agent profile for the logged-in agent user.
 export const useGetCurrentAgent = () => {
   const isLoggedIn = getCookie("is_logged_in") === "true";
 
-  const { data, isLoading } = useGetQuery<ApiAgentGet>({
-    queryKey: ["agent", "me"],
-    apiPath: apiPathAgentMe,
+  const { data: user, isLoading: userLoading } = useGetQuery<ApiUserGet & { agentId?: number }>({
+    queryKey: ["user"],
+    apiPath: apiPathMe,
     staleTime: cacheTTL,
     enabled: isLoggedIn,
     addLang: false,
   });
 
-  return { agent: data, isLoading };
+  const agentId = user?.agentId;
+
+  const { data: agent, isLoading: agentLoading } = useGetQuery<ApiAgentGet>({
+    queryKey: ["agent", String(agentId)],
+    apiPath: `${apiPathAgent}/${agentId}`,
+    staleTime: cacheTTL,
+    enabled: !!agentId,
+    addLang: false,
+  });
+
+  return { agent, agentId, isLoading: userLoading || (!!agentId && agentLoading) };
 };


### PR DESCRIPTION
## Summary
- Creates `src/app/[lang]/dashboard/profile/page.tsx` — the missing route that caused a 404 when NGO users clicked Profile in the sidebar
- Fixes `useGetCurrentAgent` to derive `agentId` from `GET /user/me` (which returns `agentId` since https://github.com/need4deed-org/be/pull/692) instead of the non-existent `GET /agent/me`; then fetches the full agent via `GET /agent/:id`
- Page shows a loading message while resolving, a "not set up" message if no agentId, and `AgentProfileController` when the agent is found — consistent with how `/dashboard/agents/:id` works
- Also fixes `useGetCurrentAgent` for `NewOpportunity`, which previously couldn't pre-fill contact details because `GET /agent/me` never existed

Closes https://github.com/need4deed-org/fe/issues/677

## Test plan
- [ ] NGO user clicks Profile in sidebar → profile page loads with their agent profile
- [ ] User with no agent linked → "not set up" message shown
- [ ] Loading state shown briefly while fetching
- [ ] New opportunity form pre-fills contact name/phone/email from agent representative

🤖 Generated with [Claude Code](https://claude.com/claude-code)