### PR TITLE
fix: read addressStreet/addressPostcode directly from API; show — when empty

### DIFF
--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from "react-i18next";
 import { FormContainer } from "../shared/styles";
 import { EditableSectionProps, EditableSectionRef } from "../shared/types";
 import { useEditingChangeNotifier } from "../shared/useEditingChangeNotifier";
-import { apiLanguagesToFormValues, parseAddress, toLanguagesForForm } from "./formatters";
+import { apiLanguagesToFormValues, toLanguagesForForm } from "./formatters";
 import { OrganisationDetailsDisplay } from "./OrganisationDetailsDisplay";
 import { OrganisationDetailsEdit } from "./OrganisationDetailsEdit";
 import { createOrganisationDetailsSchema, OrganisationDetailsFormData } from "./organisationDetailsSchema";
@@ -33,14 +33,13 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
   const languagesForForm = toLanguagesForForm(apiLanguages, i18n.language);
   const schema = createOrganisationDetailsSchema(t);
 
-  const { street, postcode } = parseAddress(details?.address || "");
   const initialFormValues = {
     ...details,
     website: details?.website || "",
     operator: details?.operator || agent.operator || "",
     clientLanguages: apiLanguagesToFormValues(details?.clientLanguages),
-    addressStreet: street,
-    addressPostcode: postcode,
+    addressStreet: details?.addressStreet ?? "",
+    addressPostcode: details?.addressPostcode ?? "",
   };
 
   const methods = useForm<OrganisationDetailsFormData>({

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsDisplay.tsx
@@ -37,7 +37,7 @@ export const OrganisationDetailsDisplay = ({ rawClientLanguages, address }: Prop
         mode="display"
         type="text"
         label={t(`${i18nPrefix}.address`)}
-        value={address ?? ""}
+        value={address || "—"}
         setValue={() => {}}
       />
       <EditableField

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/formatters.ts
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/formatters.ts
@@ -15,8 +15,3 @@ export const apiLanguagesToFormValues = (langs?: Array<{ id: number; title: stri
 
 export const clientLanguagesToDisplay = (langs?: Array<{ id: number; title: string }>): string =>
   langs?.map((lang) => lang.title).join(", ") ?? "";
-
-export function parseAddress(formatted: string): { street: string; postcode: string } {
-  const match = formatted.match(/^(.+),\s*(\d{5})/);
-  return match ? { street: match[1].trim(), postcode: match[2] } : { street: "", postcode: "" };
-}

--- a/src/components/Dashboard/Profile/types/agent.ts
+++ b/src/components/Dashboard/Profile/types/agent.ts
@@ -1,6 +1,16 @@
+import { AgentDetails, ApiAgentGet } from "need4deed-sdk";
+
 export {
   AgentEngagementStatusType as AgentEngagementStatus,
   AgentTrustType as AgentTrustLevel,
   AgentVolunteerSearchType as AgentVolunteerSearch,
 } from "need4deed-sdk";
-export type { ApiAgentGet as ApiAgentProfileGet } from "need4deed-sdk";
+
+type AgentDetailsExtended = AgentDetails & {
+  addressStreet?: string | null;
+  addressPostcode?: string | null;
+};
+
+export type ApiAgentProfileGet = Omit<ApiAgentGet, "agentDetails"> & {
+  agentDetails: AgentDetailsExtended;
+};


### PR DESCRIPTION
## Summary
- `ApiAgentProfileGet.agentDetails` extended locally with `addressStreet?: string | null` and `addressPostcode?: string | null` (mirrors https://github.com/need4deed-org/be/pull/694)
- `OrganisationDetails.tsx` now initialises the edit form from `details.addressStreet` / `details.addressPostcode` directly instead of calling `parseAddress()` on the serialised string
- `parseAddress` removed from `formatters.ts` (no longer needed)
- Display mode shows `"—"` when address is empty (BE no longer returns `"Berlin"` as fallback)

Closes https://github.com/need4deed-org/fe/issues/657
Depends on https://github.com/need4deed-org/be/pull/694 (must be merged first)

## Test plan
- [ ] Agent with address: street and postcode fields pre-populated correctly in edit form
- [ ] Agent with no address: edit form starts empty, display shows "—"
- [ ] Editing and saving address updates both fields via PATCH
- [ ] No "Berlin" phantom address shown for agents with no real address

🤖 Generated with [Claude Code](https://claude.com/claude-code)