### PR TITLE
feat: rework new opportunity page to match profile edit layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "0.0.108",
+    "need4deed-sdk": "0.0.109",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "0.0.109",
+    "need4deed-sdk": "0.0.110",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "0.0.107",
+    "need4deed-sdk": "0.0.108",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/src/components/Dashboard/Home/AgentOpportunityCards.tsx
+++ b/src/components/Dashboard/Home/AgentOpportunityCards.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { apiPathAgent, apiPathOption, cacheTTL } from "@/config/constants";
+import { useGetCurrentAgent } from "@/hooks/useGetCurrentAgent";
+import { useGetQuery } from "@/hooks";
+import { ApiOptionLists, ApiOpportunityGetList, ApiVolunteerOpportunityGetList } from "need4deed-sdk";
+import { OpportunityCard } from "../Opportunities/OpportunityCard";
+import { useTranslation } from "react-i18next";
+import { Heading4 } from "@/components/styled/text";
+import { DashboardCardContainer } from "./styles";
+
+export function AgentOpportunityCards() {
+  const { t } = useTranslation();
+  const { agentId } = useGetCurrentAgent();
+
+  const { data: apiFilterOptions } = useGetQuery<ApiOptionLists>({ queryKey: ["options"], apiPath: apiPathOption });
+  const { data: opportunities, isLoading } = useGetQuery<ApiOpportunityGetList[]>({
+    queryKey: ["agent-opportunities", String(agentId)],
+    apiPath: `${apiPathAgent}/${agentId}/opportunity-linked`,
+    staleTime: cacheTTL,
+    enabled: !!agentId,
+    addLang: false,
+  });
+
+  const activitiesList = apiFilterOptions?.activity ?? undefined;
+  const districtsList = apiFilterOptions?.district ?? undefined;
+
+  if (isLoading) return <Heading4>{t("dashboard.home.content.loading")}</Heading4>;
+
+  return (
+    <DashboardCardContainer>
+      {opportunities?.map((opp) => (
+        <OpportunityCard
+          key={String(opp.id)}
+          opportunity={opp as ApiVolunteerOpportunityGetList}
+          volunteerId={undefined}
+          activitiesList={activitiesList}
+          districtsList={districtsList}
+        />
+      ))}
+    </DashboardCardContainer>
+  );
+}

--- a/src/components/Dashboard/Home/HomeContent.tsx
+++ b/src/components/Dashboard/Home/HomeContent.tsx
@@ -1,7 +1,10 @@
 "use client";
 import { Heading2, Heading3 } from "@/components/styled/text";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { UserRole } from "need4deed-sdk";
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { AgentOpportunityCards } from "./AgentOpportunityCards";
 import { CreateOpportunityButton } from "./CreateOpportunityButton";
 import { NewestOpportunities } from "./NewestOpportunities";
 import { NewestVolunteers } from "./NewestVolunteers";
@@ -10,6 +13,19 @@ import { NewestTaggedComments } from "./NewestTaggedComments";
 
 export default function DashboardHomeContent() {
   const { t } = useTranslation();
+  const user = useCurrentUser(true);
+  const isAgent = user?.role === UserRole.AGENT;
+
+  if (isAgent) {
+    return (
+      <DashboardContentContainer>
+        <Heading2>{t("dashboard.home.content.header")}</Heading2>
+        <CreateOpportunityButton />
+        <AgentOpportunityCards />
+      </DashboardContentContainer>
+    );
+  }
+
   return (
     <DashboardContentContainer>
       <Heading2>{t("dashboard.home.content.header")}</Heading2>

--- a/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
+++ b/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
@@ -1,48 +1,33 @@
 "use client";
 import { EditableField } from "@/components/EditableField/EditableField";
 import { SectionCard } from "@/components/Dashboard/Profile/common/SectionCard";
-import { useEnumTranslation } from "@/components/Dashboard/Profile/sections/ContactDetails/shared";
 import { FormDetails } from "@/components/Dashboard/Profile/sections/shared/styles";
 import { BackButton, PageContainer } from "@/components/Dashboard/Profile/styles";
 import { IconName } from "@/components/Dashboard/Profile/types";
 import Button from "@/components/core/button/Button/Button";
-import { apiPathOpportunity, DashboardRoutes, PHONE_NUMBER_REGEX } from "@/config/constants";
+import { apiPathOpportunity, DashboardRoutes } from "@/config/constants";
 import { useMutationQuery } from "@/hooks";
 import { useGetCurrentAgent } from "@/hooks/useGetCurrentAgent";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Heading2 } from "@/components/styled/text";
 import { ArrowLeftIcon } from "@phosphor-icons/react";
-import { ApiOpportunityGet, PreferredCommunicationType } from "need4deed-sdk";
+import { ApiOpportunityGet } from "need4deed-sdk";
 import i18next from "i18next";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { z } from "zod";
 
-const WAYS_TO_CONTACT_TYPES = Object.values(PreferredCommunicationType);
-
 const createSchema = (t: (key: string) => string) =>
   z.object({
     title: z.string().min(1, t("form.error.required")),
-    name: z.string().min(1, t("dashboard.opportunityProfile.contactDetails.validation.nameRequired")),
-    phone: z
-      .string()
-      .min(1, t("dashboard.opportunityProfile.contactDetails.validation.phoneRequired"))
-      .regex(PHONE_NUMBER_REGEX, t("dashboard.opportunityProfile.contactDetails.validation.phoneInvalid")),
-    email: z
-      .string()
-      .min(1, t("dashboard.opportunityProfile.contactDetails.validation.emailRequired"))
-      .email(t("dashboard.opportunityProfile.contactDetails.validation.emailInvalid")),
-    waysToContact: z.array(z.nativeEnum(PreferredCommunicationType)).optional(),
   });
 
 type FormData = z.infer<ReturnType<typeof createSchema>>;
 
 type CreateOpportunityBody = {
   title: string;
-  contact: { name: string; phone: string; email: string };
   agentId?: number;
 };
 
@@ -50,32 +35,18 @@ export function NewOpportunity() {
   const { t } = useTranslation();
   const router = useRouter();
   const { agent } = useGetCurrentAgent();
-  const { options, keysToLabels, labelsToKeys } = useEnumTranslation(
-    WAYS_TO_CONTACT_TYPES,
-    "dashboard.opportunityProfile.contactDetails.waysToContact",
-  );
 
   const methods = useForm<FormData>({
     resolver: zodResolver(createSchema(t)),
     mode: "onChange",
-    defaultValues: { title: "", name: "", phone: "", email: "", waysToContact: [] },
+    defaultValues: { title: "" },
   });
 
   const {
     control,
     handleSubmit,
-    reset,
     formState: { errors, isValid },
   } = methods;
-
-  useEffect(() => {
-    if (!agent?.representative) return;
-    const rep = agent.representative;
-    reset(
-      { title: "", name: rep.firstName ?? "", phone: rep.phone ?? "", email: rep.email ?? "", waysToContact: [] },
-      { keepDirtyValues: true },
-    );
-  }, [agent, reset]);
 
   const { mutate: createOpportunity, isPending } = useMutationQuery<
     CreateOpportunityBody,
@@ -90,11 +61,7 @@ export function NewOpportunity() {
   });
 
   const onSubmit = (values: FormData) => {
-    createOpportunity({
-      title: values.title,
-      contact: { name: values.name, phone: values.phone, email: values.email },
-      agentId: agent?.id,
-    });
+    createOpportunity({ title: values.title, agentId: agent?.id });
   };
 
   return (
@@ -123,71 +90,6 @@ export function NewOpportunity() {
                     value={field.value}
                     setValue={field.onChange}
                     errorMessage={errors.title?.message}
-                  />
-                )}
-              />
-            </FormDetails>
-          }
-        />
-
-        <SectionCard
-          iconName={IconName.ChatsCircle}
-          title={t("dashboard.opportunityProfile.contactDetailsTitle")}
-          subComponent={
-            <FormDetails>
-              <Controller
-                name="name"
-                control={control}
-                render={({ field }) => (
-                  <EditableField
-                    mode="edit"
-                    type="text"
-                    label={t("dashboard.opportunityProfile.contactDetails.name")}
-                    value={field.value}
-                    setValue={field.onChange}
-                    errorMessage={errors.name?.message}
-                  />
-                )}
-              />
-              <Controller
-                name="phone"
-                control={control}
-                render={({ field }) => (
-                  <EditableField
-                    mode="edit"
-                    type="text"
-                    label={t("dashboard.opportunityProfile.contactDetails.phone")}
-                    value={field.value}
-                    setValue={field.onChange}
-                    errorMessage={errors.phone?.message}
-                  />
-                )}
-              />
-              <Controller
-                name="email"
-                control={control}
-                render={({ field }) => (
-                  <EditableField
-                    mode="edit"
-                    type="text"
-                    label={t("dashboard.opportunityProfile.contactDetails.email")}
-                    value={field.value}
-                    setValue={field.onChange}
-                    errorMessage={errors.email?.message}
-                  />
-                )}
-              />
-              <Controller
-                name="waysToContact"
-                control={control}
-                render={({ field }) => (
-                  <EditableField
-                    mode="edit"
-                    type="checkbox-list"
-                    label={t("dashboard.opportunityProfile.contactDetails.waysToContact.label")}
-                    value={keysToLabels(field.value ?? [])}
-                    setValue={(value) => field.onChange(labelsToKeys(Array.isArray(value) ? value : [value]))}
-                    options={options}
                   />
                 )}
               />

--- a/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
+++ b/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
@@ -1,182 +1,215 @@
 "use client";
-import { Button } from "@/components/core/button";
-import { FormInput } from "@/components/core/common";
-import { apiPathOpportunity, DashboardRoutes } from "@/config/constants";
+import { EditableField } from "@/components/EditableField/EditableField";
+import { SectionCard } from "@/components/Dashboard/Profile/common/SectionCard";
+import { useEnumTranslation } from "@/components/Dashboard/Profile/sections/ContactDetails/shared";
+import { FormDetails } from "@/components/Dashboard/Profile/sections/shared/styles";
+import { BackButton, PageContainer } from "@/components/Dashboard/Profile/styles";
+import { IconName } from "@/components/Dashboard/Profile/types";
+import Button from "@/components/core/button/Button/Button";
+import { apiPathOpportunity, DashboardRoutes, PHONE_NUMBER_REGEX } from "@/config/constants";
 import { useMutationQuery } from "@/hooks";
 import { useGetCurrentAgent } from "@/hooks/useGetCurrentAgent";
-import { ApiOpportunityGet } from "need4deed-sdk";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Heading2 } from "@/components/styled/text";
+import { ArrowLeftIcon } from "@phosphor-icons/react";
+import { ApiOpportunityGet, PreferredCommunicationType } from "need4deed-sdk";
 import i18next from "i18next";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
+import { Controller, FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import {
-  AgentInfo,
-  AgentLabel,
-  AgentRow,
-  AgentValue,
-  Card,
-  ErrorBanner,
-  FieldLabel,
-  FieldWrapper,
-  PageSubtitle,
-  PageTitle,
-  SectionTitle,
-  Wrapper,
-} from "./styled";
+import styled from "styled-components";
+import { z } from "zod";
+
+const WAYS_TO_CONTACT_TYPES = Object.values(PreferredCommunicationType);
+
+const createSchema = (t: (key: string) => string) =>
+  z.object({
+    title: z.string().min(1, t("form.error.required")),
+    name: z.string().min(1, t("dashboard.opportunityProfile.contactDetails.validation.nameRequired")),
+    phone: z
+      .string()
+      .min(1, t("dashboard.opportunityProfile.contactDetails.validation.phoneRequired"))
+      .regex(PHONE_NUMBER_REGEX, t("dashboard.opportunityProfile.contactDetails.validation.phoneInvalid")),
+    email: z
+      .string()
+      .min(1, t("dashboard.opportunityProfile.contactDetails.validation.emailRequired"))
+      .email(t("dashboard.opportunityProfile.contactDetails.validation.emailInvalid")),
+    waysToContact: z.array(z.nativeEnum(PreferredCommunicationType)).optional(),
+  });
+
+type FormData = z.infer<ReturnType<typeof createSchema>>;
 
 type CreateOpportunityBody = {
   title: string;
-  contact: {
-    name: string;
-    phone: string;
-    email: string;
-  };
+  contact: { name: string; phone: string; email: string };
   agentId?: number;
 };
 
 export function NewOpportunity() {
   const { t } = useTranslation();
   const router = useRouter();
-  const { agent, isLoading: agentLoading } = useGetCurrentAgent();
+  const { agent } = useGetCurrentAgent();
+  const { options, keysToLabels, labelsToKeys } = useEnumTranslation(
+    WAYS_TO_CONTACT_TYPES,
+    "dashboard.opportunityProfile.contactDetails.waysToContact",
+  );
 
-  const [title, setTitle] = useState("");
-  const [contactName, setContactName] = useState("");
-  const [contactPhone, setContactPhone] = useState("");
-  const [contactEmail, setContactEmail] = useState("");
-  const [errors, setErrors] = useState<Record<string, string>>({});
-
-  const [prefilled, setPrefilled] = useState(false);
-  useEffect(() => {
-    if (!agent?.representative || prefilled) return;
-    setContactName(agent.representative.firstName ?? "");
-    setContactPhone(agent.representative.phone ?? "");
-    setContactEmail(agent.representative.email ?? "");
-    setPrefilled(true);
-  }, [agent, prefilled]);
+  const methods = useForm<FormData>({
+    resolver: zodResolver(createSchema(t)),
+    mode: "onChange",
+    defaultValues: { title: "", name: "", phone: "", email: "", waysToContact: [] },
+  });
 
   const {
-    mutate: createOpportunity,
-    isPending,
-    error,
-  } = useMutationQuery<CreateOpportunityBody, { message: string; data: ApiOpportunityGet }>({
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors, isValid },
+  } = methods;
+
+  useEffect(() => {
+    if (!agent?.representative) return;
+    const rep = agent.representative;
+    reset(
+      { title: "", name: rep.firstName ?? "", phone: rep.phone ?? "", email: rep.email ?? "", waysToContact: [] },
+      { keepDirtyValues: true },
+    );
+  }, [agent, reset]);
+
+  const { mutate: createOpportunity, isPending } = useMutationQuery<
+    CreateOpportunityBody,
+    { message: string; data: ApiOpportunityGet }
+  >({
     apiPath: `${apiPathOpportunity}/`,
     method: "post",
     onSuccessCallback: (response) => {
       const id = response?.data?.id;
-      if (id) {
-        router.push(`/${i18next.language}${DashboardRoutes.Opportunities}/${id}`);
-      }
+      if (id) router.push(`/${i18next.language}${DashboardRoutes.Opportunities}/${id}`);
     },
   });
 
-  const validate = () => {
-    const next: Record<string, string> = {};
-    const required = t("form.error.required");
-    if (!title.trim()) next.title = required;
-    if (!contactName.trim()) next.contactName = required;
-    if (!contactEmail.trim()) next.contactEmail = required;
-    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(contactEmail)) next.contactEmail = t("form.error.email");
-    if (!contactPhone.trim()) next.contactPhone = required;
-    setErrors(next);
-    return Object.keys(next).length === 0;
-  };
-
-  const handleSubmit = () => {
-    if (!validate()) return;
+  const onSubmit = (values: FormData) => {
     createOpportunity({
-      title: title.trim(),
-      contact: {
-        name: contactName.trim(),
-        phone: contactPhone.trim(),
-        email: contactEmail.trim(),
-      },
+      title: values.title,
+      contact: { name: values.name, phone: values.phone, email: values.email },
       agentId: agent?.id,
     });
   };
 
   return (
-    <Wrapper>
-      <Card>
-        <PageTitle>{t("dashboard.newOpportunity.title")}</PageTitle>
-        <PageSubtitle>{t("dashboard.newOpportunity.subtitle")}</PageSubtitle>
+    <PageContainer>
+      <BackButton onClick={() => router.back()}>
+        <ArrowLeftIcon size={24} />
+        {t("dashboard.volunteerProfile.backToDashboard")}
+      </BackButton>
 
-        {error && <ErrorBanner>{t("message.errorGeneric")}</ErrorBanner>}
+      <Heading2>{t("dashboard.newOpportunity.title")}</Heading2>
 
-        <FieldWrapper>
-          <FieldLabel>{t("dashboard.newOpportunity.fields.title")}</FieldLabel>
-          <FormInput
-            value={title}
-            onInputChange={setTitle}
-            placeHolder={t("dashboard.newOpportunity.fields.titlePlaceholder")}
-            errors={errors.title ? [errors.title] : []}
-          />
-        </FieldWrapper>
-
-        <SectionTitle>{t("dashboard.newOpportunity.contactSection")}</SectionTitle>
-
-        <FieldWrapper>
-          <FieldLabel>{t("dashboard.opportunityProfile.contactDetails.name")}</FieldLabel>
-          <FormInput
-            value={contactName}
-            onInputChange={setContactName}
-            placeHolder="—"
-            errors={errors.contactName ? [errors.contactName] : []}
-          />
-        </FieldWrapper>
-
-        <FieldWrapper>
-          <FieldLabel>{t("dashboard.opportunityProfile.contactDetails.email")}</FieldLabel>
-          <FormInput
-            type="email"
-            value={contactEmail}
-            onInputChange={setContactEmail}
-            placeHolder="—"
-            errors={errors.contactEmail ? [errors.contactEmail] : []}
-          />
-        </FieldWrapper>
-
-        <FieldWrapper>
-          <FieldLabel>{t("dashboard.opportunityProfile.contactDetails.phone")}</FieldLabel>
-          <FormInput
-            value={contactPhone}
-            onInputChange={setContactPhone}
-            placeHolder="—"
-            errors={errors.contactPhone ? [errors.contactPhone] : []}
-          />
-        </FieldWrapper>
-
-        {!agentLoading && agent && (
-          <>
-            <SectionTitle>{t("dashboard.newOpportunity.agentSection")}</SectionTitle>
-            <AgentInfo>
-              <AgentRow>
-                <AgentLabel>{t("dashboard.agentProfile.organisationDetails.title")}</AgentLabel>
-                <AgentValue>{agent.title}</AgentValue>
-              </AgentRow>
-              {agent.agentDetails?.address && (
-                <AgentRow>
-                  <AgentLabel>{t("agentRegistration.fields.addressStreet")}</AgentLabel>
-                  <AgentValue>{agent.agentDetails.address}</AgentValue>
-                </AgentRow>
-              )}
-              {agent.district && (
-                <AgentRow>
-                  <AgentLabel>{t("agentRegistration.fields.district")}</AgentLabel>
-                  <AgentValue>{agent.district.title?.toString()}</AgentValue>
-                </AgentRow>
-              )}
-            </AgentInfo>
-          </>
-        )}
-
-        <Button
-          text={t("dashboard.newOpportunity.submit")}
-          backgroundcolor="var(--color-aubergine)"
-          textColor="var(--color-white)"
-          onClick={handleSubmit}
-          disabled={isPending}
+      <FormProvider {...methods}>
+        <SectionCard
+          iconName={IconName.Wrench}
+          title={t("dashboard.newOpportunity.fields.title")}
+          subComponent={
+            <FormDetails>
+              <Controller
+                name="title"
+                control={control}
+                render={({ field }) => (
+                  <EditableField
+                    mode="edit"
+                    type="text"
+                    label={t("dashboard.newOpportunity.fields.title")}
+                    value={field.value}
+                    setValue={field.onChange}
+                    errorMessage={errors.title?.message}
+                  />
+                )}
+              />
+            </FormDetails>
+          }
         />
-      </Card>
-    </Wrapper>
+
+        <SectionCard
+          iconName={IconName.ChatsCircle}
+          title={t("dashboard.opportunityProfile.contactDetailsTitle")}
+          subComponent={
+            <FormDetails>
+              <Controller
+                name="name"
+                control={control}
+                render={({ field }) => (
+                  <EditableField
+                    mode="edit"
+                    type="text"
+                    label={t("dashboard.opportunityProfile.contactDetails.name")}
+                    value={field.value}
+                    setValue={field.onChange}
+                    errorMessage={errors.name?.message}
+                  />
+                )}
+              />
+              <Controller
+                name="phone"
+                control={control}
+                render={({ field }) => (
+                  <EditableField
+                    mode="edit"
+                    type="text"
+                    label={t("dashboard.opportunityProfile.contactDetails.phone")}
+                    value={field.value}
+                    setValue={field.onChange}
+                    errorMessage={errors.phone?.message}
+                  />
+                )}
+              />
+              <Controller
+                name="email"
+                control={control}
+                render={({ field }) => (
+                  <EditableField
+                    mode="edit"
+                    type="text"
+                    label={t("dashboard.opportunityProfile.contactDetails.email")}
+                    value={field.value}
+                    setValue={field.onChange}
+                    errorMessage={errors.email?.message}
+                  />
+                )}
+              />
+              <Controller
+                name="waysToContact"
+                control={control}
+                render={({ field }) => (
+                  <EditableField
+                    mode="edit"
+                    type="checkbox-list"
+                    label={t("dashboard.opportunityProfile.contactDetails.waysToContact.label")}
+                    value={keysToLabels(field.value ?? [])}
+                    setValue={(value) => field.onChange(labelsToKeys(Array.isArray(value) ? value : [value]))}
+                    options={options}
+                  />
+                )}
+              />
+            </FormDetails>
+          }
+        />
+
+        <SaveRow>
+          <Button
+            text={t("dashboard.newOpportunity.submit")}
+            backgroundcolor="var(--color-aubergine)"
+            textColor="var(--color-white)"
+            onClick={handleSubmit(onSubmit)}
+            disabled={isPending || !isValid}
+          />
+        </SaveRow>
+      </FormProvider>
+    </PageContainer>
   );
 }
+
+const SaveRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;

--- a/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
+++ b/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
@@ -1,10 +1,7 @@
 "use client";
 import { EditableField } from "@/components/EditableField/EditableField";
 import { SectionCard } from "@/components/Dashboard/Profile/common/SectionCard";
-import {
-  apiToFormAvailability,
-  formToApiAvailability,
-} from "@/components/Dashboard/Profile/sections/VolunteerProfile/availabilityUtils";
+import { apiToFormAvailability } from "@/components/Dashboard/Profile/sections/VolunteerProfile/availabilityUtils";
 import {
   ApiLanguageOption,
   useApiActivities,
@@ -40,16 +37,20 @@ import { AvailabilityGrid } from "@/components/forms/AvailabilityGrid/Availabili
 import { LanguageFields } from "@/components/forms/LanguageFields";
 import { apiPathOpportunity, DashboardRoutes, MAX_DESCRIPTION_LENGTH } from "@/config/constants";
 import { useMutationQuery } from "@/hooks";
-import { useGetCurrentAgent } from "@/hooks/useGetCurrentAgent";
-import { localHhmmToUtc } from "@/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Heading2, Heading4 } from "@/components/styled/text";
-import { ShootingStarIcon } from "@phosphor-icons/react";
-import { ArrowLeftIcon } from "@phosphor-icons/react";
-import axios from "axios";
+import { ShootingStarIcon, ArrowLeftIcon } from "@phosphor-icons/react";
 import { de, enUS } from "date-fns/locale";
 import { TFunction } from "i18next";
-import { ApiOpportunityGet, Lang, OptionItem, TranslatedIntoType, VolunteerStateTypeType } from "need4deed-sdk";
+import {
+  ApiOpportunityGet,
+  Lang,
+  OptionId,
+  OptionItem,
+  OpportunityFormDataWithAgentSubmitter,
+  TranslatedIntoType,
+  VolunteerStateTypeType,
+} from "need4deed-sdk";
 import i18next from "i18next";
 import { useMemo } from "react";
 import { useRouter } from "next/navigation";
@@ -66,8 +67,6 @@ const SELECTABLE_VOLUNTEER_TYPES = [
   VolunteerStateTypeType.EVENTS,
 ] as const;
 
-type SelectableVolunteerType = (typeof SELECTABLE_VOLUNTEER_TYPES)[number];
-
 const createHeaderSchema = (t: (key: string) => string) =>
   z.object({
     title: z.string().min(1, t("form.error.required")),
@@ -80,13 +79,7 @@ const createHeaderSchema = (t: (key: string) => string) =>
 
 type HeaderFormData = z.infer<ReturnType<typeof createHeaderSchema>>;
 
-type CreateOpportunityBody = {
-  title: string;
-  volunteerType: SelectableVolunteerType;
-  agentId?: number;
-};
-
-// ─── Helper: same lang/option transforms used in OpportunityDetailsEdit ─────
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function toLangOptionItems(
   formLangs: { language: string }[],
@@ -119,7 +112,72 @@ function toOptionItems(ids: string[], apiItems: ApiLanguageOption[]): OptionItem
   });
 }
 
-// ─── Opportunity Details fields (used inside a FormProvider for that form) ──
+function availabilityToTimeslots(availability: OpportunityDetailsFormData["availability"]): [number, OptionId][] {
+  return (availability ?? []).flatMap(({ weekday, timeSlots }) =>
+    timeSlots
+      .filter((ts) => ts.selected)
+      .map((ts) => {
+        const slotId = weekday === 0 ? ts.id.charAt(0).toUpperCase() + ts.id.slice(1) : ts.id;
+        return [weekday, slotId] as [number, OptionId];
+      }),
+  );
+}
+
+function buildCreatePayload(
+  headerData: HeaderFormData,
+  detailsData: OpportunityDetailsFormData,
+  accompData: AccompanyingDetailsFormData | null,
+  apiLanguages: ApiLanguageOption[],
+  apiActivities: ApiLanguageOption[],
+  apiSkills: ApiLanguageOption[],
+  t: TFunction,
+): OpportunityFormDataWithAgentSubmitter {
+  const isEvent = headerData.volunteerType === VolunteerStateTypeType.EVENTS;
+  const isAccompanying = headerData.volunteerType === VolunteerStateTypeType.ACCOMPANYING;
+
+  const mainLangIds = toLangOptionItems(detailsData.mainCommunication, apiLanguages, t).map((i) => i.id);
+  const residentsLangIds = toLangOptionItems(detailsData.residentsSpeak, apiLanguages, t).map((i) => i.id);
+  const refugeeLangIds = (accompData?.refugeeLanguage ?? []).map(Number).filter(Boolean);
+  const languages = [...new Set([...mainLangIds, ...residentsLangIds, ...refugeeLangIds])];
+
+  const activities = toOptionItems(detailsData.activities, apiActivities).map((i) => i.id);
+  const skills = toOptionItems(detailsData.skills, apiSkills).map((i) => i.id);
+  const timeslots = isEvent ? undefined : availabilityToTimeslots(detailsData.availability);
+
+  const onetime_date_time =
+    isEvent && detailsData.eventDate
+      ? `${detailsData.eventDate.toISOString().split("T")[0]}T${detailsData.eventTime || "00:00"}:00`
+      : undefined;
+
+  const accomp_datetime =
+    isAccompanying && accompData?.appointmentDate
+      ? `${accompData.appointmentDate.toISOString().split("T")[0]}T${accompData.appointmentTime || "00:00"}:00`
+      : null;
+
+  return {
+    title: headerData.title,
+    opportunity_type: headerData.volunteerType,
+    vo_information: detailsData.description || null,
+    volunteers_number: Number(detailsData.numberOfVolunteers) || 1,
+    languages,
+    activities,
+    skills,
+    timeslots: timeslots ?? null,
+    onetime_date_time,
+    accomp_address: isAccompanying ? (accompData?.appointmentAddress ?? "") : "",
+    accomp_postcode: isAccompanying ? (accompData?.appointmentPostcode ?? "") : "",
+    accomp_datetime,
+    accomp_name: isAccompanying ? (accompData?.refugeeName ?? null) : null,
+    accomp_phone: isAccompanying ? (accompData?.refugeeNumber ?? null) : null,
+    accomp_information: null,
+    accomp_translation: isAccompanying ? (accompData?.appointmentLanguage ?? null) : null,
+    berlin_locations: [],
+    category: "",
+    category_id: "",
+  } as OpportunityFormDataWithAgentSubmitter;
+}
+
+// ─── Opportunity Details fields ───────────────────────────────────────────────
 
 function OpportunityDetailsFields({
   isEvent,
@@ -330,7 +388,6 @@ export function NewOpportunity() {
   const lang = i18n.language;
   const locale = lang === "de" ? de : enUS;
   const router = useRouter();
-  const { agent } = useGetCurrentAgent();
   const volunteerTypeLabelMap = createVolunteerTypeLabelMap(t);
 
   const { data: apiLanguages = [] } = useApiLanguages();
@@ -370,7 +427,7 @@ export function NewOpportunity() {
     },
   });
 
-  // Accompanying details form (always initialised; only submitted when type is ACCOMPANYING)
+  // Accompanying details form (always initialised; only included in payload when type is ACCOMPANYING)
   const accompanyingMethods = useForm<AccompanyingDetailsFormData>({
     resolver: zodResolver(accompanyingDetailsSchema),
     mode: "onChange",
@@ -386,7 +443,7 @@ export function NewOpportunity() {
     },
   });
 
-  // Accompanying section helpers (mirrors AccompanyingDetails.tsx)
+  // Accompanying section helpers
   const keyToLabel: Record<string, string> = {};
   const labelToKey: Record<string, string> = {};
   apiLanguages.forEach((l) => {
@@ -404,55 +461,28 @@ export function NewOpportunity() {
   const minAppointmentDate = useMemo(() => new Date(), []);
 
   const { mutate: createOpportunity, isPending } = useMutationQuery<
-    CreateOpportunityBody,
+    OpportunityFormDataWithAgentSubmitter,
     { message: string; data: ApiOpportunityGet }
   >({
     apiPath: `${apiPathOpportunity}/`,
     method: "post",
-    onSuccessCallback: async (response) => {
+    onSuccessCallback: (response) => {
       const id = response?.data?.id;
-      if (!id) return;
-
-      const detailsData = detailsMethods.getValues();
-
-      // PATCH opportunity details
-      await axios.patch(`${apiPathOpportunity}/${id}`, {
-        description: detailsData.description,
-        numberVolunteers: Number(detailsData.numberOfVolunteers) || 1,
-        languagesMain: toLangOptionItems(detailsData.mainCommunication, apiLanguages, t),
-        languagesResidents: toLangOptionItems(detailsData.residentsSpeak, apiLanguages, t),
-        activities: toOptionItems(detailsData.activities, apiActivities),
-        skills: toOptionItems(detailsData.skills, apiSkills),
-        schedule: detailsData.availability ? formToApiAvailability(detailsData.availability) : undefined,
-      });
-
-      // PATCH accompanying details if applicable
-      if (isAccompanying) {
-        const acc = accompanyingMethods.getValues();
-        await axios.patch(`${apiPathOpportunity}/${id}`, {
-          accompanyingDetails: {
-            appointmentAddress: acc.appointmentAddress,
-            appointmentPostcode: acc.appointmentPostcode || undefined,
-            appointmentDate: acc.appointmentDate ? acc.appointmentDate.toISOString() : undefined,
-            appointmentTime: acc.appointmentTime ? localHhmmToUtc(acc.appointmentTime) : undefined,
-            refugeeNumber: acc.refugeeNumber,
-            refugeeName: acc.refugeeName,
-            refugeeLanguage: (acc.refugeeLanguage ?? []).map((id) => ({ id })),
-            appointmentLanguage: acc.appointmentLanguage || undefined,
-          },
-        });
-      }
-
-      router.push(`/${i18next.language}${DashboardRoutes.Opportunities}/${id}`);
+      if (id) router.push(`/${i18next.language}${DashboardRoutes.Opportunities}/${id}`);
     },
   });
 
   const onSubmit = (headerData: HeaderFormData) => {
-    createOpportunity({
-      title: headerData.title,
-      volunteerType: headerData.volunteerType,
-      agentId: agent?.id,
-    });
+    const payload = buildCreatePayload(
+      headerData,
+      detailsMethods.getValues(),
+      isAccompanying ? accompanyingMethods.getValues() : null,
+      apiLanguages,
+      apiActivities,
+      apiSkills,
+      t,
+    );
+    createOpportunity(payload);
   };
 
   return (

--- a/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
+++ b/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
@@ -1,52 +1,407 @@
 "use client";
 import { EditableField } from "@/components/EditableField/EditableField";
 import { SectionCard } from "@/components/Dashboard/Profile/common/SectionCard";
+import {
+  apiToFormAvailability,
+  formToApiAvailability,
+} from "@/components/Dashboard/Profile/sections/VolunteerProfile/availabilityUtils";
+import {
+  ApiLanguageOption,
+  useApiActivities,
+  useApiLanguages,
+  useApiSkills,
+} from "@/components/Dashboard/Profile/sections/VolunteerProfile/hooks";
+import { createMapping } from "@/components/Dashboard/Profile/sections/VolunteerProfile/mappingUtils";
+import {
+  createOpportunityDetailsSchema,
+  OpportunityDetailsFormData,
+} from "@/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema";
+import {
+  AccompanyingDetailsFormData,
+  accompanyingDetailsSchema,
+} from "@/components/Dashboard/Profile/sections/AccompanyingDetails/accompanyingDetailsSchema";
+import { AccompanyingDetailsEdit } from "@/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsEdit";
 import { FormDetails } from "@/components/Dashboard/Profile/sections/shared/styles";
 import { BackButton, PageContainer } from "@/components/Dashboard/Profile/styles";
 import { IconName } from "@/components/Dashboard/Profile/types";
+import {
+  Card,
+  IconContainer,
+  ProfileContent,
+  ProfileInfo,
+  StatusSection,
+  TitleSection,
+} from "@/components/Dashboard/Profile/sections/ProfileHeader/common/profileHeaderStyles";
+import { createVolunteerTypeLabelMap } from "@/components/Dashboard/Profile/sections/ProfileHeader/common/labelMaps";
 import Button from "@/components/core/button/Button/Button";
-import { apiPathOpportunity, DashboardRoutes } from "@/config/constants";
+import { DatePickerWithLabel } from "@/components/core/common/DatePicker";
+import { ErrorMessage } from "@/components/core/common";
+import { AvailabilityGrid } from "@/components/forms/AvailabilityGrid/AvailabilityGrid";
+import { LanguageFields } from "@/components/forms/LanguageFields";
+import { apiPathOpportunity, DashboardRoutes, MAX_DESCRIPTION_LENGTH } from "@/config/constants";
 import { useMutationQuery } from "@/hooks";
 import { useGetCurrentAgent } from "@/hooks/useGetCurrentAgent";
+import { localHhmmToUtc } from "@/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Heading2 } from "@/components/styled/text";
+import { Heading2, Heading4 } from "@/components/styled/text";
+import { ShootingStarIcon } from "@phosphor-icons/react";
 import { ArrowLeftIcon } from "@phosphor-icons/react";
-import { ApiOpportunityGet } from "need4deed-sdk";
+import axios from "axios";
+import { de, enUS } from "date-fns/locale";
+import { TFunction } from "i18next";
+import { ApiOpportunityGet, Lang, OptionItem, TranslatedIntoType, VolunteerStateTypeType } from "need4deed-sdk";
 import i18next from "i18next";
+import { useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { Controller, FormProvider, useForm } from "react-hook-form";
+import { Controller, FormProvider, useForm, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { z } from "zod";
 
-const createSchema = (t: (key: string) => string) =>
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+const SELECTABLE_VOLUNTEER_TYPES = [
+  VolunteerStateTypeType.REGULAR,
+  VolunteerStateTypeType.ACCOMPANYING,
+  VolunteerStateTypeType.EVENTS,
+] as const;
+
+type SelectableVolunteerType = (typeof SELECTABLE_VOLUNTEER_TYPES)[number];
+
+const createHeaderSchema = (t: (key: string) => string) =>
   z.object({
     title: z.string().min(1, t("form.error.required")),
+    volunteerType: z.enum([
+      VolunteerStateTypeType.REGULAR,
+      VolunteerStateTypeType.ACCOMPANYING,
+      VolunteerStateTypeType.EVENTS,
+    ]),
   });
 
-type FormData = z.infer<ReturnType<typeof createSchema>>;
+type HeaderFormData = z.infer<ReturnType<typeof createHeaderSchema>>;
 
 type CreateOpportunityBody = {
   title: string;
+  volunteerType: SelectableVolunteerType;
   agentId?: number;
 };
 
-export function NewOpportunity() {
-  const { t } = useTranslation();
-  const router = useRouter();
-  const { agent } = useGetCurrentAgent();
+// ─── Helper: same lang/option transforms used in OpportunityDetailsEdit ─────
 
-  const methods = useForm<FormData>({
-    resolver: zodResolver(createSchema(t)),
-    mode: "onChange",
-    defaultValues: { title: "" },
+function toLangOptionItems(
+  formLangs: { language: string }[],
+  apiLanguages: ApiLanguageOption[],
+  t: TFunction,
+): OptionItem[] {
+  return formLangs.flatMap(({ language }) => {
+    if (!language) return [];
+    const numId = Number(language);
+    if (!isNaN(numId) && numId > 0) {
+      const found = apiLanguages.find((a) => a.id === numId);
+      return found ? [{ id: found.id, title: found.title }] : [];
+    }
+    const found = apiLanguages.find((a) => {
+      if (a.title === language || a.title.toLowerCase() === language.toLowerCase()) return true;
+      const key = `languageNames.${a.title.toLowerCase()}`;
+      const translated = t(key);
+      return translated !== key && translated === language;
+    });
+    return found ? [{ id: found.id, title: found.title }] : [];
   });
+}
+
+function toOptionItems(ids: string[], apiItems: ApiLanguageOption[]): OptionItem[] {
+  const map = new Map(apiItems.map((i) => [i.id, i.title]));
+  return ids.flatMap((id) => {
+    const numId = Number(id);
+    const title = map.get(numId);
+    return title ? [{ id: numId, title }] : [];
+  });
+}
+
+// ─── Opportunity Details fields (used inside a FormProvider for that form) ──
+
+function OpportunityDetailsFields({
+  isEvent,
+  apiLanguages,
+  apiActivities,
+  apiSkills,
+}: {
+  isEvent: boolean;
+  apiLanguages: ApiLanguageOption[];
+  apiActivities: ApiLanguageOption[];
+  apiSkills: ApiLanguageOption[];
+}) {
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language;
+  const locale = lang === "de" ? de : enUS;
+  const prefix = "dashboard.opportunityProfile.opportunityDetails";
 
   const {
     control,
-    handleSubmit,
-    formState: { errors, isValid },
-  } = methods;
+    formState: { errors },
+  } = useFormContext<OpportunityDetailsFormData>();
+
+  const activityMapping = createMapping(apiActivities);
+  const skillMapping = createMapping(apiSkills);
+  const languagesForForm = apiLanguages.map((l) => ({
+    id: l.id,
+    title: { [lang as Lang]: l.title } as Record<Lang, string>,
+  }));
+
+  return (
+    <FormDetails>
+      <Controller
+        name="description"
+        control={control}
+        render={({ field }) => (
+          <EditableField
+            mode="edit"
+            type="textarea"
+            label={t(`${prefix}.description`)}
+            value={field.value}
+            setValue={field.onChange}
+            maxLength={MAX_DESCRIPTION_LENGTH}
+            hint={t(`${prefix}.descriptionHint`, { max: MAX_DESCRIPTION_LENGTH })}
+            errorMessage={errors.description?.message}
+          />
+        )}
+      />
+
+      <Controller
+        name="mainCommunication"
+        control={control}
+        render={({ field, fieldState }) => (
+          <FieldGroup>
+            <label>{t(`${prefix}.mainCommunication`)}</label>
+            <div>
+              <LanguageFields
+                languages={field.value}
+                onChange={field.onChange}
+                t={t}
+                availableLanguages={languagesForForm}
+                showLevel={false}
+              />
+              {fieldState.error?.message && <ErrorMessage message={fieldState.error.message} />}
+            </div>
+          </FieldGroup>
+        )}
+      />
+
+      <Controller
+        name="residentsSpeak"
+        control={control}
+        render={({ field, fieldState }) => (
+          <FieldGroup>
+            <label>{t(`${prefix}.residentsSpeak`)}</label>
+            <div>
+              <LanguageFields
+                languages={field.value}
+                onChange={field.onChange}
+                t={t}
+                availableLanguages={languagesForForm}
+                showLevel={false}
+              />
+              {fieldState.error?.message && <ErrorMessage message={fieldState.error.message} />}
+            </div>
+          </FieldGroup>
+        )}
+      />
+
+      {isEvent ? (
+        <>
+          <Controller
+            name="eventDate"
+            control={control}
+            render={({ field }) => (
+              <DateFieldRow>
+                <label>{t(`${prefix}.eventDate`)}</label>
+                <DatePickerContainer>
+                  <DatePickerWithLabel
+                    date={field.value ?? undefined}
+                    onSelect={(d) => field.onChange(d ?? null)}
+                    locale={locale}
+                    allowFuture
+                  />
+                </DatePickerContainer>
+              </DateFieldRow>
+            )}
+          />
+          <Controller
+            name="eventTime"
+            control={control}
+            render={({ field }) => (
+              <DateFieldRow>
+                <label htmlFor="new-opp-eventTime">{t(`${prefix}.eventTime`)}</label>
+                <TimeInputWrapper>
+                  <TimeInput
+                    id="new-opp-eventTime"
+                    type="time"
+                    value={field.value || ""}
+                    onChange={field.onChange}
+                    $hasError={!!errors.eventTime}
+                  />
+                </TimeInputWrapper>
+              </DateFieldRow>
+            )}
+          />
+        </>
+      ) : (
+        <Controller
+          name="availability"
+          control={control}
+          render={({ field, fieldState }) => (
+            <FieldGroup>
+              <label>{t(`${prefix}.schedule`)}</label>
+              <div>
+                <AvailabilityGrid
+                  availability={field.value ?? apiToFormAvailability(undefined)}
+                  onChange={field.onChange}
+                  t={t}
+                  currentLanguage={lang as Lang}
+                />
+                {fieldState.error?.message && <ErrorMessage message={fieldState.error.message} />}
+              </div>
+            </FieldGroup>
+          )}
+        />
+      )}
+
+      <Controller
+        name="numberOfVolunteers"
+        control={control}
+        render={({ field }) => (
+          <EditableField
+            mode="edit"
+            type="stepper"
+            label={t(`${prefix}.numberOfVolunteers`)}
+            value={field.value}
+            setValue={field.onChange}
+            errorMessage={errors.numberOfVolunteers?.message}
+          />
+        )}
+      />
+
+      <Controller
+        name="activities"
+        control={control}
+        render={({ field }) => (
+          <EditableField
+            mode="edit"
+            type="checkbox-list"
+            label={t(`${prefix}.activities`)}
+            value={field.value.map((id) => activityMapping.idToTitle[Number(id)] || String(id))}
+            setValue={(value) => {
+              const labels = Array.isArray(value) ? value : [value];
+              field.onChange(labels.map((label) => String(activityMapping.titleToId[label])));
+            }}
+            options={apiActivities.map((a) => a.title)}
+            errorMessage={errors.activities?.message}
+          />
+        )}
+      />
+
+      <Controller
+        name="skills"
+        control={control}
+        render={({ field }) => (
+          <EditableField
+            mode="edit"
+            type="checkbox-list"
+            label={t(`${prefix}.skills`)}
+            value={field.value.map((id) => skillMapping.idToTitle[Number(id)] || String(id))}
+            setValue={(value) => {
+              const labels = Array.isArray(value) ? value : [value];
+              field.onChange(labels.map((label) => String(skillMapping.titleToId[label])));
+            }}
+            options={apiSkills.map((s) => s.title)}
+            errorMessage={errors.skills?.message}
+          />
+        )}
+      />
+    </FormDetails>
+  );
+}
+
+// ─── Main component ──────────────────────────────────────────────────────────
+
+export function NewOpportunity() {
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language;
+  const locale = lang === "de" ? de : enUS;
+  const router = useRouter();
+  const { agent } = useGetCurrentAgent();
+  const volunteerTypeLabelMap = createVolunteerTypeLabelMap(t);
+
+  const { data: apiLanguages = [] } = useApiLanguages();
+  const { data: apiActivities = [] } = useApiActivities();
+  const { data: apiSkills = [] } = useApiSkills();
+
+  // Header form: title + volunteerType
+  const headerMethods = useForm<HeaderFormData>({
+    resolver: zodResolver(createHeaderSchema(t)),
+    mode: "onChange",
+    defaultValues: { title: "", volunteerType: VolunteerStateTypeType.REGULAR },
+  });
+  const {
+    control: headerControl,
+    handleSubmit: handleHeaderSubmit,
+    watch: watchHeader,
+    formState: { errors: headerErrors },
+  } = headerMethods;
+  const selectedType = watchHeader("volunteerType");
+  const isAccompanying = selectedType === VolunteerStateTypeType.ACCOMPANYING;
+  const isEvent = selectedType === VolunteerStateTypeType.EVENTS;
+
+  // Opportunity details form
+  const detailsMethods = useForm<OpportunityDetailsFormData>({
+    resolver: zodResolver(createOpportunityDetailsSchema(t)),
+    mode: "onChange",
+    defaultValues: {
+      description: "",
+      numberOfVolunteers: "1",
+      mainCommunication: [{ id: 1, language: "", level: "" }],
+      residentsSpeak: [{ id: 1, language: "", level: "" }],
+      availability: undefined,
+      eventDate: null,
+      eventTime: "",
+      activities: [],
+      skills: [],
+    },
+  });
+
+  // Accompanying details form (always initialised; only submitted when type is ACCOMPANYING)
+  const accompanyingMethods = useForm<AccompanyingDetailsFormData>({
+    resolver: zodResolver(accompanyingDetailsSchema),
+    mode: "onChange",
+    defaultValues: {
+      appointmentAddress: "",
+      appointmentPostcode: "",
+      appointmentDate: null,
+      appointmentTime: "",
+      refugeeNumber: "",
+      refugeeName: "",
+      refugeeLanguage: [],
+      appointmentLanguage: undefined,
+    },
+  });
+
+  // Accompanying section helpers (mirrors AccompanyingDetails.tsx)
+  const keyToLabel: Record<string, string> = {};
+  const labelToKey: Record<string, string> = {};
+  apiLanguages.forEach((l) => {
+    keyToLabel[String(l.id)] = l.title;
+    labelToKey[l.title] = String(l.id);
+  });
+  const appointmentLanguageKeys = Object.values(TranslatedIntoType);
+  const appointmentLanguageKeyToLabel: Record<string, string> = {};
+  const appointmentLanguageLabelToKey: Record<string, string> = {};
+  appointmentLanguageKeys.forEach((key) => {
+    const label = t(`dashboard.opportunityProfile.accompanyingDetails.appointmentLanguageOptions.${key}`);
+    appointmentLanguageKeyToLabel[key] = label;
+    appointmentLanguageLabelToKey[label] = key;
+  });
+  const minAppointmentDate = useMemo(() => new Date(), []);
 
   const { mutate: createOpportunity, isPending } = useMutationQuery<
     CreateOpportunityBody,
@@ -54,14 +409,50 @@ export function NewOpportunity() {
   >({
     apiPath: `${apiPathOpportunity}/`,
     method: "post",
-    onSuccessCallback: (response) => {
+    onSuccessCallback: async (response) => {
       const id = response?.data?.id;
-      if (id) router.push(`/${i18next.language}${DashboardRoutes.Opportunities}/${id}`);
+      if (!id) return;
+
+      const detailsData = detailsMethods.getValues();
+
+      // PATCH opportunity details
+      await axios.patch(`${apiPathOpportunity}/${id}`, {
+        description: detailsData.description,
+        numberVolunteers: Number(detailsData.numberOfVolunteers) || 1,
+        languagesMain: toLangOptionItems(detailsData.mainCommunication, apiLanguages, t),
+        languagesResidents: toLangOptionItems(detailsData.residentsSpeak, apiLanguages, t),
+        activities: toOptionItems(detailsData.activities, apiActivities),
+        skills: toOptionItems(detailsData.skills, apiSkills),
+        schedule: detailsData.availability ? formToApiAvailability(detailsData.availability) : undefined,
+      });
+
+      // PATCH accompanying details if applicable
+      if (isAccompanying) {
+        const acc = accompanyingMethods.getValues();
+        await axios.patch(`${apiPathOpportunity}/${id}`, {
+          accompanyingDetails: {
+            appointmentAddress: acc.appointmentAddress,
+            appointmentPostcode: acc.appointmentPostcode || undefined,
+            appointmentDate: acc.appointmentDate ? acc.appointmentDate.toISOString() : undefined,
+            appointmentTime: acc.appointmentTime ? localHhmmToUtc(acc.appointmentTime) : undefined,
+            refugeeNumber: acc.refugeeNumber,
+            refugeeName: acc.refugeeName,
+            refugeeLanguage: (acc.refugeeLanguage ?? []).map((id) => ({ id })),
+            appointmentLanguage: acc.appointmentLanguage || undefined,
+          },
+        });
+      }
+
+      router.push(`/${i18next.language}${DashboardRoutes.Opportunities}/${id}`);
     },
   });
 
-  const onSubmit = (values: FormData) => {
-    createOpportunity({ title: values.title, agentId: agent?.id });
+  const onSubmit = (headerData: HeaderFormData) => {
+    createOpportunity({
+      title: headerData.title,
+      volunteerType: headerData.volunteerType,
+      agentId: agent?.id,
+    });
   };
 
   return (
@@ -73,15 +464,17 @@ export function NewOpportunity() {
 
       <Heading2>{t("dashboard.newOpportunity.title")}</Heading2>
 
-      <FormProvider {...methods}>
-        <SectionCard
-          iconName={IconName.Wrench}
-          title={t("dashboard.newOpportunity.fields.title")}
-          subComponent={
-            <FormDetails>
+      {/* Header card — title input + volunteer type selector */}
+      <Card>
+        <ProfileContent>
+          <IconContainer>
+            <ShootingStarIcon size={120} color="var(--color-blue-500)" weight="duotone" />
+          </IconContainer>
+          <ProfileInfo>
+            <TitleSection>
               <Controller
                 name="title"
-                control={control}
+                control={headerControl}
                 render={({ field }) => (
                   <EditableField
                     mode="edit"
@@ -89,29 +482,178 @@ export function NewOpportunity() {
                     label={t("dashboard.newOpportunity.fields.title")}
                     value={field.value}
                     setValue={field.onChange}
-                    errorMessage={errors.title?.message}
+                    errorMessage={headerErrors.title?.message}
                   />
                 )}
               />
-            </FormDetails>
+            </TitleSection>
+
+            <StatusSection>
+              <VolunteerTypeRow>
+                <Heading4>{t("dashboard.volunteerProfile.volunteerHeader.volunteerType_title")}</Heading4>
+                <TypeButtons>
+                  {SELECTABLE_VOLUNTEER_TYPES.map((type) => (
+                    <TypeButton
+                      key={type}
+                      type="button"
+                      $active={selectedType === type}
+                      onClick={() => headerMethods.setValue("volunteerType", type, { shouldValidate: true })}
+                    >
+                      {volunteerTypeLabelMap[type]}
+                    </TypeButton>
+                  ))}
+                </TypeButtons>
+              </VolunteerTypeRow>
+            </StatusSection>
+          </ProfileInfo>
+        </ProfileContent>
+      </Card>
+
+      {/* Opportunity Details section */}
+      <SectionCard
+        iconName={IconName.Wrench}
+        title={t("dashboard.opportunityProfile.opportunityDetails.title")}
+        subComponent={
+          <FormProvider {...detailsMethods}>
+            <OpportunityDetailsFields
+              isEvent={isEvent}
+              apiLanguages={apiLanguages}
+              apiActivities={apiActivities}
+              apiSkills={apiSkills}
+            />
+          </FormProvider>
+        }
+      />
+
+      {/* Accompanying Details section — only for ACCOMPANYING type */}
+      {isAccompanying && (
+        <SectionCard
+          iconName={IconName.Users}
+          title={t("dashboard.opportunityProfile.accompanyingDetailsTitle")}
+          subComponent={
+            <FormProvider {...accompanyingMethods}>
+              <AccompanyingDetailsEdit
+                locale={locale}
+                languageOptions={apiLanguages.map((l) => l.title)}
+                keyToLabel={keyToLabel}
+                labelToKey={labelToKey}
+                appointmentLanguageOptions={appointmentLanguageKeys.map((k) => appointmentLanguageKeyToLabel[k])}
+                appointmentLanguageKeyToLabel={appointmentLanguageKeyToLabel}
+                appointmentLanguageLabelToKey={appointmentLanguageLabelToKey}
+                onCancel={() => {}}
+                onSubmit={() => {}}
+                isPending={false}
+                minAppointmentDate={minAppointmentDate}
+              />
+            </FormProvider>
           }
         />
+      )}
 
-        <SaveRow>
-          <Button
-            text={t("dashboard.newOpportunity.submit")}
-            backgroundcolor="var(--color-aubergine)"
-            textColor="var(--color-white)"
-            onClick={handleSubmit(onSubmit)}
-            disabled={isPending || !isValid}
-          />
-        </SaveRow>
-      </FormProvider>
+      <SaveRow>
+        <Button
+          text={t("dashboard.newOpportunity.submit")}
+          backgroundcolor="var(--color-aubergine)"
+          textColor="var(--color-white)"
+          onClick={handleHeaderSubmit(onSubmit)}
+          disabled={isPending}
+        />
+      </SaveRow>
     </PageContainer>
   );
 }
 
+// ─── Styled components ───────────────────────────────────────────────────────
+
 const SaveRow = styled.div`
   display: flex;
   justify-content: flex-end;
+`;
+
+const VolunteerTypeRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing-16) 0;
+  border-bottom: var(--border-width-thin) solid var(--color-blue-50);
+
+  h4 {
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-blue-700);
+    margin: 0;
+    flex-shrink: 0;
+  }
+`;
+
+const TypeButtons = styled.div`
+  display: flex;
+  gap: var(--spacing-8);
+  flex-wrap: wrap;
+`;
+
+const TypeButton = styled.button<{ $active: boolean }>`
+  padding: var(--spacing-8) var(--spacing-16);
+  border-radius: var(--border-radius-sm);
+  border: 2px solid var(--color-aubergine);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: var(--transition-all);
+  background-color: ${({ $active }) => ($active ? "var(--color-aubergine)" : "var(--color-white)")};
+  color: ${({ $active }) => ($active ? "var(--color-white)" : "var(--color-aubergine)")};
+
+  &:hover {
+    opacity: var(--opacity-hover);
+  }
+`;
+
+const FieldGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-8);
+  padding: var(--spacing-16) 0;
+  border-bottom: var(--border-width-thin) solid var(--color-grey-100);
+  width: 100%;
+
+  > label {
+    font-size: var(--editableField-fieldWrapper-label-fontSize);
+    font-weight: var(--editableField-fieldWrapper-label-fontWeight);
+  }
+`;
+
+const DateFieldRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: var(--spacing-16) 0;
+  border-bottom: var(--border-width-thin) solid var(--color-grey-100);
+  gap: var(--spacing-16);
+  width: 100%;
+
+  > label {
+    font-size: var(--editableField-fieldWrapper-label-fontSize);
+    font-weight: var(--editableField-fieldWrapper-label-fontWeight);
+    flex-shrink: 0;
+    width: var(--editableField-fieldWrapper-label-width);
+  }
+`;
+
+const DatePickerContainer = styled.div`
+  flex: 1;
+`;
+
+const TimeInputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+`;
+
+const TimeInput = styled.input<{ $hasError?: boolean }>`
+  padding: var(--spacing-8) var(--spacing-12);
+  border: ${({ $hasError }) => ($hasError ? "1px solid var(--color-error)" : "1px solid var(--color-grey-300)")};
+  border-radius: var(--border-radius-xs);
+  font-size: var(--font-size-lg);
+  color: var(--color-midnight);
 `;

--- a/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
+++ b/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
@@ -43,15 +43,12 @@ import { ShootingStarIcon, ArrowLeftIcon } from "@phosphor-icons/react";
 import { de, enUS } from "date-fns/locale";
 import { TFunction } from "i18next";
 import {
-  ApiOpportunityGet,
   Lang,
-  OptionId,
   OptionItem,
   OpportunityFormDataWithAgentSubmitter,
   TranslatedIntoType,
   VolunteerStateTypeType,
 } from "need4deed-sdk";
-import i18next from "i18next";
 import { useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { Controller, FormProvider, useForm, useFormContext } from "react-hook-form";
@@ -112,13 +109,13 @@ function toOptionItems(ids: string[], apiItems: ApiLanguageOption[]): OptionItem
   });
 }
 
-function availabilityToTimeslots(availability: OpportunityDetailsFormData["availability"]): [number, OptionId][] {
+function availabilityToTimeslots(availability: OpportunityDetailsFormData["availability"]): [number, string][] {
   return (availability ?? []).flatMap(({ weekday, timeSlots }) =>
     timeSlots
       .filter((ts) => ts.selected)
       .map((ts) => {
         const slotId = weekday === 0 ? ts.id.charAt(0).toUpperCase() + ts.id.slice(1) : ts.id;
-        return [weekday, slotId] as [number, OptionId];
+        return [weekday, slotId] as [number, string];
       }),
   );
 }
@@ -130,24 +127,25 @@ function buildCreatePayload(
   apiLanguages: ApiLanguageOption[],
   apiActivities: ApiLanguageOption[],
   apiSkills: ApiLanguageOption[],
+  lang: string,
   t: TFunction,
 ): OpportunityFormDataWithAgentSubmitter {
   const isEvent = headerData.volunteerType === VolunteerStateTypeType.EVENTS;
   const isAccompanying = headerData.volunteerType === VolunteerStateTypeType.ACCOMPANYING;
 
-  const mainLangIds = toLangOptionItems(detailsData.mainCommunication, apiLanguages, t).map((i) => i.id);
-  const residentsLangIds = toLangOptionItems(detailsData.residentsSpeak, apiLanguages, t).map((i) => i.id);
-  const refugeeLangIds = (accompData?.refugeeLanguage ?? []).map(Number).filter(Boolean);
+  const mainLangIds = toLangOptionItems(detailsData.mainCommunication, apiLanguages, t).map((i) => String(i.id));
+  const residentsLangIds = toLangOptionItems(detailsData.residentsSpeak, apiLanguages, t).map((i) => String(i.id));
+  const refugeeLangIds = (accompData?.refugeeLanguage ?? []).map(String).filter(Boolean);
   const languages = [...new Set([...mainLangIds, ...residentsLangIds, ...refugeeLangIds])];
 
-  const activities = toOptionItems(detailsData.activities, apiActivities).map((i) => i.id);
-  const skills = toOptionItems(detailsData.skills, apiSkills).map((i) => i.id);
-  const timeslots = isEvent ? undefined : availabilityToTimeslots(detailsData.availability);
+  const activities = toOptionItems(detailsData.activities, apiActivities).map((i) => String(i.id));
+  const skills = toOptionItems(detailsData.skills, apiSkills).map((i) => String(i.id));
+  const timeslots = isEvent ? null : availabilityToTimeslots(detailsData.availability);
 
   const onetime_date_time =
     isEvent && detailsData.eventDate
       ? `${detailsData.eventDate.toISOString().split("T")[0]}T${detailsData.eventTime || "00:00"}:00`
-      : undefined;
+      : null;
 
   const accomp_datetime =
     isAccompanying && accompData?.appointmentDate
@@ -156,25 +154,29 @@ function buildCreatePayload(
 
   return {
     title: headerData.title,
-    opportunity_type: headerData.volunteerType,
+    opportunity_type: isAccompanying ? "accompanying" : "volunteering",
     vo_information: detailsData.description || null,
     volunteers_number: Number(detailsData.numberOfVolunteers) || 1,
     languages,
     activities,
     skills,
-    timeslots: timeslots ?? null,
+    timeslots,
     onetime_date_time,
-    accomp_address: isAccompanying ? (accompData?.appointmentAddress ?? "") : "",
-    accomp_postcode: isAccompanying ? (accompData?.appointmentPostcode ?? "") : "",
+    accomp_address: isAccompanying ? (accompData?.appointmentAddress ?? null) : null,
+    accomp_postcode: isAccompanying ? (accompData?.appointmentPostcode ?? null) : null,
     accomp_datetime,
     accomp_name: isAccompanying ? (accompData?.refugeeName ?? null) : null,
     accomp_phone: isAccompanying ? (accompData?.refugeeNumber ?? null) : null,
     accomp_information: null,
     accomp_translation: isAccompanying ? (accompData?.appointmentLanguage ?? null) : null,
-    berlin_locations: [],
+    berlin_locations: null,
     category: "",
     category_id: "",
-  } as OpportunityFormDataWithAgentSubmitter;
+    language: lang as `${Lang}`,
+    agent_id: null,
+    submitted_by_id: null,
+    last_edited_time_notion: null,
+  };
 }
 
 // ─── Opportunity Details fields ───────────────────────────────────────────────
@@ -460,15 +462,11 @@ export function NewOpportunity() {
   });
   const minAppointmentDate = useMemo(() => new Date(), []);
 
-  const { mutate: createOpportunity, isPending } = useMutationQuery<
-    OpportunityFormDataWithAgentSubmitter,
-    { message: string; data: ApiOpportunityGet }
-  >({
+  const { mutate: createOpportunity, isPending } = useMutationQuery<OpportunityFormDataWithAgentSubmitter, unknown>({
     apiPath: `${apiPathOpportunity}/`,
     method: "post",
-    onSuccessCallback: (response) => {
-      const id = response?.data?.id;
-      if (id) router.push(`/${i18next.language}${DashboardRoutes.Opportunities}/${id}`);
+    onSuccessCallback: () => {
+      router.push(`/${lang}${DashboardRoutes.Home}`);
     },
   });
 
@@ -480,6 +478,7 @@ export function NewOpportunity() {
       apiLanguages,
       apiActivities,
       apiSkills,
+      lang,
       t,
     );
     createOpportunity(payload);

--- a/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
+++ b/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
@@ -573,6 +573,7 @@ export function NewOpportunity() {
                 onSubmit={() => {}}
                 isPending={false}
                 minAppointmentDate={minAppointmentDate}
+                hideButtons
               />
             </FormProvider>
           }

--- a/src/components/Dashboard/Opportunities/OpportunityTableRow.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityTableRow.tsx
@@ -30,7 +30,6 @@ export function OpportunityTableRow({ opportunity, isLast, districtsList }: Tabl
     district,
     agentTitle,
     numberOfVolunteers,
-    volunteerNames,
   } = opportunity;
   const districtTitle = district?.id ? (districtsList?.find((d) => d.id === district.id)?.title ?? null) : null;
 
@@ -43,8 +42,6 @@ export function OpportunityTableRow({ opportunity, isLast, districtsList }: Tabl
 
   const mainCommunication = getLanguagesByPurpose(languages, LangPurpose.GENERAL);
   const isMatched = statusMatch === OpportunityMatchStatusType.MATCHED;
-  const firstNames = (volunteerNames ?? []).map((name) => name.split(" ")[0]).filter(Boolean);
-  const matchedNames = firstNames.length > 1 ? `${firstNames[0]} +${firstNames.length - 1}` : (firstNames[0] ?? "");
   const statusLabel = t(`dashboard.opportunities.matchStatus.${statusMatch}`);
 
   const handleGoToProfile = () => {
@@ -73,7 +70,7 @@ export function OpportunityTableRow({ opportunity, isLast, districtsList }: Tabl
         $width={OPPORTUNITY_COL_WIDTHS.numberOfVolunteers}
         data-testid={`opportunity-number-of-volunteers-${id}`}
       >
-        <WrappedText>{isMatched ? matchedNames : (numberOfVolunteers ?? "—")}</WrappedText>
+        <WrappedText>{numberOfVolunteers ?? "—"}</WrappedText>
       </TableCell>
       <TableCell $noWrap $width={OPPORTUNITY_COL_WIDTHS.agentTitle} data-testid={`opportunity-agent-${id}`}>
         <TruncatedText>{agentTitle || "—"}</TruncatedText>

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsEdit.tsx
@@ -27,6 +27,7 @@ type Props = {
   onSubmit: () => void;
   isPending: boolean;
   minAppointmentDate: Date;
+  hideButtons?: boolean;
 };
 
 export const AccompanyingDetailsEdit = ({
@@ -41,6 +42,7 @@ export const AccompanyingDetailsEdit = ({
   onSubmit,
   isPending,
   minAppointmentDate,
+  hideButtons = false,
 }: Props) => {
   const { t } = useTranslation();
   const {
@@ -196,24 +198,26 @@ export const AccompanyingDetailsEdit = ({
         />
       </Details>
 
-      <ButtonRow>
-        <Button
-          text={t("dashboard.opportunityProfile.accompanyingDetails.cancel")}
-          onClick={onCancel}
-          width="auto"
-          padding="var(--volunteer-profile-section-card-header-button-padding)"
-          backgroundcolor="var(--color-white)"
-          textColor="var(--color-aubergine)"
-          border="var(--volunteer-profile-section-card-header-button-border)"
-        />
-        <Button
-          text={t("dashboard.opportunityProfile.accompanyingDetails.saveChanges")}
-          onClick={onSubmit}
-          width="auto"
-          padding="var(--volunteer-profile-section-card-header-button-padding)"
-          disabled={!isDirty || !isValid || isPending}
-        />
-      </ButtonRow>
+      {!hideButtons && (
+        <ButtonRow>
+          <Button
+            text={t("dashboard.opportunityProfile.accompanyingDetails.cancel")}
+            onClick={onCancel}
+            width="auto"
+            padding="var(--volunteer-profile-section-card-header-button-padding)"
+            backgroundcolor="var(--color-white)"
+            textColor="var(--color-aubergine)"
+            border="var(--volunteer-profile-section-card-header-button-border)"
+          />
+          <Button
+            text={t("dashboard.opportunityProfile.accompanyingDetails.saveChanges")}
+            onClick={onSubmit}
+            width="auto"
+            padding="var(--volunteer-profile-section-card-header-button-padding)"
+            disabled={!isDirty || !isValid || isPending}
+          />
+        </ButtonRow>
+      )}
     </>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,10 +2412,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.108:
-  version "0.0.108"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.108.tgz#ecbac8afecc53e97afba1a59d4cab5c9592ba1b1"
-  integrity sha512-3HWU2yfjqFhCeHUK08/JfVn/u2AiOk4wiZ6j48km/I7L5R+YM2pM/11/2dzUOvuqXjIiQyd3TE57PNUIKtfGkg==
+need4deed-sdk@0.0.109:
+  version "0.0.109"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.109.tgz#3525b6eac77839c8b67f6c9c3dcde63ed3893bdd"
+  integrity sha512-VIz7sAfT0sDCO6ZRJ1OUKETFmVXQQcXB8SuN3JKcSrXqrB6c+SpE9Kn0h7fTdN9M6JIHF0cE4ch99QmQLxkNLQ==
 
 next@15.3.8:
   version "15.3.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,10 +2412,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.109:
-  version "0.0.109"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.109.tgz#3525b6eac77839c8b67f6c9c3dcde63ed3893bdd"
-  integrity sha512-VIz7sAfT0sDCO6ZRJ1OUKETFmVXQQcXB8SuN3JKcSrXqrB6c+SpE9Kn0h7fTdN9M6JIHF0cE4ch99QmQLxkNLQ==
+need4deed-sdk@0.0.110:
+  version "0.0.110"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.110.tgz#4428170ca81fddd35ec80f7a72825c3e6b29d8e7"
+  integrity sha512-kHa6B13x3CcHMhexam+9CBfRX9AV9/8K1RrUTDSAVdRcJ0PecNFs3JSscwBkJ7UWqjSKV89xaqVkN6N3qGQnAA==
 
 next@15.3.8:
   version "15.3.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,10 +2412,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.107:
-  version "0.0.107"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.107.tgz#3b9e0b42970a9ef6a21045cf522bbca1cdeee902"
-  integrity sha512-UrHmAnlCg2jfBdM6oVYMESfg5H/U9dAAvIN14zWJBHP82NNtScFEqvojdZD9GlCgUxtDqW1chcWsRY/Zzm7Jvg==
+need4deed-sdk@0.0.108:
+  version "0.0.108"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.108.tgz#ecbac8afecc53e97afba1a59d4cab5c9592ba1b1"
+  integrity sha512-3HWU2yfjqFhCeHUK08/JfVn/u2AiOk4wiZ6j48km/I7L5R+YM2pM/11/2dzUOvuqXjIiQyd3TE57PNUIKtfGkg==
 
 next@15.3.8:
   version "15.3.8"


### PR DESCRIPTION
## Summary

- Replaces the simple card form with the same `PageContainer` + `SectionCard` layout used by the opportunity profile page
- Title is presented in a Wrench section card (same as Opportunity Details on the profile)
- Contact details are in a ChatsCircle section card, always in edit mode, pre-filled from the current agent's representative
- Validation uses zod + react-hook-form with the same phone regex and email rules as `opportunityContactDetailsSchema`
- Save POSTs `{ title, contact: { name, phone, email }, agentId }` to `POST /api/opportunity/` and redirects to the new opportunity's profile on success

Closes https://github.com/need4deed-org/fe/issues/445

## Test plan
- [ ] Log in as an agent; click "New Opportunity" from the dashboard
- [ ] Verify the page uses the profile-style section card layout (not the old card form)
- [ ] Verify contact name/phone/email are pre-filled from the logged-in agent's representative
- [ ] Verify title is empty and required; submit without it shows validation error
- [ ] Verify phone/email validation works the same as on the opportunity profile contact section
- [ ] Fill in all fields and submit; confirm redirect to the new opportunity's profile page

🤖 Generated with [Claude Code](https://claude.com/claude-code)