### PR TITLE
🐛 fix: align POST /opportunity body with OpportunityFormDataWithAgentSubmitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "0.0.107",
+    "need4deed-sdk": "0.0.110",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
+++ b/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
@@ -104,9 +104,11 @@ export function NewOpportunity() {
 
   const handleSubmit = () => {
     if (!validate()) return;
+    // Don't create an unlinked opportunity: the agent must be loaded first.
+    if (!agent?.id) return;
     createOpportunity({
       title: title.trim(),
-      agent_id: agent?.id,
+      agent_id: agent.id,
       contact: {
         name: contactName.trim(),
         phone: contactPhone.trim(),
@@ -195,7 +197,7 @@ export function NewOpportunity() {
           backgroundcolor="var(--color-aubergine)"
           textColor="var(--color-white)"
           onClick={handleSubmit}
-          disabled={isPending}
+          disabled={isPending || agentLoading || !agent}
         />
       </Card>
     </Wrapper>

--- a/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
+++ b/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
@@ -4,6 +4,7 @@ import { FormInput } from "@/components/core/common";
 import { apiPathOpportunity, DashboardRoutes } from "@/config/constants";
 import { useMutationQuery } from "@/hooks";
 import { useGetCurrentAgent } from "@/hooks/useGetCurrentAgent";
+import axios from "axios";
 import { ApiOpportunityGet } from "need4deed-sdk";
 import i18next from "i18next";
 import { useRouter } from "next/navigation";
@@ -24,14 +25,19 @@ import {
   Wrapper,
 } from "./styled";
 
-type CreateOpportunityBody = {
+type CreateOpportunityResponse = { message: string; data: ApiOpportunityGet };
+
+// The create endpoint (`OpportunityFormDataWithAgentSubmitter`) only accepts the
+// opportunity itself + `agent_id`; contact details are persisted via a follow-up
+// PATCH (`ApiOpportunityPatch.contact`) once we have the new opportunity id.
+type CreateOpportunityVariables = {
   title: string;
+  agent_id?: number;
   contact: {
     name: string;
     phone: string;
     email: string;
   };
-  agentId?: number;
 };
 
 export function NewOpportunity() {
@@ -58,9 +64,24 @@ export function NewOpportunity() {
     mutate: createOpportunity,
     isPending,
     error,
-  } = useMutationQuery<CreateOpportunityBody, { message: string; data: ApiOpportunityGet }>({
-    apiPath: `${apiPathOpportunity}/`,
-    method: "post",
+  } = useMutationQuery<CreateOpportunityVariables, CreateOpportunityResponse>({
+    mutationFn: async ({ title: oppTitle, agent_id, contact }) => {
+      const { data: created } = await axios.post<CreateOpportunityResponse>(`${apiPathOpportunity}/`, {
+        title: oppTitle,
+        agent_id,
+      });
+      const id = created?.data?.id;
+      if (id) {
+        // Contact is best-effort: the opportunity already exists and contact is
+        // editable on its profile, so a failed PATCH must not fail the create.
+        try {
+          await axios.patch(`${apiPathOpportunity}/${id}`, { contact });
+        } catch {
+          // swallow — agent can set contact from the opportunity profile
+        }
+      }
+      return created;
+    },
     onSuccessCallback: (response) => {
       const id = response?.data?.id;
       if (id) {
@@ -85,12 +106,12 @@ export function NewOpportunity() {
     if (!validate()) return;
     createOpportunity({
       title: title.trim(),
+      agent_id: agent?.id,
       contact: {
         name: contactName.trim(),
         phone: contactPhone.trim(),
         email: contactEmail.trim(),
       },
-      agentId: agent?.id,
     });
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,10 +2412,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.107:
-  version "0.0.107"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.107.tgz#3b9e0b42970a9ef6a21045cf522bbca1cdeee902"
-  integrity sha512-UrHmAnlCg2jfBdM6oVYMESfg5H/U9dAAvIN14zWJBHP82NNtScFEqvojdZD9GlCgUxtDqW1chcWsRY/Zzm7Jvg==
+need4deed-sdk@0.0.110:
+  version "0.0.110"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.110.tgz#4428170ca81fddd35ec80f7a72825c3e6b29d8e7"
+  integrity sha512-kHa6B13x3CcHMhexam+9CBfRX9AV9/8K1RrUTDSAVdRcJ0PecNFs3JSscwBkJ7UWqjSKV89xaqVkN6N3qGQnAA==
 
 next@15.3.8:
   version "15.3.8"


### PR DESCRIPTION
## Problem

`NewOpportunity` (the agent-authenticated "create opportunity" screen) posted to `POST /opportunity/` with a body that didn't match the SDK contract `OpportunityFormDataWithAgentSubmitter`:

- The agent was sent as `agentId` (camelCase). The endpoint expects **`agent_id`** (snake_case), confirmed against both the SDK type (bumped to `need4deed-sdk@0.0.110`) and the runtime swagger. Since the schema is `additionalProperties: true`, the backend silently dropped the unknown key — so **opportunities were never linked to their agent**.
- The body also included a `contact` object that isn't part of the create contract, so the agent's contact details were silently dropped too.

## Fix

- Rename `agentId` → `agent_id` so the agent link actually binds.
- Keep the create body to contract fields only (`title`, `agent_id`).
- Persist contact via a follow-up `PATCH /opportunity/:id` (`ApiOpportunityPatch.contact`), chained inside a single `mutationFn` so there's one toast and one navigation.
- The contact PATCH is **best-effort**: if it fails, the create still succeeds and the agent lands on the opportunity profile where contact is editable.
- Bump `need4deed-sdk` to `0.0.110`.

## Testing

- `yarn typecheck` ✅
- `yarn lint` ✅ (only pre-existing warnings in unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)