### PR TITLE
🐛 fix: link created opportunity to the current agent

### DIFF
--- a/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
+++ b/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
@@ -392,7 +392,7 @@ export function NewOpportunity() {
   const lang = i18n.language;
   const locale = lang === "de" ? de : enUS;
   const router = useRouter();
-  const { agent, isLoading: agentLoading } = useGetCurrentAgent();
+  const { agentId } = useGetCurrentAgent();
   const volunteerTypeLabelMap = createVolunteerTypeLabelMap(t);
 
   const { data: apiLanguages = [] } = useApiLanguages();
@@ -475,7 +475,7 @@ export function NewOpportunity() {
 
   const onSubmit = (headerData: HeaderFormData) => {
     // Don't create an opportunity that isn't linked to its agent.
-    if (!agent?.id) return;
+    if (!agentId) return;
     const payload = buildCreatePayload(
       headerData,
       detailsMethods.getValues(),
@@ -485,7 +485,7 @@ export function NewOpportunity() {
       apiSkills,
       lang,
       t,
-      agent.id,
+      agentId,
     );
     createOpportunity(payload);
   };
@@ -592,7 +592,7 @@ export function NewOpportunity() {
           backgroundcolor="var(--color-aubergine)"
           textColor="var(--color-white)"
           onClick={handleHeaderSubmit(onSubmit)}
-          disabled={isPending || agentLoading || !agent}
+          disabled={isPending || !agentId}
         />
       </SaveRow>
     </PageContainer>

--- a/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
+++ b/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
@@ -37,6 +37,7 @@ import { AvailabilityGrid } from "@/components/forms/AvailabilityGrid/Availabili
 import { LanguageFields } from "@/components/forms/LanguageFields";
 import { apiPathOpportunity, DashboardRoutes, MAX_DESCRIPTION_LENGTH } from "@/config/constants";
 import { useMutationQuery } from "@/hooks";
+import { useGetCurrentAgent } from "@/hooks/useGetCurrentAgent";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Heading2, Heading4 } from "@/components/styled/text";
 import { ShootingStarIcon, ArrowLeftIcon } from "@phosphor-icons/react";
@@ -129,6 +130,7 @@ function buildCreatePayload(
   apiSkills: ApiLanguageOption[],
   lang: string,
   t: TFunction,
+  agentId: number,
 ): OpportunityFormDataWithAgentSubmitter {
   const isEvent = headerData.volunteerType === VolunteerStateTypeType.EVENTS;
   const isAccompanying = headerData.volunteerType === VolunteerStateTypeType.ACCOMPANYING;
@@ -173,7 +175,7 @@ function buildCreatePayload(
     category: "",
     category_id: "",
     language: lang as `${Lang}`,
-    agent_id: null,
+    agent_id: agentId,
     submitted_by_id: null,
     last_edited_time_notion: null,
   };
@@ -390,6 +392,7 @@ export function NewOpportunity() {
   const lang = i18n.language;
   const locale = lang === "de" ? de : enUS;
   const router = useRouter();
+  const { agent, isLoading: agentLoading } = useGetCurrentAgent();
   const volunteerTypeLabelMap = createVolunteerTypeLabelMap(t);
 
   const { data: apiLanguages = [] } = useApiLanguages();
@@ -471,6 +474,8 @@ export function NewOpportunity() {
   });
 
   const onSubmit = (headerData: HeaderFormData) => {
+    // Don't create an opportunity that isn't linked to its agent.
+    if (!agent?.id) return;
     const payload = buildCreatePayload(
       headerData,
       detailsMethods.getValues(),
@@ -480,6 +485,7 @@ export function NewOpportunity() {
       apiSkills,
       lang,
       t,
+      agent.id,
     );
     createOpportunity(payload);
   };
@@ -586,7 +592,7 @@ export function NewOpportunity() {
           backgroundcolor="var(--color-aubergine)"
           textColor="var(--color-white)"
           onClick={handleHeaderSubmit(onSubmit)}
-          disabled={isPending}
+          disabled={isPending || agentLoading || !agent}
         />
       </SaveRow>
     </PageContainer>


### PR DESCRIPTION
## Problem

The rewritten `NewOpportunity` form (from #693) builds its payload with `buildCreatePayload`, which hardcodes:

```ts
agent_id: null,
submitted_by_id: null,
```

and the component never fetches the current agent. So every opportunity created through this screen is sent to `POST /opportunity/` **unlinked to any agent**, even though the contract (`OpportunityFormDataWithAgentSubmitter`) carries `agent_id`.

This supersedes #696 (closed), which fixed the same class of bug on the pre-rewrite version of this file.

## Fix

- Fetch the logged-in agent via `useGetCurrentAgent` (`GET /agent/me`).
- Pass `agent.id` into `buildCreatePayload`, setting `agent_id` on the payload.
- Gate submit until the agent is loaded (`disabled={isPending || agentLoading || !agent}`) and bail in `onSubmit` if there's no agent id, so we never create an unlinked opportunity under a race.

`submitted_by_id` is left as `null` — its source/semantics aren't established here and the backend may derive it from the authenticated session. Happy to wire it up in a follow-up if it should come from the agent representative.

## Testing

- `yarn typecheck` ✅
- `yarn lint` ✅ (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)