### PR TITLE
fix(703): restore consent links in opportunity form

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -20,7 +20,12 @@
       "legalNotice": "Rechtlicher Hinweis",
       "privacy": "Datenschutz",
       "vpa": "Freiwilligenvereinbarung",
-      "contact": "Kontakt"
+      "contact": "Kontakt",
+      "legal": {
+        "guidelines": "Need4Deed Leitlinien",
+        "legalNotice": "Rechtlicher Hinweis",
+        "dataPrivacy": "Datenschutz"
+      }
     },
     "testimonials": {
       "header": "ERFAHRUNGSBERICHTE",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -27,6 +27,7 @@
         "dataPrivacy": "Privacy",
         "agreement": "Voluntary Participation Agreement",
         "guidelines": "Need4Deed Guidelines",
+        "legalNotice": "Legal notice",
         "cookies": "Cookies"
       }
     },

--- a/src/components/forms/AddOpportunity/AddOpportunity.tsx
+++ b/src/components/forms/AddOpportunity/AddOpportunity.tsx
@@ -725,9 +725,10 @@ export default function AddOpportunity() {
                   <label htmlFor="consent">{getTickMark(!!field.state.value)}</label>
                   <span>
                     {t("form.addOpportunity.fields.consent.header")} {t("form.addOpportunity.fields.consent.agree")}{" "}
-                    <a href={`/${Subpage.GUIDELINES}/${lng}`}>{t("homepage.footer.legal.guidelines")}</a>{" "}
+                    <a href={`/${lng}/${Subpage.RAC_GUIDELINES}`}>{t("homepage.footer.legal.guidelines")}</a>,{" "}
+                    <a href={`/${lng}/${Subpage.LEGAL_NOTICE}`}>{t("homepage.footer.legal.legalNotice")}</a>{" "}
                     {t("form.addOpportunity.fields.consent.and")}{" "}
-                    <a href={`/${Subpage.DATA_PROTECTION}/${lng}`}>{t("homepage.footer.legal.dataPrivacy")}</a>
+                    <a href={`/${lng}/${Subpage.DATA_PRIVACY}`}>{t("homepage.footer.legal.dataPrivacy")}</a>
                   </span>
                 </div>
                 <FieldInfo field={field} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export enum Subpage {
   OPPORTUNITY_FORM = "opportunity-form",
   DATA_PROTECTION = "data-protection",
   GUIDELINES = "guidelines",
+  RAC_GUIDELINES = "rac-guidelines",
 }
 
 export enum Env {


### PR DESCRIPTION
## Summary

- Fixes raw i18n keys rendering as link text in the opportunity form consent checkbox (DE was missing the entire `homepage.footer.legal` translation object)
- Fixes broken link URLs: corrected path order from `/{subpage}/{lang}` to `/{lang}/{subpage}` and replaced wrong slugs with the correct `rac-guidelines` / `data-privacy`
- Adds the missing **Legal Notice** third link alongside RAC Guidelines and Data Privacy

## Rendered result

**DE:** Hiermit stimme ich zu: [Need4Deed Leitlinien](/de/rac-guidelines), [Rechtlicher Hinweis](/de/legal-notice) und [Datenschutz](/de/data-privacy)

**EN:** I hereby agree to the: [Need4Deed Guidelines](/en/rac-guidelines), [Legal notice](/en/legal-notice) and [Privacy](/en/data-privacy)

## Test plan

- [ ] Open `/de/forms/opportunity`, scroll to bottom — consent checkbox shows three readable German link labels (not raw key strings)
- [ ] Click each link — verify it navigates to the correct page (rac-guidelines, legal-notice, data-privacy)
- [ ] Repeat in English locale (`/en/forms/opportunity`)

Closes https://github.com/need4deed-org/fe/issues/703

🤖 Generated with [Claude Code](https://claude.com/claude-code)