### PR TITLE
separate copied emails by newline

### DIFF
--- a/src/utils/copyEmails.ts
+++ b/src/utils/copyEmails.ts
@@ -1,3 +1,3 @@
 export async function copyEmails(emails: string[]) {
-  await navigator.clipboard.writeText(emails.join(", "));
+  await navigator.clipboard.writeText(emails.join("\n"));
 }


### PR DESCRIPTION
## Description
Copy-all emails were joined with ", " and pasted into a single cell in Sheets/Excel. Now joined with newlines so each email lands in its own row. Verified it also pastes correctly into Gmail's recipient field.

## Related Issues
Closes #707 

## Changes
 - `copyEmails`  : joins emails with `"\n"` instead of `", "`


## Screenshots / Demos
[Screencast from 2026-06-19 12-06-24.webm](https://github.com/user-attachments/assets/f0ab2531-1e39-45cb-a42d-50ef9007b263)

<img width="529" height="491" alt="Screenshot from 2026-06-19 12-35-19" src="https://github.com/user-attachments/assets/4f0ba9a0-dc99-4925-ac6a-070f015960c2" />


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

