### PR TITLE
fix: open avatar dropdown with logout on caret click

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -487,7 +487,8 @@
       "button": {
         "login": "Anmelden",
         "joinVolunteer": "Jetzt sich engagieren",
-        "dashboard": "Dashboard"
+        "dashboard": "Dashboard",
+        "logout": "Abmelden"
       }
     },
     "login": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -483,7 +483,8 @@
       "button": {
         "login": "Log in",
         "joinVolunteer": "Join as a volunteer",
-        "dashboard": "Dashboard"
+        "dashboard": "Dashboard",
+        "logout": "Log out"
       }
     },
     "login": {

--- a/src/components/Header/UserProfile.tsx
+++ b/src/components/Header/UserProfile.tsx
@@ -1,8 +1,17 @@
+"use client";
+import { useClickOutside } from "@/hooks";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
-import { CaretDownIcon, CaretUpIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import { CaretDownIcon, CaretUpIcon, SignOutIcon } from "@phosphor-icons/react";
+import { useRouter } from "next/navigation";
+import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { Paragraph } from "../styled/text";
+
+const UserProfileWrapper = styled.div`
+  position: relative;
+  display: inline-flex;
+`;
 
 const UserProfileContainer = styled.div`
   display: flex;
@@ -22,6 +31,35 @@ const UserIconDiv = styled.div`
   border-radius: var(--dashboard-cards-header-user-icon-border-radius);
 `;
 
+const DropdownMenu = styled.ul`
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 100;
+  margin: 0;
+  padding: var(--spacing-8) 0;
+  list-style: none;
+  background: var(--color-white);
+  border-radius: var(--border-radius-xs);
+  box-shadow: var(--dropdown-box-shadow);
+  min-width: 140px;
+`;
+
+const DropdownItem = styled.li`
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-8);
+  padding: var(--spacing-8) var(--spacing-16);
+  font-size: var(--font-size-lg);
+  color: var(--color-midnight);
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover {
+    background-color: var(--color-grey-50);
+  }
+`;
+
 const getInitials = (fullName: string | undefined): string => {
   if (!fullName) return "";
   return fullName
@@ -34,23 +72,51 @@ const getInitials = (fullName: string | undefined): string => {
 };
 
 export function UserProfile() {
-  const [isCaretDown, setIsCaretDown] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
   const user = useCurrentUser();
+  const router = useRouter();
+  const { t, i18n } = useTranslation();
+
+  useClickOutside(ref, () => setIsOpen(false));
+
   const userName = getInitials(user?.fullName) || user?.firstName?.[0]?.toUpperCase() || "";
 
+  const handleLogout = () => {
+    document.cookie = "is_logged_in=; path=/; max-age=0; SameSite=Lax; Secure";
+    router.push(`/${i18n.language}/login`);
+  };
+
   return (
-    <UserProfileContainer onClick={() => setIsCaretDown(!isCaretDown)}>
-      <UserIconDiv>
-        <Paragraph color="var(--color-white)" fontWeight={400} fontSize="14px" lineheight="18px" letterSpacing="0.2px">
-          {userName}
-        </Paragraph>
-      </UserIconDiv>
-      {isCaretDown ? (
-        <CaretDownIcon size={20} color={"var(--color-midnight)"} />
-      ) : (
-        <CaretUpIcon size={20} color={"var(--color-midnight)"} />
+    <UserProfileWrapper ref={ref}>
+      <UserProfileContainer onClick={() => setIsOpen((prev) => !prev)}>
+        <UserIconDiv>
+          <Paragraph
+            color="var(--color-white)"
+            fontWeight={400}
+            fontSize="14px"
+            lineheight="18px"
+            letterSpacing="0.2px"
+          >
+            {userName}
+          </Paragraph>
+        </UserIconDiv>
+        {isOpen ? (
+          <CaretUpIcon size={20} color={"var(--color-midnight)"} />
+        ) : (
+          <CaretDownIcon size={20} color={"var(--color-midnight)"} />
+        )}
+      </UserProfileContainer>
+
+      {isOpen && (
+        <DropdownMenu>
+          <DropdownItem onClick={handleLogout}>
+            <SignOutIcon size={18} />
+            {t("dashboard.header.button.logout")}
+          </DropdownItem>
+        </DropdownMenu>
       )}
-    </UserProfileContainer>
+    </UserProfileWrapper>
   );
 }
 

--- a/src/components/Header/UserProfile.tsx
+++ b/src/components/Header/UserProfile.tsx
@@ -1,8 +1,8 @@
 "use client";
 import { useClickOutside } from "@/hooks";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { clearAuthHint } from "@/utils/helpers";
 import { CaretDownIcon, CaretUpIcon, SignOutIcon } from "@phosphor-icons/react";
-import { useRouter } from "next/navigation";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
@@ -75,7 +75,6 @@ export function UserProfile() {
   const [isOpen, setIsOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const user = useCurrentUser();
-  const router = useRouter();
   const { t, i18n } = useTranslation();
 
   useClickOutside(ref, () => setIsOpen(false));
@@ -83,8 +82,8 @@ export function UserProfile() {
   const userName = getInitials(user?.fullName) || user?.firstName?.[0]?.toUpperCase() || "";
 
   const handleLogout = () => {
-    document.cookie = "is_logged_in=; path=/; max-age=0; SameSite=Lax; Secure";
-    router.push(`/${i18n.language}/login`);
+    clearAuthHint();
+    window.location.href = `/${i18n.language}/login`;
   };
 
   return (

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,10 @@ import { userAgent } from "next/server";
 import { supportedLangs } from "./config/constants";
 import { Lang } from "need4deed-sdk";
 
+const AUTH_HINT_COOKIE = "is_logged_in";
+const ACCESS_COOKIE = "access";
+const REFRESH_COOKIE = "refresh";
+
 const DEFAULT_LOCALE = Lang.EN;
 const DEFAULT_DEVICE_TYPE = "desktop";
 const DEVICE_HEADER_NAME = "x-device-type";
@@ -45,6 +49,22 @@ export function middleware(request: NextRequest) {
   }
 
   const response = NextResponse.next();
+
+  // Clear auth tokens when is_logged_in hint is absent but access token is still present.
+  // This prevents a logged-out user from bypassing auth by manually re-adding the hint cookie.
+  const cookieToken = request.cookies.get(ACCESS_COOKIE)?.value;
+  const cookieAuth = request.cookies.get(AUTH_HINT_COOKIE)?.value;
+  if (cookieToken && !cookieAuth) {
+    const isProd = process.env.NODE_ENV === "production";
+    const baseOptions = {
+      path: "/",
+      secure: true,
+      sameSite: "lax" as const,
+      domain: isProd ? "app.need4deed.org" : undefined,
+    };
+    response.cookies.delete({ name: ACCESS_COOKIE, ...baseOptions });
+    response.cookies.delete({ name: REFRESH_COOKIE, ...baseOptions });
+  }
 
   // Persist the current locale in a cookie so bare URLs respect the user's choice
   if (currentLocale && supportedLangs.includes(currentLocale)) {


### PR DESCRIPTION
Closes #661

When clicking the avatar caret in the dashboard header, only the icon flipped direction but no menu appeared. There was also no way to log out at all.

Changes:
- UserProfile.tsx: added dropdown with useRef and useClickOutside, opens on caret click and closes on outside click
- Logout item clears the is_logged_in cookie and redirects to /login
- Added dashboard.header.button.logout translation key to en and de locales
