### PR TITLE
NGO dashboard: Volunteers page should show card view only

### DIFF
--- a/src/components/Dashboard/Volunteers/Volunteers.tsx
+++ b/src/components/Dashboard/Volunteers/Volunteers.tsx
@@ -6,7 +6,7 @@ import styled from "styled-components";
 import { DashboardLayout } from "@/components/Layout";
 import { apiPathOption, questionMark } from "@/config/constants";
 import { useGetOpportunity, useGetQuery } from "@/hooks";
-import { ApiOptionLists, EntityTableName, QueryParamsKeys, SortOrder } from "need4deed-sdk";
+import { ApiOptionLists, EntityTableName, QueryParamsKeys, SortOrder, UserRole } from "need4deed-sdk";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import Filters from "../common/CardsFilter/Filters";
 import CardsHeader from "../common/CardsHeader/CardsHeader";
@@ -22,8 +22,11 @@ import {
 } from "./helpers";
 import { VolunteerListController } from "./VolunteerListController";
 import { ViewMode } from "../common/types";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 export function Volunteers() {
+  const user = useCurrentUser(true);
+  const isAgent = user?.role === UserRole.AGENT;
   const { t } = useTranslation();
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const [isFiltersOpen, setIsFiltersOpen] = useState(false);
@@ -34,8 +37,8 @@ export function Volunteers() {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
-  const tabs = [t("dashboard.volunteers.tabs.tab1"), t("dashboard.volunteers.tabs.tab2")];
-  const viewMode = Object.values(ViewMode)[selectedTabIndex];
+  const tabs = !user || isAgent ? [] : [t("dashboard.volunteers.tabs.tab1"), t("dashboard.volunteers.tabs.tab2")];
+  const viewMode = isAgent ? ViewMode.CARDS : Object.values(ViewMode)[selectedTabIndex];
   const opportunityId = searchParams.get("opportunity") ?? undefined;
   const opportunityFilter = useGetOpportunity(opportunityId);
 


### PR DESCRIPTION
## Description
For the NGO (agent) dashboard, the volunteers page shouldn't offer the list view at all ,only cards. This hides the List/Cards tab toggle for agents and forces the card view, so an NGO can't switch to the list. Coordinator/Admin are unchanged.

## Related Issues
Closes #720 

## Changes
  - Read the current user's role via useCurrentUser and derive isAgent.
  - Agents: tabs = [] (hide the List/Cards toggle) 
  - viewMode = ViewMode.CARDS (force card view).
  - While the user is still loading (!user), hide the toggle so it doesn't flash before the role resolves.
  - Coordinator/Admin unchanged.


## Screenshots / Demos
<img width="1362" height="631" alt="Screenshot from 2026-06-23 21-30-18" src="https://github.com/user-attachments/assets/aa80147e-ef31-4b16-90dc-7886eb76f16d" />


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

