### PR TITLE
fix: relabel 'Regelmäßig' button to 'Regelmäßig oder Veranstaltungen' on opportunity form

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -257,7 +257,7 @@
           "header": "Art des Bedarfs",
           "volunteering": "Freizeit",
           "accompanying": "Begleitung",
-          "regular": "Regelmäßig",
+          "regular": "Regelmäßig oder Veranstaltungen",
           "events": "Veranstaltung",
           "helpText": "Es gibt zwei Arten von Unterstützung: Freiwilliges Engagement bei verschiedenen Aktivitäten (meist Freizeitaktivitäten) und Begleitung zu Terminen.",
           "helpTitle": ""

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -253,7 +253,7 @@
           "header": "Type Of Opportunity",
           "volunteering": "Volunteering Opportunity",
           "accompanying": "Accompanying Appointment",
-          "regular": "Regular",
+          "regular": "Regular or Events",
           "events": "Events",
           "helpText": "There are two ways of helping: Volunteering doing various activities and Accompanying to appointments essentially providing translation",
           "helpTitle": ""


### PR DESCRIPTION
## Description
Relabels the "Regelmäßig" button in the public opportunity request form's "Art des Bedarfs" section to make clear it also covers single dated events.

## Related Issues
Closes https://github.com/need4deed-org/fe/issues/727

## Changes
- `public/locales/de/translations.json`: `form.addOpportunity.fields.opportunityType.regular` → "Regelmäßig oder Veranstaltungen"
- `public/locales/en/translations.json`: same key → "Regular or Events"
- No change to `OpportunityType` values, form schema, or submission behavior — text only, and only this one key (other "regular" labels used elsewhere in the dashboard are untouched).

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes