### PR TITLE
Opportunities page NGO show card view only

### DIFF
--- a/src/components/Dashboard/Opportunities/Opportunities.tsx
+++ b/src/components/Dashboard/Opportunities/Opportunities.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { DashboardLayout } from "@/components/Layout";
 import { apiPathOption, questionMark } from "@/config/constants";
 import { useGetVolunteer, useGetQuery } from "@/hooks";
-import { ApiOptionLists, EntityTableName, SortOrder } from "need4deed-sdk";
+import { ApiOptionLists, EntityTableName, SortOrder, UserRole } from "need4deed-sdk";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import Filters from "../common/CardsFilter/Filters";
 import CardsHeader from "../common/CardsHeader/CardsHeader";
@@ -18,8 +18,11 @@ import { deserializeOpportunityFilters, serializeOpportunityFilters } from "./he
 import { OpportunityListController } from "./OpportunityListController";
 import { ContentRow, OpportunitiesContainer } from "./styles";
 import { ViewMode } from "../common/types";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 export function Opportunities() {
+  const user = useCurrentUser(true);
+  const isAgent = user?.role === UserRole.AGENT;
   const { t } = useTranslation();
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const [isFiltersOpen, setIsFiltersOpen] = useState(false);
@@ -30,13 +33,18 @@ export function Opportunities() {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
-  const tabs = [
-    t("dashboard.opportunities.tabs.tab1"),
-    t("dashboard.opportunities.tabs.tab2"),
-    t("dashboard.opportunities.tabs.tab3"),
-  ];
-  const VIEW_MODE_BY_TAB = [ViewMode.LIST, ViewMode.CARDS, ViewMode.MAP] as const;
-  const viewMode = VIEW_MODE_BY_TAB[selectedTabIndex] ?? ViewMode.LIST;
+  const tabs = !user
+    ? []
+    : isAgent
+      ? [t("dashboard.opportunities.tabs.tab2"), t("dashboard.opportunities.tabs.tab3")]
+      : [
+          t("dashboard.opportunities.tabs.tab1"),
+          t("dashboard.opportunities.tabs.tab2"),
+          t("dashboard.opportunities.tabs.tab3"),
+        ];
+
+  const VIEW_MODE_BY_TAB = isAgent ? [ViewMode.CARDS, ViewMode.MAP] : [ViewMode.LIST, ViewMode.CARDS, ViewMode.MAP];
+  const viewMode = VIEW_MODE_BY_TAB[selectedTabIndex] ?? ViewMode.CARDS;
 
   const volunteerId = searchParams.get("volunteer") ?? undefined;
   const volunteerFilter = useGetVolunteer(volunteerId);


### PR DESCRIPTION
## Description
On the NGO, Opportunities now defaults to card view, and the List tab is hidden. The Map tab stays in place for future use. Coordinator/Admin are unchanged.
Closes #721 

## Changes
- Detect agent role with `useCurrentUser` / `UserRole.AGENT`
- Agents: show only Cards and Map tabs, default to Cards
- Coordinator/Admin: keep List, Cards, and Map tabs as before


## Screenshots / Demos
NGO 
<img width="1362" height="706" alt="OpNGO" src="https://github.com/user-attachments/assets/8299f536-df61-410a-a8ae-db8d4e73dbb9" />
 Admin
<img width="1362" height="706" alt="OpAdmin" src="https://github.com/user-attachments/assets/0d2c24ed-6ec2-411d-8cba-dc31ebaa45f9" />


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

