### PR TITLE
agent page NGO show card view only

### DIFF
--- a/src/components/Dashboard/Agents/Agents.tsx
+++ b/src/components/Dashboard/Agents/Agents.tsx
@@ -8,7 +8,7 @@ import CardsHeader from "../common/CardsHeader/CardsHeader";
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { ApiOptionLists, EntityTableName, SortOrder } from "need4deed-sdk";
+import { ApiOptionLists, EntityTableName, SortOrder, UserRole } from "need4deed-sdk";
 import { useGetQuery } from "@/hooks";
 import { apiPathOption, questionMark } from "@/config/constants";
 import { AgentCardsFilter } from "./Filters/types";
@@ -19,8 +19,11 @@ import { deserializeAgentFilters, serializeAgentFilters } from "./helpers";
 import Filters from "../common/CardsFilter/Filters";
 import FiltersContent from "./Filters/FiltersContent";
 import { ViewMode } from "../common/types";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 export const Agents = () => {
+  const user = useCurrentUser(true);
+  const isAgent = user?.role === UserRole.AGENT;
   const { t } = useTranslation();
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const [isFiltersOpen, setIsFiltersOpen] = useState(false);
@@ -31,9 +34,15 @@ export const Agents = () => {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
-  const tabs = [t("dashboard.agents.tabs.tab1"), t("dashboard.agents.tabs.tab2"), t("dashboard.agents.tabs.tab3")];
-  const VIEW_MODE_BY_TAB = [ViewMode.LIST, ViewMode.CARDS, ViewMode.MAP] as const;
-  const viewMode = VIEW_MODE_BY_TAB[selectedTabIndex] ?? ViewMode.LIST;
+
+  const tabs = !user
+    ? []
+    : isAgent
+      ? [t("dashboard.agents.tabs.tab2"), t("dashboard.agents.tabs.tab3")]
+      : [t("dashboard.agents.tabs.tab1"), t("dashboard.agents.tabs.tab2"), t("dashboard.agents.tabs.tab3")];
+
+  const VIEW_MODE_BY_TAB = isAgent ? [ViewMode.CARDS, ViewMode.MAP] : [ViewMode.LIST, ViewMode.CARDS, ViewMode.MAP];
+  const viewMode = VIEW_MODE_BY_TAB[selectedTabIndex] ?? ViewMode.CARDS;
 
   const handleSearchInputChange = (searchInput: string) => {
     handleFilterUpdate((prev) => ({ ...prev, search: searchInput }));


### PR DESCRIPTION
## Description
On the NGO account, Agent page  now defaults to card view, and the List tab is hidden. The Map tab stays in place for future use. Coordinator/Admin are unchanged.

## Related Issues
Closes #722 

## Changes
- Detect agent role with useCurrentUser / UserRole.AGENT
- Agents: show only Cards and Map tabs, default to Cards
- Coordinator/Admin: keep List, Cards, and Map tabs as before

## Screenshots / Demos
Agent  account: 
<img width="1362" height="706" alt="agentAgent" src="https://github.com/user-attachments/assets/e15363da-b069-4d59-afaf-283a6ce2113e" />

 Admin:
<img width="1362" height="706" alt="Screenshot from 2026-06-30 18-54-52" src="https://github.com/user-attachments/assets/86cb1dd7-2374-4752-8121-8cdd8b8eaf47" />

- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

