### PR TITLE
hotfix: resolve package.json, yarn.lock merge conflict on develop, ke…

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-<<<<<<< HEAD
     "need4deed-sdk": "0.0.115",
-=======
-    "need4deed-sdk": "../sdk",
->>>>>>> 41a5fa4 (🐛 reduce  "Needed" column width from 140px to 120px)
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,20 +2412,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-<<<<<<< HEAD
 need4deed-sdk@0.0.115:
   version "0.0.115"
   resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.115.tgz#cb07ffaabbd22353e65b28e9a592a3a78b269593"
   integrity sha512-VoOpHlSnAUgNIHrUsKPrj1L4299ze+bBFsnCLs3BP5IPL5lLN5uK1vzkT+t9rAgilb8h22HqXWlzxMAPBhoTcA==
-=======
-need4deed-sdk@../sdk:
-  version "0.0.114"
-
-need4deed-sdk@0.0.110:
-  version "0.0.110"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.110.tgz#4428170ca81fddd35ec80f7a72825c3e6b29d8e7"
-  integrity sha512-kHa6B13x3CcHMhexam+9CBfRX9AV9/8K1RrUTDSAVdRcJ0PecNFs3JSscwBkJ7UWqjSKV89xaqVkN6N3qGQnAA==
->>>>>>> 41a5fa4 (🐛 reduce  "Needed" column width from 140px to 120px)
 
 next@15.3.8:
   version "15.3.8"


### PR DESCRIPTION

## Description
 develop was left with unresolved merge conflict markers in `package.json` from #735, making it invalid JSON. This broke `yarn install` and failed lint on every open PR. This hotfix removes the markers and keeps the published `need4deed-sdk` 0.0.115 (the `../sdk` was a local path that shouldn't have been committed). yarn.lock is resolved to match.

 ## Changes
  - Remove conflict markers in `package.json`, keep `need4deed-sdk`: `0.0.115` (drop `../sdk`)
  - Resolve matching conflict in `yarn.lock`




## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

