### PR TITLE
749: redirects nonusers when they access /dashboard routes

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,12 +13,23 @@ const REFRESH = "refresh";
 
 const authorizedRoutes: Record<string, { regex: RegExp; redirect: string }> = {
   AGENT: { regex: /^(?:\/[a-z]{2})?\/dashboard\/agents\/([0-9]+)$/, redirect: "/dashboard/agents" },
+  DASHBOARD: { regex: /^(?:\/[a-z]{2})?\/dashboard(?:\/|$)/, redirect: "/login" },
 };
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   const token = request.cookies.get(REFRESH)?.value;
+
+  if (!token) {
+    const match = pathname.match(authorizedRoutes.DASHBOARD.regex);
+    if (match) {
+      const url = request.nextUrl.clone();
+      url.search = "";
+      url.pathname = authorizedRoutes.DASHBOARD.redirect;
+      return NextResponse.redirect(url);
+    }
+  }
 
   if (token) {
     const userObject = decodeJwtPayload(token);


### PR DESCRIPTION
## Description
Adds a `middleware` handler that redirects users who have no logged-in when they try to access `/dashboard` routes.

Previously we had an `axios` handler but this was quite slow and with the `middleware` the user won't even see the dashboard

## Related Issues
Closes #749 

## Changes
- Bullet list of meaningful changes (optional)

## Screenshots / Demos
If UI-related, add before/after or GIFs.

## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

