### PR TITLE
fix: persist Opportunities sort order in URL (#729)

### DIFF
--- a/src/components/Dashboard/Opportunities/Opportunities.tsx
+++ b/src/components/Dashboard/Opportunities/Opportunities.tsx
@@ -36,7 +36,7 @@ export function Opportunities() {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
-  const [sortOrder, setSortOrder] = useState<string>(() => parseSortParam(searchParams.get(SORT_PARAM)));
+  const sortOrder = parseSortParam(searchParams.get(SORT_PARAM));
   const tabs = !user
     ? []
     : isAgent
@@ -61,7 +61,6 @@ export function Opportunities() {
 
   const handleSortChange = (order: string) => {
     const sort = parseSortParam(order);
-    setSortOrder(sort);
     const params = new URLSearchParams(searchParams);
     params.delete("page");
     if (sort === DEFAULT_SORT_ORDER) params.delete(SORT_PARAM);
@@ -106,17 +105,10 @@ export function Opportunities() {
   const handleClearAllFilters = () => {
     const cleared = getClearFilter(cardsFilter);
     setCardsFilter(cleared);
-    setSortOrder(DEFAULT_SORT_ORDER);
     const params = serializeOpportunityFilters(cleared, searchParams, false);
     params.delete(SORT_PARAM);
     router.push(pathname + questionMark + params.toString());
   };
-
-  // sync sort on back/forward within the same route (no remount → lazy init won't re-run)
-  const sortParam = searchParams.get(SORT_PARAM);
-  useEffect(() => {
-    setSortOrder(parseSortParam(sortParam));
-  }, [sortParam]);
 
   useEffect(() => {
     if (!apiFilterOptions) return;

--- a/src/components/Dashboard/Opportunities/Opportunities.tsx
+++ b/src/components/Dashboard/Opportunities/Opportunities.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { DashboardLayout } from "@/components/Layout";
 import { apiPathOption, questionMark } from "@/config/constants";
 import { useGetVolunteer, useGetQuery } from "@/hooks";
-import { ApiOptionLists, EntityTableName, SortOrder, UserRole } from "need4deed-sdk";
+import { ApiOptionLists, EntityTableName, UserRole } from "need4deed-sdk";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import Filters from "../common/CardsFilter/Filters";
 import CardsHeader from "../common/CardsHeader/CardsHeader";
@@ -13,7 +13,13 @@ import { defaultOpportunityCardsFilter } from "./Filters/constants";
 import FiltersContent from "./Filters/FiltersContent";
 import { OpportunityCardsFilter } from "./Filters/types";
 import { createSelectedOpportunityFiltersAsFlatArray } from "./Filters/helpers";
-import { deserializeOpportunityFilters, serializeOpportunityFilters } from "./helpers";
+import {
+  deserializeOpportunityFilters,
+  serializeOpportunityFilters,
+  parseSortParam,
+  SORT_PARAM,
+  DEFAULT_SORT_ORDER,
+} from "./helpers";
 import { OpportunityListController } from "./OpportunityListController";
 import { ContentRow, OpportunitiesContainer } from "./styles";
 import { ViewMode } from "../common/types";
@@ -25,12 +31,12 @@ export function Opportunities() {
   const { t } = useTranslation();
   const [isFiltersOpen, setIsFiltersOpen] = useState(false);
   const [numOfOpps, setNumOfOpps] = useState(0);
-  const [sortOrder, setSortOrder] = useState<string>(SortOrder.NewToOld);
   const [cardsFilter, setCardsFilter] = useState(defaultOpportunityCardsFilter);
   const { data: apiFilterOptions } = useGetQuery<ApiOptionLists>({ queryKey: ["options"], apiPath: apiPathOption });
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
+  const [sortOrder, setSortOrder] = useState<string>(() => parseSortParam(searchParams.get(SORT_PARAM)));
   const tabs = !user
     ? []
     : isAgent
@@ -54,7 +60,13 @@ export function Opportunities() {
   };
 
   const handleSortChange = (order: string) => {
-    setSortOrder(order);
+    const sort = parseSortParam(order);
+    setSortOrder(sort);
+    const params = new URLSearchParams(searchParams);
+    params.delete("page");
+    if (sort === DEFAULT_SORT_ORDER) params.delete(SORT_PARAM);
+    else params.set(SORT_PARAM, sort);
+    router.push(pathname + questionMark + params.toString());
   };
 
   const handleTabChange = (index: number) => {
@@ -94,8 +106,17 @@ export function Opportunities() {
   const handleClearAllFilters = () => {
     const cleared = getClearFilter(cardsFilter);
     setCardsFilter(cleared);
-    router.push(pathname + questionMark + serializeOpportunityFilters(cleared, searchParams));
+    setSortOrder(DEFAULT_SORT_ORDER);
+    const params = serializeOpportunityFilters(cleared, searchParams, false);
+    params.delete(SORT_PARAM);
+    router.push(pathname + questionMark + params.toString());
   };
+
+  // sync sort on back/forward within the same route (no remount → lazy init won't re-run)
+  const sortParam = searchParams.get(SORT_PARAM);
+  useEffect(() => {
+    setSortOrder(parseSortParam(sortParam));
+  }, [sortParam]);
 
   useEffect(() => {
     if (!apiFilterOptions) return;

--- a/src/components/Dashboard/Opportunities/OpportunityListController.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityListController.tsx
@@ -4,17 +4,10 @@ import { apiPathOpportunity, cacheTTL, CARD_COLUMNS, CARD_LIMIT, CARD_ROWS, TABL
 import { useGetQuery, usePageParam } from "@/hooks";
 import { ApiVolunteerOpportunityGetList, ApiOptionLists, SortOrder } from "need4deed-sdk";
 import { OpportunityCardsFilter } from "./Filters/types";
-import { serializeOpportunityFilters } from "./helpers";
+import { AppointmentSort, isAppointmentSort, serializeOpportunityFilters } from "./helpers";
 import { OpportunityCardList } from "./OpportunityCardList";
 import { ViewMode } from "../common/types";
 import { OpportunityTableList } from "./OpportunityTableList";
-
-const APPOINTMENT_SORT_VALUES = ["appointment-proximal", "appointment-distant"] as const;
-type AppointmentSort = (typeof APPOINTMENT_SORT_VALUES)[number];
-
-function isAppointmentSort(sort: string): sort is AppointmentSort {
-  return (APPOINTMENT_SORT_VALUES as readonly string[]).includes(sort);
-}
 
 type OpportunityWithAccompanying = ApiVolunteerOpportunityGetList & {
   accompanyingDetails?: { appointmentDate?: string };
@@ -63,7 +56,7 @@ export function OpportunityListController({
   const serializedFilter = serializeOpportunityFilters(filter, undefined, false, {
     serializeToIDs: true,
     apiFilterOptions,
-  }) as URLSearchParams;
+  });
 
   if (volunteerId) {
     serializedFilter.set("volunteer", volunteerId);

--- a/src/components/Dashboard/Opportunities/helpers.ts
+++ b/src/components/Dashboard/Opportunities/helpers.ts
@@ -6,6 +6,7 @@ import {
   OptionById,
   OptionItem,
   QueryParamsKeys,
+  SortOrder,
 } from "need4deed-sdk";
 import { ReadonlyURLSearchParams } from "next/navigation";
 import { AvailabilityKeys, AvailabilitySubKeys, SEPARATOR } from "./Filters/constants";
@@ -22,12 +23,40 @@ interface SerializeFiltersOptions {
   apiFilterOptions?: ApiOptionLists;
 }
 
+export const SORT_PARAM = "sort";
+export const DEFAULT_SORT_ORDER: string = SortOrder.NewToOld;
+
+export const APPOINTMENT_SORT_VALUES = ["appointment-proximal", "appointment-distant"] as const;
+export type AppointmentSort = (typeof APPOINTMENT_SORT_VALUES)[number];
+
+export function isAppointmentSort(sort: string): sort is AppointmentSort {
+  return (APPOINTMENT_SORT_VALUES as readonly string[]).includes(sort);
+}
+
+const VALID_SORT_VALUES: string[] = [SortOrder.NewToOld, SortOrder.OldToNew, ...APPOINTMENT_SORT_VALUES];
+
+export function parseSortParam(value: string | null): string {
+  return value && VALID_SORT_VALUES.includes(value) ? value : DEFAULT_SORT_ORDER;
+}
+
+export function serializeOpportunityFilters(
+  filter: OpportunityCardsFilter,
+  searchParams?: ReadonlyURLSearchParams,
+  asString?: true,
+  options?: SerializeFiltersOptions,
+): string;
+export function serializeOpportunityFilters(
+  filter: OpportunityCardsFilter,
+  searchParams: ReadonlyURLSearchParams | undefined,
+  asString: false,
+  options?: SerializeFiltersOptions,
+): URLSearchParams;
 export function serializeOpportunityFilters(
   filter: OpportunityCardsFilter,
   searchParams?: ReadonlyURLSearchParams,
   asString = true,
   options?: SerializeFiltersOptions,
-) {
+): string | URLSearchParams {
   const params = new URLSearchParams(searchParams);
   params.delete("page");
 


### PR DESCRIPTION
## What & why

Fixes #729. Sorting the Opportunities table (e.g. "Event: Nächste zuerst"),
opening an opportunity, and navigating back lost the chosen sort — it reset
to the default because `sortOrder` was plain component state, never written
to the URL. Filters were already synced to the URL (the #356 fix); this
extends the same mechanism to sort order.

## Changes

- Read the initial sort from the `sort` query param and validate it against
  an allow-list (`parseSortParam`), falling back to the default.
- Write/remove the `sort` param on sort change; reset pagination (`page`)
  the same way filter changes already do.
- Reset sort to default on "Clear all filters".
- Keep sort untouched on filter updates and single-filter clears (it rides
  along in the URL).
- Refactor-only: move the appointment-sort helpers
  (`APPOINTMENT_SORT_VALUES` / `isAppointmentSort`) into `helpers.ts` to
  remove duplication, and add `serializeOpportunityFilters` overloads so the
  `as URLSearchParams` casts can be dropped.

## Notes

- The appointment sorts are client-side only (backend has no such
  `SortOrder`), so they currently sort within the loaded page only — a
  pre-existing limitation, out of scope here. Candidate follow-up: add
  first-class appointment sorting in backend + SDK, then drop the FE
  client-sort and remap.
- `Volunteers.tsx` has the same "sort not persisted" pattern — separate
  follow-up, not addressed here.
