### PR TITLE
Dashboard/posts placeholder page

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -468,6 +468,11 @@
       },
       "createOpportunity": "Neue Möglichkeit erstellen"
     },
+    "posts": {
+      "inputPlaceholder": "Nachricht eingeben...",
+      "send": "Senden",
+      "empty": "Noch keine Beiträge. Sei der Erste, der eine Nachricht postet."
+    },
     "found": "gefunden",
     "searchPlaceHolder": "Freiwillige suchen",
     "sortBy": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -464,6 +464,11 @@
       },
       "createOpportunity": "Create New Opportunity"
     },
+    "posts": {
+      "inputPlaceholder": "Type a message...",
+      "send": "Send",
+      "empty": "No posts yet. Be the first to post a message."
+    },
     "found": "found",
     "searchPlaceHolder": "Search volunteers",
     "sortBy": {

--- a/src/app/[lang]/dashboard/posts/page.tsx
+++ b/src/app/[lang]/dashboard/posts/page.tsx
@@ -1,0 +1,5 @@
+import { Posts } from "@/components/Dashboard";
+
+export default function PostsPage() {
+  return <Posts />;
+}

--- a/src/components/Dashboard/Posts/Posts.tsx
+++ b/src/components/Dashboard/Posts/Posts.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/core/button";
+import { EditableField } from "@/components/EditableField/EditableField";
+import { DashboardLayout } from "@/components/Layout";
+
+import { EmptyState, NewPostSection, PostsContainer } from "./styles";
+import { Paragraph } from "../../styled/text";
+
+export function Posts() {
+  const { t } = useTranslation();
+
+  return (
+    <DashboardLayout>
+      <PostsContainer>
+        <EmptyState>
+          <Paragraph>{t("dashboard.posts.empty")}</Paragraph>
+        </EmptyState>
+        <NewPostSection>
+          <EditableField
+            placeholder={t("dashboard.posts.inputPlaceholder")}
+            mode="edit"
+            type="textarea"
+            value=""
+            setValue={() => {}}
+          />
+          <Button text={t("dashboard.posts.send")} onClick={() => {}} height="" disabled />
+        </NewPostSection>
+      </PostsContainer>
+    </DashboardLayout>
+  );
+}
+
+export default Posts;

--- a/src/components/Dashboard/Posts/index.ts
+++ b/src/components/Dashboard/Posts/index.ts
@@ -1,0 +1,1 @@
+export * from "./Posts";

--- a/src/components/Dashboard/Posts/styles.ts
+++ b/src/components/Dashboard/Posts/styles.ts
@@ -1,0 +1,30 @@
+import styled from "styled-components";
+
+export const NewPostSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+`;
+
+export const PostsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-16);
+`;
+
+export const EmptyState = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-8);
+  padding: var(--spacing-16);
+  height: 320px;
+`;
+
+export const InputRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  gap: var(--spacing-8);
+`;

--- a/src/components/Dashboard/index.ts
+++ b/src/components/Dashboard/index.ts
@@ -3,3 +3,4 @@ export * from "./Opportunities";
 export * from "./Volunteers";
 export * from "./Agents";
 export * from "./Calendar";
+export * from "./Posts";

--- a/src/components/EditableField/EditableField.tsx
+++ b/src/components/EditableField/EditableField.tsx
@@ -273,6 +273,7 @@ export interface EditableFieldRef<T> {
 interface EditableFieldProps<T = string | number | string[]> {
   mode: "display" | "edit";
   type: EditableFieldType;
+  placeholder?: string;
   label?: string;
   value: T;
   setValue: (value: T) => void;
@@ -295,6 +296,7 @@ export const EditableField = forwardRef(function EditableField<T extends string 
     validator,
     options = [],
     errorMessage,
+    placeholder,
     hint,
     maxLength,
   }: EditableFieldProps<T>,
@@ -385,6 +387,7 @@ export const EditableField = forwardRef(function EditableField<T extends string 
             <input
               type="text"
               value={localValue}
+              placeholder={placeholder}
               onChange={(e) => {
                 const v = e.target.value as T;
                 setLocalValue(v);
@@ -412,6 +415,7 @@ export const EditableField = forwardRef(function EditableField<T extends string 
           <InputWrapper $hasError={!!errorMessage}>
             <textarea
               value={localValue as string}
+              placeholder={placeholder}
               maxLength={maxLength}
               onChange={(e) => {
                 const v = e.target.value as T;


### PR DESCRIPTION
## Description
Adds a placeholder page for /dashboard/posts

## Related Issues
Closes #723

## Changes
- Add /dashboard/posts route and page component
- Add placeholder prop for EditableField

## Screenshots / Demos

<img width="1500" height="760" alt="image" src="https://github.com/user-attachments/assets/b5b4f4b6-2030-4e91-bfdc-b54be4b0c6d7" />


## Checklist
- [ ] Go to /dashboard/posts. Make sure it has basic empty state, textarea and send button
