### PR TITLE
fix: hide irrelevant fields for accompanying opportunities

### DIFF
--- a/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
+++ b/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
@@ -209,11 +209,13 @@ function OpportunityDetailsFields({
   apiLanguages,
   apiActivities,
   apiSkills,
+  isAccompanying,
 }: {
   isEvent: boolean;
   apiLanguages: ApiLanguageOption[];
   apiActivities: ApiLanguageOption[];
   apiSkills: ApiLanguageOption[];
+  isAccompanying: boolean;
 }) {
   const { t, i18n } = useTranslation();
   const lang = i18n.language;
@@ -231,6 +233,29 @@ function OpportunityDetailsFields({
     id: l.id,
     title: { [lang as Lang]: l.title } as Record<Lang, string>,
   }));
+
+  if (isAccompanying) {
+    return (
+      <FormDetails>
+        <Controller
+          name="description"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="textarea"
+              label={t(`${prefix}.description`)}
+              value={field.value}
+              setValue={field.onChange}
+              maxLength={MAX_DESCRIPTION_LENGTH}
+              hint={t(`${prefix}.descriptionHint`, { max: MAX_DESCRIPTION_LENGTH })}
+              errorMessage={errors.description?.message}
+            />
+          )}
+        />
+      </FormDetails>
+    );
+  }
 
   return (
     <FormDetails>
@@ -250,7 +275,6 @@ function OpportunityDetailsFields({
           />
         )}
       />
-
       <Controller
         name="mainCommunication"
         control={control}
@@ -579,6 +603,7 @@ export function NewOpportunity() {
               apiLanguages={apiLanguages}
               apiActivities={apiActivities}
               apiSkills={apiSkills}
+              isAccompanying={isAccompanying}
             />
           </FormProvider>
         }


### PR DESCRIPTION
## Description
Fixed form display for accompanying opportunities. These only need a description field since they're one-time appointment tasks, not regular volunteering with schedules/skills/activities.
`src/components/Dashboard/NewOppor`

Now displays
title
description
appointment section (accompany section)

Closes #758

## Changes
- Added `isAccompanying` prop to `OpportunityDetailsFields` component
- Added early return to show only the description field when `isAccompanying` is true


## Screenshots / Demos

https://github.com/user-attachments/assets/21796a21-ad95-4af3-9a5f-32ab9a08fd10



## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

