### PR TITLE
User menu logout

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -489,7 +489,8 @@
       "button": {
         "login": "Anmelden",
         "joinVolunteer": "Finde jetzt dein Ehrenamt",
-        "dashboard": "Dashboard"
+        "dashboard": "Dashboard",
+        "logout": "Abmelden"
       }
     },
     "login": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -483,7 +483,8 @@
       "button": {
         "login": "Log in",
         "joinVolunteer": "Join as a volunteer",
-        "dashboard": "Dashboard"
+        "dashboard": "Dashboard",
+        "logout": "Log out"
       }
     },
     "login": {

--- a/src/app/[lang]/globals.css
+++ b/src/app/[lang]/globals.css
@@ -537,7 +537,7 @@ html {
   --dashboard-cards-header-sortBy-circle-arrow-margin-left: 12px;
   --dashboard-cards-header-user-profile-container-gap: 8px;
   --dashboard-cards-header-user-icon-size: 32px;
-  --dashboard-cards-header-user-icon-border-radius: 16px;
+  --dashboard-cards-header-user-info-icon-size: 42px;
   --dashboard-cards-header-filter-item-container-gap: 8px;
   --dashboard-home-container-padding: 40px 16px 60px 16px;
   --dashboard-home-container-gap: 20px;
@@ -1449,7 +1449,6 @@ html {
     --dashboard-notification-font-size: 0.85rem;
     --dashboard-notification-background-color: var(--color-red-600);
     --dashboard-notification-text-color: var(--color-white);
-
 
     --dashboard-home-container-padding: 40px 120px 100px 132px;
 

--- a/src/components/Header/UserProfile.tsx
+++ b/src/components/Header/UserProfile.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { Paragraph } from "../styled/text";
 import { Menu, ItemText } from "@/components/core/menu";
+import { useLogout } from "@/hooks/useLogout";
 
 const FlexWrapper = styled.div`
   display: flex;
@@ -77,6 +78,7 @@ const getInitials = (fullName: string | undefined): string => {
 
 export function UserProfile() {
   const { t } = useTranslation();
+  const { mutate: logout } = useLogout();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const user = useCurrentUser();
   const initials = getInitials(user?.fullName) || user?.firstName?.[0]?.toUpperCase() || "";
@@ -127,7 +129,7 @@ export function UserProfile() {
             </UserTextColumn>
           </UserInfoBlock>
         )}
-        <Menu.Item onSelect={() => {}}>
+        <Menu.Item onSelect={logout}>
           <ItemText fw="bold">{t("dashboard.header.button.logout")}</ItemText>
         </Menu.Item>
       </Menu.Dropdown>

--- a/src/components/Header/UserProfile.tsx
+++ b/src/components/Header/UserProfile.tsx
@@ -1,25 +1,67 @@
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { CaretDownIcon, CaretUpIcon } from "@phosphor-icons/react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { Paragraph } from "../styled/text";
+import { Menu, ItemText } from "@/components/core/menu";
 
-const UserProfileContainer = styled.div`
+const FlexWrapper = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
   gap: var(--dashboard-cards-header-user-profile-container-gap);
-  cursor: pointer;
 `;
 
-const UserIconDiv = styled.div`
+const UserIconDiv = styled.div<{ $size?: "m" | "l" }>`
   display: flex;
-  height: var(--dashboard-cards-header-user-icon-size);
-  width: var(--dashboard-cards-header-user-icon-size);
+  height: ${({ $size }) =>
+    $size === "l"
+      ? "var(--dashboard-cards-header-user-info-icon-size)"
+      : "var(--dashboard-cards-header-user-icon-size)"};
+  width: ${({ $size }) =>
+    $size === "l"
+      ? "var(--dashboard-cards-header-user-info-icon-size)"
+      : "var(--dashboard-cards-header-user-icon-size)"};
   background-color: var(--color-midnight);
   justify-content: center;
   align-items: center;
-  border-radius: var(--dashboard-cards-header-user-icon-border-radius);
+  border-radius: 50%;
+`;
+
+const UserInfoBlock = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-8);
+  padding: var(--spacing-12) var(--spacing-12);
+  border-bottom: 1px solid var(--color-grey-200);
+`;
+
+const UserTextColumn = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+`;
+
+const UserInfoBlockTextContainer = styled.div`
+  height: 25px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  white-space: nowrap;
+`;
+
+const UserInfoNameText = styled.div`
+  font-size: 20px;
+  line-height: var(--line-height-24);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-midnight);
+`;
+
+const UserInfoEmailText = styled.div`
+  font-size: var(--font-size-14);
+  color: var(--color-grey-500);
+  line-height: var(--line-height-20);
 `;
 
 const getInitials = (fullName: string | undefined): string => {
@@ -34,23 +76,62 @@ const getInitials = (fullName: string | undefined): string => {
 };
 
 export function UserProfile() {
-  const [isCaretDown, setIsCaretDown] = useState(true);
+  const { t } = useTranslation();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const user = useCurrentUser();
-  const userName = getInitials(user?.fullName) || user?.firstName?.[0]?.toUpperCase() || "";
+  const initials = getInitials(user?.fullName) || user?.firstName?.[0]?.toUpperCase() || "";
 
   return (
-    <UserProfileContainer onClick={() => setIsCaretDown(!isCaretDown)}>
-      <UserIconDiv>
-        <Paragraph color="var(--color-white)" fontWeight={400} fontSize="14px" lineheight="18px" letterSpacing="0.2px">
-          {userName}
-        </Paragraph>
-      </UserIconDiv>
-      {isCaretDown ? (
-        <CaretDownIcon size={20} color={"var(--color-midnight)"} />
-      ) : (
-        <CaretUpIcon size={20} color={"var(--color-midnight)"} />
-      )}
-    </UserProfileContainer>
+    <Menu open={isMenuOpen} onOpen={() => setIsMenuOpen(true)} onClose={() => setIsMenuOpen(false)}>
+      <Menu.Target>
+        <FlexWrapper>
+          <UserIconDiv>
+            <Paragraph
+              color="var(--color-white)"
+              fontWeight={400}
+              fontSize="14px"
+              lineheight="18px"
+              letterSpacing="0.2px"
+            >
+              {initials}
+            </Paragraph>
+          </UserIconDiv>
+          {isMenuOpen ? (
+            <CaretUpIcon size={20} color={"var(--color-midnight)"} />
+          ) : (
+            <CaretDownIcon size={20} color={"var(--color-midnight)"} />
+          )}
+        </FlexWrapper>
+      </Menu.Target>
+      <Menu.Dropdown align="right">
+        {user && (
+          <UserInfoBlock>
+            <UserIconDiv $size="l">
+              <Paragraph
+                color="var(--color-white)"
+                fontWeight={400}
+                fontSize="14px"
+                lineheight="18px"
+                letterSpacing="0.2px"
+              >
+                {initials}
+              </Paragraph>
+            </UserIconDiv>
+            <UserTextColumn>
+              <UserInfoBlockTextContainer>
+                <UserInfoNameText>{user.fullName}</UserInfoNameText>
+              </UserInfoBlockTextContainer>
+              <UserInfoBlockTextContainer>
+                <UserInfoEmailText>{user.email}</UserInfoEmailText>
+              </UserInfoBlockTextContainer>
+            </UserTextColumn>
+          </UserInfoBlock>
+        )}
+        <Menu.Item onSelect={() => {}}>
+          <ItemText fw="bold">{t("dashboard.header.button.logout")}</ItemText>
+        </Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
   );
 }
 

--- a/src/components/core/menu/Menu.tsx
+++ b/src/components/core/menu/Menu.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useClickOutside } from "@/hooks";
+import React, { createContext, useContext, useRef, useState, useCallback, type ReactNode } from "react";
+import styled from "styled-components";
+
+interface MenuContextType {
+  isOpen: boolean;
+  selectItem: (onSelect: () => void) => void;
+  close: () => void;
+  toggle: () => void;
+}
+
+const MenuContext = createContext<MenuContextType | undefined>(undefined);
+
+const useMenuContext = () => {
+  const ctx = useContext(MenuContext);
+  if (!ctx) {
+    throw new Error("Menu compound components must be used within <Menu>");
+  }
+  return ctx;
+};
+
+const Container = styled.div`
+  position: relative;
+  display: inline-flex;
+`;
+
+const TargetButton = styled.button`
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  color: inherit;
+`;
+
+const DropdownDiv = styled.div<{ $align: "left" | "right" }>`
+  position: absolute;
+  top: 100%;
+  ${({ $align }) => ($align === "right" ? "right: 0;" : "left: 0;")}
+  z-index: 10;
+  margin: var(--spacing-4) 0 0;
+  padding: var(--spacing-8) 0;
+  background: var(--color-white);
+  border-radius: var(--border-radius-xs);
+  box-shadow: var(--dropdown-box-shadow);
+  min-width: 140px;
+`;
+
+const ItemButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-8);
+  padding: var(--spacing-12);
+  cursor: pointer;
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+  white-space: nowrap;
+
+  &:hover {
+    background-color: var(--color-grey-50);
+  }
+`;
+
+const sizeMap = {
+  s: { fontSize: "var(--font-size-14)", lineHeight: "var(--line-height-20)" },
+  m: { fontSize: "var(--font-size-16)", lineHeight: "var(--line-height-24)" },
+  l: { fontSize: "var(--font-size-24)", lineHeight: "var(--line-height-32)" },
+  xl: { fontSize: "var(--font-size-32)", lineHeight: "var(--line-height-40)" },
+} as const;
+
+const fwMap = {
+  regular: "var(--font-weight-regular)",
+  semibold: "var(--font-weight-semibold)",
+  bold: "var(--font-weight-bold)",
+} as const;
+
+const ItemTextStyled = styled.span<{ $size: keyof typeof sizeMap; $fw: keyof typeof fwMap }>`
+  font-size: ${({ $size }) => sizeMap[$size].fontSize};
+  line-height: ${({ $size }) => sizeMap[$size].lineHeight};
+  letter-spacing: var(--letter-spacing-tight);
+  font-weight: ${({ $fw }) => fwMap[$fw]};
+  color: var(--color-blue-700);
+`;
+
+function ItemText({
+  children,
+  size = "m",
+  fw = "regular",
+}: {
+  children: ReactNode;
+  size?: keyof typeof sizeMap;
+  fw?: keyof typeof fwMap;
+}) {
+  return (
+    <ItemTextStyled $size={size} $fw={fw}>
+      {children}
+    </ItemTextStyled>
+  );
+}
+
+interface MenuProps {
+  children: ReactNode;
+  closeOnSelect?: boolean;
+  open?: boolean;
+  onOpen?: () => void;
+  onClose?: () => void;
+}
+
+function Menu({ children, closeOnSelect = true, open, onOpen, onClose }: MenuProps) {
+  const isControlled = open !== undefined;
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isOpen = isControlled ? open : internalOpen;
+
+  const ref = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => {
+    if (isControlled) {
+      onClose?.();
+    } else {
+      setInternalOpen(false);
+      onClose?.();
+    }
+  }, [isControlled, onClose]);
+
+  const toggle = useCallback(() => {
+    const next = !isOpen;
+    if (isControlled) {
+      if (next) onOpen?.();
+      else onClose?.();
+    } else {
+      setInternalOpen(next);
+      if (next) onOpen?.();
+      else onClose?.();
+    }
+  }, [isControlled, isOpen, onOpen, onClose]);
+
+  const selectItem = useCallback(
+    (onSelect: () => void) => {
+      onSelect();
+      if (closeOnSelect) {
+        if (isControlled) {
+          onClose?.();
+        } else {
+          setInternalOpen(false);
+          onClose?.();
+        }
+      }
+    },
+    [closeOnSelect, isControlled, onClose],
+  );
+
+  useClickOutside(ref, close);
+
+  return (
+    <MenuContext.Provider value={{ isOpen, selectItem, close, toggle }}>
+      <Container ref={ref}>{children}</Container>
+    </MenuContext.Provider>
+  );
+}
+
+function Target({ children }: { children: ReactNode }) {
+  const { toggle } = useMenuContext();
+
+  return (
+    <TargetButton
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        toggle();
+      }}
+    >
+      {children}
+    </TargetButton>
+  );
+}
+
+interface DropdownProps {
+  children: ReactNode;
+  align?: "left" | "right";
+}
+
+function Dropdown({ children, align = "left" }: DropdownProps) {
+  const { isOpen } = useMenuContext();
+
+  if (!isOpen) return null;
+
+  return (
+    <DropdownDiv $align={align} role="menu">
+      {children}
+    </DropdownDiv>
+  );
+}
+
+interface ItemProps {
+  children: ReactNode;
+  onSelect: () => void;
+}
+
+function Item({ children, onSelect }: ItemProps) {
+  const { selectItem } = useMenuContext();
+
+  return (
+    <ItemButton
+      role="menuitem"
+      onClick={(e) => {
+        e.stopPropagation();
+        selectItem(onSelect);
+      }}
+    >
+      {children}
+    </ItemButton>
+  );
+}
+
+Menu.Target = Target;
+Menu.Dropdown = Dropdown;
+Menu.Item = Item;
+
+export { Menu, ItemText };

--- a/src/components/core/menu/index.ts
+++ b/src/components/core/menu/index.ts
@@ -1,0 +1,1 @@
+export { Menu, ItemText } from "./Menu";

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -10,6 +10,7 @@ export const apiPathCommunication = `/${apiPrefix}/communication`;
 export const apiPathAppreciation = `/${apiPrefix}/appreciation`;
 export const apiPathLogin = `/${apiPrefix}/auth/login`;
 export const apiPathAuthRefresh = `/${apiPrefix}/auth/refresh`;
+export const apiPathAuthLogout = `/${apiPrefix}/auth/logout`;
 export const apiPathAuthEmailDomain = `/${apiPrefix}/auth-email-domain/`;
 export const apiPathOpportunity = `/${apiPrefix}/opportunity`;
 export const apiPathAgent = `/${apiPrefix}/agent`;

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,0 +1,14 @@
+import { apiPathAuthLogout } from "@/config/constants";
+import { useMutationQuery } from "@/hooks";
+import { clearAuthHint } from "@/utils/helpers";
+
+export const useLogout = () => {
+  return useMutationQuery<void, unknown>({
+    apiPath: apiPathAuthLogout,
+    method: "post",
+    onSuccessCallback: () => {
+      clearAuthHint();
+      window.location.href = "/login";
+    },
+  });
+};


### PR DESCRIPTION
## Description
Added user menu on user avatar click and logout action

## Related Issues
Closes #661

## Changes
- Added general purpose component for menu. Loosely based on TrustLevelDropdown. After review if everyone okay with it I will replace TrustLevelDropdown implementation with that shared one
_But in general I would advise to discuss installing some ui lib, as there is none currently. Implementing this stuff by hand is waste of time, and it wont be as thought out and accessible as lib implementation_
- Implemented user profile dropdown based on figma design.
_Note that I didnt use background color for user dropdown from figma, as i didnt find any instances of this color in the project. Tell me if you want to use the color form figma layout(Below I attached screenshot of the figma layout for this block for your reference)
And box-shadow is slightly different color, again, i've used the one from code, rather than one from layout. Tell me if you want it changed_
<img width="414" height="441" alt="image" src="https://github.com/user-attachments/assets/bdf06d27-d1b3-4cc5-b58a-5db662f5464f" />

- Added useLogout hook, the same way current mutation requests are implemented, wired it to the logout button

## Screenshots / Demos

<img width="253" height="206" alt="image" src="https://github.com/user-attachments/assets/1f51018b-9004-4244-b66b-276293f7b484" />


## Checklist
- [ ] Check user menu is opening. Contains name of logged in user and their email
- [ ] Logout button is working. Logout request is sent when button is clicked. Access/refresh tokens removed from cookies. User redirected to /login page

