### PR TITLE
default opportunities view to first tab when no ?view= param

### DIFF
--- a/src/components/Dashboard/Opportunities/Opportunities.tsx
+++ b/src/components/Dashboard/Opportunities/Opportunities.tsx
@@ -43,8 +43,9 @@ export function Opportunities() {
 
   const urlViewParam = searchParams.get("view");
   const VIEW_MODE_BY_TAB = isAgent ? [ViewMode.CARDS, ViewMode.MAP] : [ViewMode.LIST, ViewMode.CARDS, ViewMode.MAP];
-  const selectedTabIndex = VIEW_MODE_BY_TAB.findIndex((mode) => mode === urlViewParam);
-  const viewMode = VIEW_MODE_BY_TAB[selectedTabIndex] ?? ViewMode.CARDS;
+  const foundIndex = VIEW_MODE_BY_TAB.findIndex((mode) => mode === urlViewParam);
+  const selectedTabIndex = foundIndex === -1 ? 0 : foundIndex;
+  const viewMode = VIEW_MODE_BY_TAB[selectedTabIndex];
 
   const volunteerId = searchParams.get("volunteer") ?? undefined;
   const volunteerFilter = useGetVolunteer(volunteerId);


### PR DESCRIPTION
 ## Description
 Admins landed on the Opportunities page seeing **card view with no tab highlighted**. They should default to **list**  and see the tabs: List, Cards, Map. 

## Related Issues
Closes #764 

## Changes
- Default the tab index to `0` when there's no `?view=`

## Screenshots / Demos
<img width="1540" height="1116" alt="Screenshot 2026-07-05 at 10 42 56 AM" src="https://github.com/user-attachments/assets/ec51ce43-8ce7-4e8e-b031-57fc22903511" />


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

