### PR TITLE
🐛 fix: restore opportunity title editing in opportunity details

### DIFF
--- a/src/components/Dashboard/Profile/sections/OpportunityDetails/OpportunityDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/OpportunityDetails/OpportunityDetailsEdit.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/Dashboard/Profile/sections/VolunteerProfile/hooks";
 import { createMapping } from "@/components/Dashboard/Profile/sections/VolunteerProfile/mappingUtils";
 import { useUpdateOpportunityDetails } from "@/hooks/useUpdateOpportunityDetails";
+import { useUpdateOpportunityTitle } from "@/hooks/useUpdateOpportunityTitle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { MAX_DESCRIPTION_LENGTH } from "@/config/constants";
 import { de, enUS } from "date-fns/locale";
@@ -77,6 +78,7 @@ export function OpportunityDetailsEdit({ opportunity, onCancel }: Props) {
   const isEventType = opp.volunteerType === VolunteerStateTypeType.EVENTS;
 
   const { mutate: updateOpportunityDetails } = useUpdateOpportunityDetails(opp.id);
+  const { mutate: updateTitle } = useUpdateOpportunityTitle(opp.id);
   const { data: apiLanguages = [] } = useApiLanguages();
   const { data: apiActivities = [] } = useApiActivities();
   const { data: apiSkills = [] } = useApiSkills();
@@ -107,6 +109,7 @@ export function OpportunityDetailsEdit({ opportunity, onCancel }: Props) {
     resolver: zodResolver(schema),
     mode: "onChange",
     defaultValues: {
+      title: opp.title ?? "",
       description: opp.description ?? "",
       numberOfVolunteers: String(opp.numberOfVolunteers ?? ""),
       mainCommunication: languagesToFormValues(generalLangs, t),
@@ -125,6 +128,9 @@ export function OpportunityDetailsEdit({ opportunity, onCancel }: Props) {
   };
 
   const onSubmit = (values: OpportunityDetailsFormData) => {
+    if (values.title !== opp.title) {
+      updateTitle({ title: values.title });
+    }
     updateOpportunityDetails(
       {
         description: values.description,
@@ -142,6 +148,21 @@ export function OpportunityDetailsEdit({ opportunity, onCancel }: Props) {
   return (
     <>
       <FormDetails>
+        <Controller
+          name="title"
+          control={control}
+          render={({ field }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t(`${prefix}.opportunityName`)}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.title?.message}
+            />
+          )}
+        />
+
         <Controller
           name="description"
           control={control}

--- a/src/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema.ts
@@ -13,6 +13,7 @@ const languageObjectSchema = z.object({
 
 export const createOpportunityDetailsSchema = (t: (key: string) => string) =>
   z.object({
+    title: z.string().min(1, t(`${i18nPrefix}.opportunityNameRequired`)),
     description: z.string().max(MAX_DESCRIPTION_LENGTH, t(`${i18nPrefix}.descriptionTooLong`)),
     numberOfVolunteers: z.string(),
     mainCommunication: z.array(languageObjectSchema),


### PR DESCRIPTION
## Summary

- Restores the editable **Name** field in the Opportunity Details edit form, which was accidentally dropped in e82d815d when `useUpdateOpportunityTitle` was replaced by `useUpdateOpportunityDetails`
- Re-adds `title` to `opportunityDetailsSchema` with required validation (using the existing `opportunityNameRequired` i18n key)
- Re-wires `useUpdateOpportunityTitle` alongside `useUpdateOpportunityDetails` — title is not part of `ApiOpportunityPatch` so it needs its own PATCH call

## Root cause

PR #360 added the title field. Commit e82d815d (same day, different author) reworked the save logic using a new `useUpdateOpportunityDetails` hook and silently dropped the title `<Controller>`, its form default, schema field, and the `useUpdateOpportunityTitle` usage. The display-mode field (in `OpportunityDetailsDisplay`) was left intact, so the title showed as read-only but could no longer be edited.

## Test plan

- [ ] Open an opportunity profile as a coordinator
- [ ] Click Edit on the Opportunity Details section
- [ ] Verify the **Name** field appears as the first field, pre-filled with the current title
- [ ] Clear the field → verify required validation error appears
- [ ] Change the title and save → verify title updates in display mode and in the opportunity header

🤖 Generated with [Claude Code](https://claude.com/claude-code)