### PR TITLE
🐛 fix: auth hint TTL, useAuth cleanup bug, logout cache clear

### DIFF
--- a/src/components/Dashboard/Profile/sections/ProfileHeader/volunteer/VolunteerHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/volunteer/VolunteerHeader.tsx
@@ -51,7 +51,7 @@ type Props = {
 export const VolunteerHeader = ({ volunteer }: Props) => {
   const { t } = useTranslation();
   const dialog = useEngagementStatusDialog(volunteer);
-  const { isAuthorized, isOwnProfile } = useAuth();
+  const { isAuthorized, isOwnProfile } = useAuth(volunteer.person.id);
   const hasEditingRights = isAuthorized || isOwnProfile;
 
   const { data: opportunitiesData } = useGetQuery<ApiOpportunityVolunteerGet[]>({

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -80,9 +80,10 @@ export const MAX_DESCRIPTION_LENGTH = 500;
 
 export const PHONE_NUMBER_REGEX = /^[+\d\s\-()/]+$/;
 
+export const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 7; // 7 days in seconds, matches BE refresh token TTL
 export const AUTH_HINT_COOKIE_NAME = "is_logged_in";
-export const AUTH_HINT_COOKIE_ATTRS = "path=/; SameSite=Lax; Secure";
-export const AUTH_HINT_MAX_AGE = 6000;
+export const AUTH_HINT_COOKIE_ATTRS = `path=/; SameSite=Lax${process.env.NODE_ENV === "production" ? "; Secure" : ""}`;
+export const AUTH_HINT_MAX_AGE = REFRESH_TOKEN_MAX_AGE;
 
 export const TABLE_LIMIT = 20;
 export const CARD_COLUMNS = 3;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -80,10 +80,12 @@ export const MAX_DESCRIPTION_LENGTH = 500;
 
 export const PHONE_NUMBER_REGEX = /^[+\d\s\-()/]+$/;
 
-export const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 7; // 7 days in seconds, matches BE refresh token TTL
+export const REFRESH_TOKEN_MAX_AGE_S = 60 * 60 * 24 * 7; // seconds — matches BE refresh token TTL (cookie max-age expects seconds)
 export const AUTH_HINT_COOKIE_NAME = "is_logged_in";
 export const AUTH_HINT_COOKIE_ATTRS = `path=/; SameSite=Lax${process.env.NODE_ENV === "production" ? "; Secure" : ""}`;
-export const AUTH_HINT_MAX_AGE = REFRESH_TOKEN_MAX_AGE;
+export const AUTH_HINT_MAX_AGE = REFRESH_TOKEN_MAX_AGE_S;
+
+export const USER_QUERY_KEY = ["user"];
 
 export const TABLE_LIMIT = 20;
 export const CARD_COLUMNS = 3;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -3,7 +3,7 @@ import { useCurrentUser } from "./useCurrentUser";
 
 export const useAuth = (contactPersonId?: Id) => {
   const user = useCurrentUser();
-  const personId = (user as typeof user & { personId?: number })?.personId;
+  const personId = user?.personId;
 
   const isAuthorized = user?.role === UserRole.ADMIN || user?.role === UserRole.COORDINATOR;
   const isOwnProfile =

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,26 +1,13 @@
 import { Id, UserRole } from "need4deed-sdk";
 import { useCurrentUser } from "./useCurrentUser";
-import { useEffect, useState } from "react";
 
 export const useAuth = (contactPersonId?: Id) => {
-  const [isAuthorized, setIsAuthorized] = useState<boolean>(false);
-  const [isOwnProfile, setIsOwnProfile] = useState<boolean>(false);
-
   const user = useCurrentUser();
+  const personId = (user as typeof user & { personId?: number })?.personId;
 
-  useEffect(() => {
-    const userIsAuthorized = user?.role === UserRole.ADMIN || user?.role === UserRole.COORDINATOR;
-    const personId = (user as typeof user & { personId?: number })?.personId;
-    if (userIsAuthorized) setIsAuthorized(true);
-    if (user?.role === UserRole.VOLUNTEER && personId === contactPersonId) {
-      setIsOwnProfile(true);
-    } else if (user?.role === UserRole.AGENT && personId === contactPersonId) {
-      setIsOwnProfile(true);
-    } else {
-      setIsOwnProfile(false);
-    }
-    return () => setIsAuthorized(false);
-  }, [user, contactPersonId]);
+  const isAuthorized = user?.role === UserRole.ADMIN || user?.role === UserRole.COORDINATOR;
+  const isOwnProfile =
+    (user?.role === UserRole.VOLUNTEER || user?.role === UserRole.AGENT) && personId === contactPersonId;
 
   return { isAuthorized, isOwnProfile };
 };

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -1,13 +1,13 @@
-import { apiPathMe, cacheTTL } from "@/config/constants";
+import { apiPathMe, AUTH_HINT_COOKIE_NAME, cacheTTL, USER_QUERY_KEY } from "@/config/constants";
 import { useGetQuery } from "@/hooks";
 import { getCookie } from "@/utils/helpers";
 import { ApiUserGet } from "need4deed-sdk";
 
 export const useCurrentUser = (enabled?: boolean) => {
-  const hasAuthHint = getCookie("is_logged_in") === "true";
+  const hasAuthHint = getCookie(AUTH_HINT_COOKIE_NAME) === "true";
 
   const { data } = useGetQuery<ApiUserGet>({
-    queryKey: ["user"],
+    queryKey: USER_QUERY_KEY,
     apiPath: apiPathMe,
     staleTime: cacheTTL,
     enabled: hasAuthHint && enabled,

--- a/src/hooks/useGetCurrentAgent.ts
+++ b/src/hooks/useGetCurrentAgent.ts
@@ -1,13 +1,13 @@
-import { apiPathAgent, apiPathMe, cacheTTL } from "@/config/constants";
+import { apiPathAgent, apiPathMe, AUTH_HINT_COOKIE_NAME, cacheTTL, USER_QUERY_KEY } from "@/config/constants";
 import { useGetQuery } from "@/hooks";
 import { getCookie } from "@/utils/helpers";
 import { ApiAgentGet, ApiUserGet } from "need4deed-sdk";
 
 export const useGetCurrentAgent = () => {
-  const isLoggedIn = getCookie("is_logged_in") === "true";
+  const isLoggedIn = getCookie(AUTH_HINT_COOKIE_NAME) === "true";
 
   const { data: user, isLoading: userLoading } = useGetQuery<ApiUserGet & { agentId?: number }>({
-    queryKey: ["user"],
+    queryKey: USER_QUERY_KEY,
     apiPath: apiPathMe,
     staleTime: cacheTTL,
     enabled: isLoggedIn,

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,4 +1,4 @@
-import { apiPathAuthLogout } from "@/config/constants";
+import { apiPathAuthLogout, USER_QUERY_KEY } from "@/config/constants";
 import { useMutationQuery } from "@/hooks";
 import { clearAuthHint } from "@/utils/helpers";
 import { useQueryClient } from "@tanstack/react-query";
@@ -10,7 +10,7 @@ export const useLogout = () => {
     apiPath: apiPathAuthLogout,
     method: "post",
     onSuccessCallback: () => {
-      queryClient.removeQueries({ queryKey: ["user"] });
+      queryClient.removeQueries({ queryKey: USER_QUERY_KEY, exact: true });
       clearAuthHint();
       window.location.href = "/login";
     },

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,12 +1,16 @@
 import { apiPathAuthLogout } from "@/config/constants";
 import { useMutationQuery } from "@/hooks";
 import { clearAuthHint } from "@/utils/helpers";
+import { useQueryClient } from "@tanstack/react-query";
 
 export const useLogout = () => {
+  const queryClient = useQueryClient();
+
   return useMutationQuery<void, unknown>({
     apiPath: apiPathAuthLogout,
     method: "post",
     onSuccessCallback: () => {
+      queryClient.removeQueries({ queryKey: ["user"] });
       clearAuthHint();
       window.location.href = "/login";
     },


### PR DESCRIPTION
## Summary

- **`AUTH_HINT_MAX_AGE`** now equals `REFRESH_TOKEN_MAX_AGE` (7 days) via a new named constant, so the `is_logged_in` cookie stays valid as long as the refresh token
- **`useAuth`** refactored from `useState`/`useEffect` to direct derivation — the old `return () => setIsAuthorized(false)` cleanup was firing before every re-render, causing edit buttons to briefly disappear on each render cycle
- **`useLogout`** now calls `queryClient.removeQueries({ queryKey: ['user'] })` before clearing the auth hint and redirecting, so stale user data from the current session is not visible to the next one

## Test plan

- [ ] Log in, verify edit buttons are visible and stable on opportunity/volunteer profiles (no flicker)
- [ ] Log out, log back in as a different user — confirm old user data does not appear
- [ ] On localhost (HTTP), confirm `is_logged_in` cookie persists across page reloads after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)