### PR TITLE
fix: create opportunity button silently no-ops

### DIFF
--- a/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
+++ b/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
@@ -10,8 +10,8 @@ import {
 } from "@/components/Dashboard/Profile/sections/VolunteerProfile/hooks";
 import { createMapping } from "@/components/Dashboard/Profile/sections/VolunteerProfile/mappingUtils";
 import {
-  createOpportunityDetailsSchema,
-  OpportunityDetailsFormData,
+  createNewOpportunityDetailsSchema,
+  NewOpportunityDetailsFormData,
 } from "@/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema";
 import { AccompanyingDetailsEdit } from "@/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsEdit";
 import { FormDetails } from "@/components/Dashboard/Profile/sections/shared/styles";
@@ -131,7 +131,7 @@ function toOptionItems(ids: string[], apiItems: ApiLanguageOption[]): OptionItem
   });
 }
 
-function availabilityToTimeslots(availability: OpportunityDetailsFormData["availability"]): [number, string][] {
+function availabilityToTimeslots(availability: NewOpportunityDetailsFormData["availability"]): [number, string][] {
   return (availability ?? []).flatMap(({ weekday, timeSlots }) =>
     timeSlots
       .filter((ts) => ts.selected)
@@ -144,7 +144,7 @@ function availabilityToTimeslots(availability: OpportunityDetailsFormData["avail
 
 function buildCreatePayload(
   headerData: HeaderFormData,
-  detailsData: OpportunityDetailsFormData,
+  detailsData: NewOpportunityDetailsFormData,
   accompData: AccompanyingDetailsFormData | null,
   apiLanguages: ApiLanguageOption[],
   apiActivities: ApiLanguageOption[],
@@ -225,7 +225,7 @@ function OpportunityDetailsFields({
   const {
     control,
     formState: { errors },
-  } = useFormContext<OpportunityDetailsFormData>();
+  } = useFormContext<NewOpportunityDetailsFormData>();
 
   const activityMapping = createMapping(apiActivities);
   const skillMapping = createMapping(apiSkills);
@@ -461,8 +461,8 @@ export function NewOpportunity() {
   const isEvent = selectedType === VolunteerStateTypeType.EVENTS;
 
   // Opportunity details form
-  const detailsMethods = useForm<OpportunityDetailsFormData>({
-    resolver: zodResolver(createOpportunityDetailsSchema(t)),
+  const detailsMethods = useForm<NewOpportunityDetailsFormData>({
+    resolver: zodResolver(createNewOpportunityDetailsSchema(t)),
     mode: "onChange",
     defaultValues: {
       description: "",

--- a/src/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema.ts
@@ -26,3 +26,8 @@ export const createOpportunityDetailsSchema = (t: (key: string) => string) =>
   });
 
 export type OpportunityDetailsFormData = z.infer<ReturnType<typeof createOpportunityDetailsSchema>>;
+
+export const createNewOpportunityDetailsSchema = (t: (key: string) => string) =>
+  createOpportunityDetailsSchema(t).omit({ title: true });
+
+export type NewOpportunityDetailsFormData = z.infer<ReturnType<typeof createNewOpportunityDetailsSchema>>;


### PR DESCRIPTION
## Summary

- `detailsMethods` used `createOpportunityDetailsSchema` which requires a `title` field
- But `title` lives in the separate `headerMethods` form — so `detailsMethods.trigger()` always returned `false`
- `handleCreate` hit the early `return` guard every time and never called `createOpportunity`
- No visible feedback to the user (button not disabled, no error message) because `title` error lands on a key that no rendered field displays

Fix: export `createNewOpportunityDetailsSchema` (omits `title` via Zod `.omit()`) and use it in `NewOpportunity`. The existing `createOpportunityDetailsSchema` + `OpportunityDetailsFormData` are unchanged — `OpportunityDetailsEdit` (where `title` IS part of that section) continues to work correctly.

## Test plan

- [ ] Open `/dashboard/opportunities/new`, fill in the form as an agent, click "Create opportunity" — request should fire and redirect on success
- [ ] Verify event-type, regular-type, and accompanying-type submissions all proceed past the button
- [ ] Verify editing an existing opportunity (OpportunityDetailsEdit) still validates `title`

🤖 Generated with [Claude Code](https://claude.com/claude-code)