### PR TITLE
🐛 fix: read role from URL param on verify-email for cross-browser redirect

### DIFF
--- a/src/app/[lang]/verify-email/[token]/page.tsx
+++ b/src/app/[lang]/verify-email/[token]/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { getCookie } from "@/utils/helpers";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
 export default function Page() {
   const [verified, setVerified] = useState(false);
   const [verifying, setVerifying] = useState(true);
   const { token, lang } = useParams<{ token: string; lang: string }>();
+  const searchParams = useSearchParams();
   const router = useRouter();
 
   useEffect(() => {
@@ -23,8 +24,11 @@ export default function Page() {
       .then((res) => {
         if (res.ok) {
           setVerified(true);
+          // role param in the URL is the primary signal; cookie is a fallback
+          // for links opened before this change was deployed.
+          const roleFromUrl = searchParams.get("role");
           const pendingRole = getCookie("n4d_pending_role");
-          if (pendingRole === "agent") {
+          if (roleFromUrl === "agent" || pendingRole === "agent") {
             document.cookie = "n4d_pending_role=; path=/; max-age=0";
             // Forward the verify token — the agent form uses it as the
             // querystring auth for POST /agent/register.
@@ -39,7 +43,7 @@ export default function Page() {
       .catch(() => {
         setVerifying(false);
       });
-  }, [token, lang, router]);
+  }, [token, lang, router, searchParams]);
 
   return (
     <div>


### PR DESCRIPTION
## Summary

- The verify-email page checked `n4d_pending_role` cookie to decide where to redirect after verification — this broke when the link was opened in a different browser
- Fix: read `?role=` from the URL (set by the backend) as the primary signal; cookie remains as a fallback for links sent before this deploy

## Test plan

- [ ] Register as agent → receive email → open link in a **different browser** → lands on `/register/agent/complete` form, not login
- [ ] Old-style links (no `?role=` param, cookie present) still redirect correctly via the cookie fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)