### PR TITLE
792: Adds auth check to trustLevel responsiveness on NGO profile

### DIFF
--- a/src/components/Dashboard/Profile/sections/ProfileHeader/agent/AgentHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/agent/AgentHeader.tsx
@@ -69,19 +69,19 @@ export const AgentHeader = ({ agent }: Props) => {
         label={volunteerSearchLabels[agent.volunteerSearch]}
       />
 
-      <StatusRowField
-        title={t("dashboard.agentProfile.trustLevel")}
-        extra={
-          isAuthorized && (
+      {isAuthorized && (
+        <StatusRowField
+          title={t("dashboard.agentProfile.trustLevel")}
+          extra={
             <TrustLevelDropdown
               value={agent.trustLevel}
               options={TRUST_LEVEL_OPTIONS}
               labels={trustLevelLabels}
               onChange={handleTrustLevelChange}
             />
-          )
-        }
-      />
+          }
+        />
+      )}
 
       <StatusRowField title={t("dashboard.agentProfile.district")} showIcon={false} extra={districtLabel} />
     </HeaderCard>


### PR DESCRIPTION
## Description
Adds auth check for `trust-level` resposiveness to `Agent profile` on `AgentHeader.tsx`

## Related Issues
Closes #792 

## Changes
- Bullet list of meaningful changes (optional)

## Screenshots / Demos
### NGO-view
<img width="1497" height="656" alt="image" src="https://github.com/user-attachments/assets/4cfbb6d1-0127-4d2b-95ae-3a7173d8ef29" />

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

