### PR TITLE
fix: preserve volunteer param in opportunity table view (#739)

### DIFF
--- a/src/components/Dashboard/Opportunities/OpportunityListController.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityListController.tsx
@@ -96,6 +96,7 @@ export function OpportunityListController({
         currentPage={currentPage}
         setCurrentPage={setCurrentPage}
         districtsList={apiFilterOptions?.district ?? undefined}
+        volunteerId={volunteerId}
       />
     );
   }

--- a/src/components/Dashboard/Opportunities/OpportunityTableList.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityTableList.tsx
@@ -16,6 +16,7 @@ interface TableListProps {
   currentPage: number;
   setCurrentPage: (page: number) => void;
   districtsList?: OptionItem[];
+  volunteerId?: string;
 }
 
 export function OpportunityTableList({
@@ -25,6 +26,7 @@ export function OpportunityTableList({
   currentPage,
   setCurrentPage,
   districtsList,
+  volunteerId,
 }: TableListProps) {
   const { t } = useTranslation();
   const { isAuthorized } = useAuth();
@@ -42,6 +44,7 @@ export function OpportunityTableList({
             opportunity={opportunity}
             isLast={isLast}
             districtsList={districtsList}
+            volunteerId={volunteerId}
           />
         ) : (
           <OpportunityReadOnlyTableRow

--- a/src/components/Dashboard/Opportunities/OpportunityTableRow.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityTableRow.tsx
@@ -26,9 +26,10 @@ interface TableRowProps {
   opportunity: ApiVolunteerOpportunityGetList;
   isLast: boolean;
   districtsList?: OptionItem[];
+  volunteerId?: string;
 }
 
-export function OpportunityTableRow({ opportunity, isLast, districtsList }: TableRowProps) {
+export function OpportunityTableRow({ opportunity, isLast, districtsList, volunteerId }: TableRowProps) {
   const { t, i18n } = useTranslation();
 
   const ext = opportunity as ExtendedOpportunity;
@@ -52,7 +53,8 @@ export function OpportunityTableRow({ opportunity, isLast, districtsList }: Tabl
   const otherVolunteersCount = numberOfVolunteers && numberOfVolunteers > 1 ? numberOfVolunteers - 1 : 0;
   const matchedNames = firstName && otherVolunteersCount ? `${firstName} +${otherVolunteersCount}` : firstName;
 
-  const profileUrl = id ? `/${i18n.language}/dashboard/opportunities/${id}` : "";
+  const params = volunteerId ? `?volunteer=${volunteerId}` : "";
+  const profileUrl = id ? `/${i18n.language}/dashboard/opportunities/${id}${params}` : "";
 
   return (
     <ClickableRow as={Link} href={profileUrl} $isLast={isLast} data-testid={`opportunity-row-${id}`}>


### PR DESCRIPTION


## Description
fix bug where the `?volunteer` query param was dropped when clicking an opportunity from the list/table view, such that 'Suggest' button never appears.
fix is done via passing volunteerId prop from OpportunityListController down through the table list to OpportunityTableRow, similar to how opportunityId is passed down in VolunteerTableRow.

## Related Issues
Closes #739  

## Screenshots / Demos
<img width="400" alt="screenshot-1784001073600" src="https://github.com/user-attachments/assets/1b8e29f3-e37a-4b63-899b-90af4d31ea02" />


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

