### PR TITLE
fix: wire real data into agent profile Volunteers section

### DIFF
--- a/src/components/Dashboard/Profile/sections/VolunteerAgents/AccordionVolunteer.tsx
+++ b/src/components/Dashboard/Profile/sections/VolunteerAgents/AccordionVolunteer.tsx
@@ -32,7 +32,7 @@ export const AccordionVolunteer = ({
   const router = useRouter();
 
   const handleGoToProfile = () => {
-    router.push(`/${i18n.language}/dashboard/volunteers/${volunteer.id}`);
+    router.push(`/${i18n.language}/dashboard/volunteers/${volunteer.volunteerId}`);
   };
 
   const engagementStatusLabels = createEngagementStatusLabelMap(t);
@@ -44,11 +44,8 @@ export const AccordionVolunteer = ({
       <Heading4 margin={0} color="var(--color-midnight)">
         {volunteer?.name}
       </Heading4>
-      <ProfileStatusBadge
-        status={volunteer?.statusEngagement}
-        label={engagementStatusLabels[volunteer?.statusEngagement]}
-      />
-      <ProfileStatusBadge status={volunteer?.statusType} label={statusLabels[volunteer?.statusType]} />
+      <ProfileStatusBadge status={volunteer?.engagement} label={engagementStatusLabels[volunteer?.engagement]} />
+      <ProfileStatusBadge status={volunteer?.volunteeringType} label={statusLabels[volunteer?.volunteeringType]} />
     </>
   );
 
@@ -56,7 +53,7 @@ export const AccordionVolunteer = ({
     <Accordion
       data-testid="volunteer-accordion"
       headerLeft={headerLeft}
-      subtitle={`${t(getDatePrefixKey(currentStatus))} 12.02.2025`}
+      subtitle={`${t(getDatePrefixKey(currentStatus))} ${new Date(volunteer.updatedAt).toLocaleDateString("de-DE")}`}
       onGoToProfile={handleGoToProfile}
     >
       <VolunteerDetail

--- a/src/components/Dashboard/Profile/sections/VolunteerAgents/VolunteerAgents.tsx
+++ b/src/components/Dashboard/Profile/sections/VolunteerAgents/VolunteerAgents.tsx
@@ -1,24 +1,88 @@
+import { apiPathAgent, cacheTTL } from "@/config/constants";
+import { useGetQuery } from "@/hooks/useGetQuery";
+import {
+  useDeleteOpportunityVolunteer,
+  useUpdateOpportunityVolunteerStatus,
+} from "@/hooks/useUpdateOpportunityVolunteerStatus";
+import { Id, OpportunityVolunteerStatusType } from "need4deed-sdk";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { SectionEmptyState } from "../shared/styles";
 import { Tabs } from "../shared/Tabs";
-import { TAB_STATUS_ORDER, useTabTransitions } from "../shared/useTabTransitions";
+import { ITEM_STATUS_REMOVED, TAB_STATUS_ORDER, useTabTransitions } from "../shared/useTabTransitions";
+import { AccordionVolunteer } from "./AccordionVolunteer";
 import { VolunteerOpportunitiesContainer } from "./styles";
 import { MappedVolunteerAgent } from "./types";
 
-export const VolunteerAgents = () => {
+type Props = { agentId: Id };
+
+export const VolunteerAgents = ({ agentId }: Props) => {
   const { t } = useTranslation();
 
-  const { selectedTabIndex, setSelectedTabIndex, tabCounts } = useTabTransitions<MappedVolunteerAgent>([]);
+  const queryKey = ["agent-volunteers", String(agentId)];
+
+  const { data, isLoading } = useGetQuery<MappedVolunteerAgent[]>({
+    queryKey,
+    apiPath: `${apiPathAgent}/${agentId}/volunteer-linked`,
+    staleTime: cacheTTL,
+    enabled: !!agentId,
+  });
+
+  const volunteers = useMemo(() => data ?? [], [data]);
+
+  const { mutate: updateStatus } = useUpdateOpportunityVolunteerStatus(queryKey);
+  const { mutate: deleteLink } = useDeleteOpportunityVolunteer(queryKey);
+
+  const { selectedTabIndex, setSelectedTabIndex, currentTabStatus, tabCounts, visibleItems, setItemStatus } =
+    useTabTransitions(volunteers);
 
   const tabs = TAB_STATUS_ORDER.map((key, index) => ({
     label: t(`dashboard.volunteerProfile.opportunitiesSec.tabs.${key}`),
     count: tabCounts[index],
   }));
 
+  const handleMatch = (m2mId: number) => {
+    setItemStatus(m2mId, OpportunityVolunteerStatusType.MATCHED);
+    updateStatus({ m2mId, status: OpportunityVolunteerStatusType.MATCHED });
+  };
+
+  const handleNotAMatch = (m2mId: number) => {
+    setItemStatus(m2mId, ITEM_STATUS_REMOVED);
+    deleteLink({ m2mId });
+  };
+
+  const handleMarkAsActive = (m2mId: number) => {
+    setItemStatus(m2mId, OpportunityVolunteerStatusType.ACTIVE);
+    updateStatus({ m2mId, status: OpportunityVolunteerStatusType.ACTIVE });
+  };
+
+  const handleMarkAsPast = (m2mId: number) => {
+    setItemStatus(m2mId, OpportunityVolunteerStatusType.PAST);
+    updateStatus({ m2mId, status: OpportunityVolunteerStatusType.PAST });
+  };
+
+  if (isLoading) {
+    return <VolunteerOpportunitiesContainer data-testid="agent-volunteers" />;
+  }
+
   return (
-    <VolunteerOpportunitiesContainer>
+    <VolunteerOpportunitiesContainer data-testid="agent-volunteers">
       <Tabs tabs={tabs} selectedTabIndex={selectedTabIndex} setSelectedTabIndex={setSelectedTabIndex} />
-      <SectionEmptyState>{t("dashboard.volunteerProfile.opportunitiesSec.emptyState")}</SectionEmptyState>
+      {visibleItems.length === 0 ? (
+        <SectionEmptyState>{t("dashboard.volunteerProfile.opportunitiesSec.emptyState")}</SectionEmptyState>
+      ) : (
+        visibleItems.map((volunteer) => (
+          <AccordionVolunteer
+            key={volunteer.id}
+            volunteer={volunteer}
+            currentStatus={currentTabStatus}
+            onMatch={() => handleMatch(volunteer.id)}
+            onNotAMatch={() => handleNotAMatch(volunteer.id)}
+            onMarkAsActive={() => handleMarkAsActive(volunteer.id)}
+            onMarkAsPast={() => handleMarkAsPast(volunteer.id)}
+          />
+        ))
+      )}
     </VolunteerOpportunitiesContainer>
   );
 };

--- a/src/components/Dashboard/Profile/sections/VolunteerAgents/types.ts
+++ b/src/components/Dashboard/Profile/sections/VolunteerAgents/types.ts
@@ -1,6 +1,5 @@
 import {
-  ApiVolunteerGetList,
-  OpportunityVolunteerStatusType,
+  ApiVolunteerOpportunityGet,
   VolunteerStateEngagementType,
   VolunteerStateMatchType,
   VolunteerStateTypeType,
@@ -8,9 +7,7 @@ import {
 
 import { TFunction } from "i18next";
 
-export type MappedVolunteerAgent = ApiVolunteerGetList & {
-  status: OpportunityVolunteerStatusType;
-};
+export type MappedVolunteerAgent = ApiVolunteerOpportunityGet;
 
 export const createEngagementStatusLabelMap = (t: TFunction): Record<VolunteerStateEngagementType, string> => ({
   [VolunteerStateEngagementType.NEW]: t("dashboard.volunteers.filters.engagement.new"),

--- a/src/hooks/useAgentProfileSections.tsx
+++ b/src/hooks/useAgentProfileSections.tsx
@@ -60,7 +60,7 @@ export const useAgentProfileSections = (agent: ApiAgentProfileGet | undefined) =
     {
       iconName: IconName.UserCheck,
       title: t("dashboard.volunteers.volunteers"),
-      subComponent: <VolunteerAgents />,
+      subComponent: <VolunteerAgents agentId={agent.id} />,
     },
     {
       iconName: IconName.ShootingStar,

--- a/src/hooks/useUpdateOpportunityVolunteerStatus.ts
+++ b/src/hooks/useUpdateOpportunityVolunteerStatus.ts
@@ -11,8 +11,17 @@ type StatusUpdatePayload = {
 
 type DeletePayload = { m2mId: number };
 
-function getComplementaryPrefix(queryKey: string[]): string {
-  return queryKey[0] === "opportunity-volunteers" ? "volunteer-opportunities" : "opportunity-volunteers";
+// "agent-volunteers" aggregates volunteers across all of an agent's
+// opportunities, so a status change made from there can affect both the
+// volunteer's own view and a single opportunity's volunteer list.
+const COMPLEMENTARY_PREFIXES: Record<string, string[]> = {
+  "opportunity-volunteers": ["volunteer-opportunities"],
+  "volunteer-opportunities": ["opportunity-volunteers"],
+  "agent-volunteers": ["volunteer-opportunities", "opportunity-volunteers"],
+};
+
+function getComplementaryPrefixes(queryKey: string[]): string[] {
+  return COMPLEMENTARY_PREFIXES[queryKey[0]] ?? ["opportunity-volunteers"];
 }
 
 export const useUpdateOpportunityVolunteerStatus = (queryKeyToInvalidate: string[]) => {
@@ -26,7 +35,9 @@ export const useUpdateOpportunityVolunteerStatus = (queryKeyToInvalidate: string
     successMessage: "dashboard.opportunityProfile.volunteersSec.statusUpdateSuccess",
     queryKeyToInvalidate,
     onSuccessCallback: () => {
-      queryClient.invalidateQueries({ queryKey: [getComplementaryPrefix(queryKeyToInvalidate)] });
+      getComplementaryPrefixes(queryKeyToInvalidate).forEach((prefix) =>
+        queryClient.invalidateQueries({ queryKey: [prefix] }),
+      );
     },
   });
 };
@@ -42,7 +53,9 @@ export const useDeleteOpportunityVolunteer = (queryKeyToInvalidate: string[]) =>
     successMessage: "dashboard.opportunityProfile.volunteersSec.removeSuccess",
     queryKeyToInvalidate,
     onSuccessCallback: () => {
-      queryClient.invalidateQueries({ queryKey: [getComplementaryPrefix(queryKeyToInvalidate)] });
+      getComplementaryPrefixes(queryKeyToInvalidate).forEach((prefix) =>
+        queryClient.invalidateQueries({ queryKey: [prefix] }),
+      );
     },
   });
 };


### PR DESCRIPTION
## Description
`VolunteerAgents.tsx` (the "Ehrenamtliche"/Volunteers section on the NGO/agent's own profile) never fetched any data — `useTabTransitions` was called with a hardcoded `[]`, so every status tab always showed 0, even when the NGO genuinely had volunteers matched via its opportunities.

## Related Issues
Closes #777

## Changes
- Wires `VolunteerAgents` up to the new `GET /agent/:id/volunteer-linked` endpoint (need4deed-org/be#762 / need4deed-org/be#759), mirroring `OpportunityVolunteers.tsx`'s existing fetch/tabs/mutation pattern (same `useTabTransitions`, same `useUpdateOpportunityVolunteerStatus`/`useDeleteOpportunityVolunteer` hooks)
- Renders the previously-unused `AccordionVolunteer`/`VolunteerDetail` components (they existed fully built but were never imported by `VolunteerAgents.tsx`)
- `MappedVolunteerAgent` type now aliases `ApiVolunteerOpportunityGet` directly (the actual shape the endpoint returns) instead of an ad-hoc `ApiVolunteerGetList & { status }` combo
- Fixed two latent bugs in the never-rendered `AccordionVolunteer.tsx`:
  - Used `statusEngagement`/`statusType` field names that don't exist on `ApiVolunteerOpportunityGet` (the real fields are `engagement`/`volunteeringType`) — always evaluated to `undefined`
  - "Go to profile" linked to `volunteer.id` (the opportunity-volunteer match id) instead of `volunteer.volunteerId` — would have routed to the wrong profile page
  - Also removed a hardcoded placeholder date (`12.02.2025`) in favor of the real `updatedAt`

## Note
No backend available in my working environment to test the full round-trip live (needs need4deed-org/be#762 merged and deployed first). Typecheck, lint, and the pre-commit hooks all pass. The component logic mirrors `OpportunityVolunteers.tsx` closely — would appreciate a manual check once both PRs are merged to a shared environment.

## Depends on
- need4deed-org/be#762 (adds the `GET /agent/:id/volunteer-linked` endpoint this relies on)

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated — no dedicated tests, consistent with `OpportunityVolunteers.tsx`/`VolunteerOpportunities.tsx`, which also have no test coverage
- [ ] Documentation updated
- [ ] CI passes