### PR TITLE
790: agent own profile missing profilelayout

### DIFF
--- a/src/app/[lang]/dashboard/profile/page.tsx
+++ b/src/app/[lang]/dashboard/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import CenteredWrapper from "@/components/core/common/CenteredWrapper";
-import { AgentProfileController } from "@/components/Dashboard/Profile/AgentProfileController";
+import ProfileLayout from "@/components/Dashboard/Profile/ProfileLayout";
 import { Paragraph } from "@/components/styled/text";
 import { useGetCurrentAgent } from "@/hooks/useGetCurrentAgent";
 import { useTranslation } from "react-i18next";
@@ -25,5 +25,5 @@ export default function DashboardProfilePage() {
     );
   }
 
-  return <AgentProfileController entityId={String(agentId)} />;
+  return <ProfileLayout entityId={String(agentId)} entityType={"agent"} />;
 }


### PR DESCRIPTION
## Description
Fixes missing profile layout for agent's own profile (when they click on profile)

## Related Issues
Closes #790 

## Changes
- Bullet list of meaningful changes (optional)

## Screenshots / Demos
<img width="1501" height="794" alt="image" src="https://github.com/user-attachments/assets/541d464c-3670-4d12-951c-934ff2d8c34f" />

## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

