### PR TITLE
🐛 fix: send numeric option ids for opportunity-create activities/skills/languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "0.0.125",
+    "need4deed-sdk": "0.0.127",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
+++ b/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
@@ -39,34 +39,14 @@ import { Heading2, Heading4 } from "@/components/styled/text";
 import { ShootingStarIcon, ArrowLeftIcon } from "@phosphor-icons/react";
 import { de, enUS } from "date-fns/locale";
 import { TFunction } from "i18next";
-import { Lang, OptionItem, TranslatedIntoType, VolunteerStateTypeType } from "need4deed-sdk";
-
-// Not yet in need4deed-sdk — defined locally until the SDK is updated.
-type OpportunityFormDataWithAgentSubmitter = {
-  title: string;
-  opportunity_type: "accompanying" | "volunteering";
-  vo_information: string | null;
-  volunteers_number: number;
-  languages: string[];
-  activities: string[];
-  skills: string[];
-  timeslots: [number, string][] | null;
-  onetime_date_time: string | null;
-  accomp_address: string | null;
-  accomp_postcode: string | null;
-  accomp_datetime: string | null;
-  accomp_name: string | null;
-  accomp_phone: string | null;
-  accomp_information: string | null;
-  accomp_translation: `${TranslatedIntoType}` | null;
-  berlin_locations: string[] | null;
-  category: string;
-  category_id: string;
-  language: `${Lang}`;
-  agent_id: number;
-  submitted_by_id: number | null;
-  last_edited_time_notion: string | null;
-};
+import {
+  Lang,
+  OpportunityFormDataWithAgentSubmitter,
+  OpportunityLegacyType,
+  OptionItem,
+  TranslatedIntoType,
+  VolunteerStateTypeType,
+} from "need4deed-sdk";
 import { useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { Controller, FormProvider, useForm, useFormContext } from "react-hook-form";
@@ -156,13 +136,13 @@ function buildCreatePayload(
   const isEvent = headerData.volunteerType === VolunteerStateTypeType.EVENTS;
   const isAccompanying = headerData.volunteerType === VolunteerStateTypeType.ACCOMPANYING;
 
-  const mainLangIds = toLangOptionItems(detailsData.mainCommunication, apiLanguages, t).map((i) => String(i.id));
-  const residentsLangIds = toLangOptionItems(detailsData.residentsSpeak, apiLanguages, t).map((i) => String(i.id));
-  const refugeeLangIds = (accompData?.refugeeLanguage ?? []).map(String).filter(Boolean);
-  const languages = [...new Set([...mainLangIds, ...residentsLangIds, ...refugeeLangIds])];
+  const mainLangIds = toLangOptionItems(detailsData.mainCommunication, apiLanguages, t).map((i) => i.id);
+  const residentsLangIds = toLangOptionItems(detailsData.residentsSpeak, apiLanguages, t).map((i) => i.id);
+  const refugeeLangIds = (accompData?.refugeeLanguage ?? []).map(Number).filter((id) => !isNaN(id));
+  const languageIds = [...new Set([...mainLangIds, ...residentsLangIds, ...refugeeLangIds])];
 
-  const activities = toOptionItems(detailsData.activities, apiActivities).map((i) => String(i.id));
-  const skills = toOptionItems(detailsData.skills, apiSkills).map((i) => String(i.id));
+  const activityIds = toOptionItems(detailsData.activities, apiActivities).map((i) => i.id);
+  const skillIds = toOptionItems(detailsData.skills, apiSkills).map((i) => i.id);
   const timeslots = isEvent ? null : availabilityToTimeslots(detailsData.availability);
 
   const onetime_date_time =
@@ -177,12 +157,12 @@ function buildCreatePayload(
 
   return {
     title: headerData.title,
-    opportunity_type: isAccompanying ? "accompanying" : "volunteering",
+    opportunity_type: isAccompanying ? OpportunityLegacyType.ACCOMPANYING : OpportunityLegacyType.VOLUNTEERING,
     vo_information: detailsData.description || null,
     volunteers_number: Number(detailsData.numberOfVolunteers) || 1,
-    languages,
-    activities,
-    skills,
+    languageIds,
+    activityIds,
+    skillIds,
     timeslots,
     onetime_date_time,
     accomp_address: isAccompanying ? (accompData?.appointmentAddress ?? null) : null,
@@ -192,7 +172,7 @@ function buildCreatePayload(
     accomp_phone: isAccompanying ? (accompData?.refugeeNumber ?? null) : null,
     accomp_information: null,
     accomp_translation: isAccompanying ? accompData?.appointmentLanguage || null : null,
-    berlin_locations: null,
+    districtIds: null,
     category: "",
     category_id: "",
     language: lang as `${Lang}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,10 +2412,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.125:
-  version "0.0.125"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.125.tgz#adee2cbc342da82c1f6dedfeebafac2502648d46"
-  integrity sha512-g/7Bwk1zqcyLZYvmgnACeXhuem5TGfDcwexzQVsaxR2HfXQW3zcJ3NHFaKqaKT9p4hOoRqkJR1vtaFOvFOAgfg==
+need4deed-sdk@0.0.127:
+  version "0.0.127"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.127.tgz#44f98dbfee3d1ecb660b4d638b30d6d7a9f552b9"
+  integrity sha512-jnK2I3Q90d2EBAF/3H/zVELxXnYVYr5iOhw17fOOMm10qKsfeCx44Xz/4L0C+ztL5STTyj830cPWQ9Afz9H9qQ==
 
 next@15.3.8:
   version "15.3.8"


### PR DESCRIPTION
## Summary
- `buildCreatePayload` (dashboard's `NewOpportunity.tsx`, `POST /opportunity/`) sent stringified numeric option ids through fields typed for the legacy public form's free-text/ISO-code strings, so `be`'s create handler silently dropped all activities, skills, and languages on save — need4deed-org/be#774.
- The local `OpportunityFormDataWithAgentSubmitter` type was defined here (with a comment saying "not yet in SDK") and masked the mismatch: both the legacy and dashboard shapes were `string[]`, just carrying different meanings.
- `need4deed-sdk@0.0.127` now exports this type properly, with its own id-based fields (`languageIds`/`activityIds`/`skillIds`/`districtIds: number[]`). Dropped the local shadow type and updated `buildCreatePayload` to send real numbers through the new fields.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` (no new warnings)
- [x] `yarn build`
- [x] Verified end-to-end against need4deed-org/be#775: ran a local `be` (fix branch) + this `fe` branch together, created an opportunity through the fe dev server's own `/api/*` proxy with the new payload shape, and confirmed in the DB that activities/skills/languages persisted correctly (previously all silently empty)
- Note: no browser-automation tool was available in this environment, so the click-through UI itself wasn't exercised — the verification above drove the real network path (fe proxy → be → DB) with the exact payload `buildCreatePayload` produces.

Depends on need4deed-org/be#775 being merged/deployed for the fix to take effect end-to-end (this PR alone changes only the request payload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)