### PR TITLE
fix: send activityIds/skillIds/languageIds on opportunity create

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "0.0.125",
+    "need4deed-sdk": "0.0.127",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
+++ b/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
@@ -39,34 +39,14 @@ import { Heading2, Heading4 } from "@/components/styled/text";
 import { ShootingStarIcon, ArrowLeftIcon } from "@phosphor-icons/react";
 import { de, enUS } from "date-fns/locale";
 import { TFunction } from "i18next";
-import { Lang, OptionItem, TranslatedIntoType, VolunteerStateTypeType } from "need4deed-sdk";
-
-// Not yet in need4deed-sdk — defined locally until the SDK is updated.
-type OpportunityFormDataWithAgentSubmitter = {
-  title: string;
-  opportunity_type: "accompanying" | "volunteering";
-  vo_information: string | null;
-  volunteers_number: number;
-  languages: string[];
-  activities: string[];
-  skills: string[];
-  timeslots: [number, string][] | null;
-  onetime_date_time: string | null;
-  accomp_address: string | null;
-  accomp_postcode: string | null;
-  accomp_datetime: string | null;
-  accomp_name: string | null;
-  accomp_phone: string | null;
-  accomp_information: string | null;
-  accomp_translation: `${TranslatedIntoType}` | null;
-  berlin_locations: string[] | null;
-  category: string;
-  category_id: string;
-  language: `${Lang}`;
-  agent_id: number;
-  submitted_by_id: number | null;
-  last_edited_time_notion: string | null;
-};
+import {
+  Lang,
+  OpportunityFormDataWithAgentSubmitter,
+  OpportunityLegacyType,
+  OptionItem,
+  TranslatedIntoType,
+  VolunteerStateTypeType,
+} from "need4deed-sdk";
 import { useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { Controller, FormProvider, useForm, useFormContext } from "react-hook-form";
@@ -156,13 +136,13 @@ function buildCreatePayload(
   const isEvent = headerData.volunteerType === VolunteerStateTypeType.EVENTS;
   const isAccompanying = headerData.volunteerType === VolunteerStateTypeType.ACCOMPANYING;
 
-  const mainLangIds = toLangOptionItems(detailsData.mainCommunication, apiLanguages, t).map((i) => String(i.id));
-  const residentsLangIds = toLangOptionItems(detailsData.residentsSpeak, apiLanguages, t).map((i) => String(i.id));
-  const refugeeLangIds = (accompData?.refugeeLanguage ?? []).map(String).filter(Boolean);
-  const languages = [...new Set([...mainLangIds, ...residentsLangIds, ...refugeeLangIds])];
+  const mainLangIds = toLangOptionItems(detailsData.mainCommunication, apiLanguages, t).map((i) => i.id);
+  const residentsLangIds = toLangOptionItems(detailsData.residentsSpeak, apiLanguages, t).map((i) => i.id);
+  const refugeeLangIds = (accompData?.refugeeLanguage ?? []).map(Number).filter(Boolean);
+  const languageIds = [...new Set([...mainLangIds, ...residentsLangIds, ...refugeeLangIds])];
 
-  const activities = toOptionItems(detailsData.activities, apiActivities).map((i) => String(i.id));
-  const skills = toOptionItems(detailsData.skills, apiSkills).map((i) => String(i.id));
+  const activityIds = toOptionItems(detailsData.activities, apiActivities).map((i) => i.id);
+  const skillIds = toOptionItems(detailsData.skills, apiSkills).map((i) => i.id);
   const timeslots = isEvent ? null : availabilityToTimeslots(detailsData.availability);
 
   const onetime_date_time =
@@ -177,12 +157,12 @@ function buildCreatePayload(
 
   return {
     title: headerData.title,
-    opportunity_type: isAccompanying ? "accompanying" : "volunteering",
+    opportunity_type: isAccompanying ? OpportunityLegacyType.ACCOMPANYING : OpportunityLegacyType.VOLUNTEERING,
     vo_information: detailsData.description || null,
     volunteers_number: Number(detailsData.numberOfVolunteers) || 1,
-    languages,
-    activities,
-    skills,
+    languageIds,
+    activityIds,
+    skillIds,
     timeslots,
     onetime_date_time,
     accomp_address: isAccompanying ? (accompData?.appointmentAddress ?? null) : null,
@@ -192,7 +172,7 @@ function buildCreatePayload(
     accomp_phone: isAccompanying ? (accompData?.refugeeNumber ?? null) : null,
     accomp_information: null,
     accomp_translation: isAccompanying ? accompData?.appointmentLanguage || null : null,
-    berlin_locations: null,
+    districtIds: null,
     category: "",
     category_id: "",
     language: lang as `${Lang}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,10 +2412,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.125:
-  version "0.0.125"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.125.tgz#adee2cbc342da82c1f6dedfeebafac2502648d46"
-  integrity sha512-g/7Bwk1zqcyLZYvmgnACeXhuem5TGfDcwexzQVsaxR2HfXQW3zcJ3NHFaKqaKT9p4hOoRqkJR1vtaFOvFOAgfg==
+need4deed-sdk@0.0.127:
+  version "0.0.127"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.127.tgz#44f98dbfee3d1ecb660b4d638b30d6d7a9f552b9"
+  integrity sha512-jnK2I3Q90d2EBAF/3H/zVELxXnYVYr5iOhw17fOOMm10qKsfeCx44Xz/4L0C+ztL5STTyj830cPWQ9Afz9H9qQ==
 
 next@15.3.8:
   version "15.3.8"


### PR DESCRIPTION
## Summary

Follow-up to need4deed-org/be#774 (and its be-side fix, need4deed-org/be#776).

`NewOpportunity.tsx` defined `OpportunityFormDataWithAgentSubmitter` locally (with a `// Not yet in need4deed-sdk` comment) and had `buildCreatePayload()` send `languages`/`activities`/`skills` as stringified numeric option ids. The `be` route these hit resolves those fields by title/ISO-code, so an id string never matches — every opportunity created from the dashboard silently lost its activities/skills/languages.

- Bumps `need4deed-sdk` to `0.0.127`, which now publishes this form's own contract (`OpportunityFormDataWithAgentSubmitter`) with `activityIds`/`skillIds`/`languageIds`/`districtIds: number[]` fields — imported instead of redefined locally.
- `buildCreatePayload()` now sends numeric `activityIds`/`skillIds`/`languageIds` (via `.map(i => i.id)` instead of `.map(i => String(i.id))`).
- `opportunity_type` now uses the SDK's `OpportunityLegacyType` enum instead of raw string literals (required once the field type came from the SDK).
- `districtIds` is sent as `null` (no UI collects it here, mirroring the previous `berlin_locations: null`).

## Test plan

- [x] `yarn typecheck` — passes
- [x] `yarn lint` — no new warnings/errors vs. `develop`
- [x] `yarn build` — production build succeeds
- [ ] Manual end-to-end: create an opportunity from the dashboard with activities/skills/languages selected, reopen it, confirm they persisted (needs the `be` fix in #776 deployed together with this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)