### PR TITLE
feat: allow agent to change status of their own opportunity

### DIFF
--- a/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
@@ -8,7 +8,7 @@ import { EmptyPlaceholder } from "@/components/core/common/EmptyPlaceholder";
 import { EMPTY_PLACEHOLDER_VALUE } from "@/config/constants";
 import { formatDateTime } from "@/utils";
 import { ShootingStarIcon } from "@phosphor-icons/react";
-import { ApiOpportunityGet } from "need4deed-sdk";
+import { ApiOpportunityGet, UserRole } from "need4deed-sdk";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
@@ -17,6 +17,7 @@ import { ChangeOpportunityStatusDialog } from "./ChangeOpportunityStatusDialog";
 import { createOpportunityStatusLabelMap } from "./constants";
 import { useOpportunityStatusDialog } from "./useOpportunityStatusDialog";
 import { useAuth } from "@/hooks/useAuth";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 type Props = {
   opportunity: ApiOpportunityGet;
@@ -24,6 +25,12 @@ type Props = {
 
 export const OpportunityHeader = ({ opportunity }: Props) => {
   const { isAuthorized } = useAuth();
+  const currentUser = useCurrentUser();
+  // Coordinator/admin may edit any opportunity; an agent may only change the
+  // status of an opportunity belonging to their own agent (mirrors the be
+  // ownership check on PATCH /opportunity/:id).
+  const canChangeStatus =
+    isAuthorized || (currentUser?.role === UserRole.AGENT && currentUser?.agentId === opportunity.agent?.id);
   const { t, i18n } = useTranslation();
   const dialog = useOpportunityStatusDialog(opportunity);
   const statusLabelMap = createOpportunityStatusLabelMap(t);
@@ -50,7 +57,7 @@ export const OpportunityHeader = ({ opportunity }: Props) => {
         status={dialog.selected}
         label={statusLabelMap[dialog.selected]}
         action={
-          isAuthorized && (
+          canChangeStatus && (
             <EditButton onClick={dialog.openDialog}>{t("dashboard.opportunityProfile.change_status")}</EditButton>
           )
         }


### PR DESCRIPTION
## Summary
- `OpportunityHeader.tsx`'s "Change status" button was gated behind `isAuthorized` (admin/coordinator only), so an agent had no way to mark their own opportunity inactive once it's no longer relevant.
- Now also shown when the viewer is an `AGENT` and the opportunity belongs to their own agent (`currentUser.agentId === opportunity.agent.id`), mirroring the ownership check the backend now enforces.
- Depends on the backend authorization change in need4deed-org/be#781 (`PATCH /opportunity/:id` now allows an AGENT to patch just `statusOpportunity` on their own agent's opportunity).

## Test plan
- [x] `yarn typecheck` passes
- [x] `yarn lint` passes (no new warnings/errors)
- [ ] Manual: log in as an agent, open one of that agent's own opportunities, confirm "Change status" button now appears and the dialog still updates status correctly (not verified live in this session — flagging for reviewer/QA since local backend networking wasn't available to exercise the full login + dashboard flow end-to-end)

Fixes #820