### PR TITLE
feat: add "Konto erstellen" button on the login page, linking to NGO registration

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -508,6 +508,7 @@
     },
     "login": {
       "login": "Anmelden",
+      "createAccount": "Konto erstellen",
       "email": "Email",
       "password": "Passwort",
       "rememberMe": "Angemeldet bleiben",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -502,6 +502,7 @@
     },
     "login": {
       "login": "Log in",
+      "createAccount": "Create account",
       "email": "Email",
       "password": "Password",
       "rememberMe": "Remember Me",

--- a/src/components/Login/Login/LoginForm.tsx
+++ b/src/components/Login/Login/LoginForm.tsx
@@ -125,6 +125,19 @@ export const LoginForm = ({ onLoginSuccess }: LoginFormProps) => {
             />
           )}
         </form.Subscribe>
+
+        <Link href={"/register/agent"} style={{ textDecoration: "none" }}>
+          <Button
+            type="button"
+            text={t("dashboard.login.createAccount")}
+            backgroundcolor="transparent"
+            textColor="var(--color-aubergine)"
+            textHoverColor="var(--color-aubergine)"
+            border="1px solid var(--color-aubergine)"
+            height="48px"
+            padding="8px 20px"
+          />
+        </Link>
       </LoginButtonDiv>
     </StyledForm>
   );

--- a/src/components/Login/Login/LoginForm.tsx
+++ b/src/components/Login/Login/LoginForm.tsx
@@ -126,18 +126,17 @@ export const LoginForm = ({ onLoginSuccess }: LoginFormProps) => {
           )}
         </form.Subscribe>
 
-        <Link href={"/register/agent"} style={{ textDecoration: "none" }}>
-          <Button
-            type="button"
-            text={t("dashboard.login.createAccount")}
-            backgroundcolor="transparent"
-            textColor="var(--color-aubergine)"
-            textHoverColor="var(--color-aubergine)"
-            border="1px solid var(--color-aubergine)"
-            height="48px"
-            padding="8px 20px"
-          />
-        </Link>
+        <Button
+          type="button"
+          onClick={() => router.push("/register/agent")}
+          text={t("dashboard.login.createAccount")}
+          backgroundcolor="transparent"
+          textColor="var(--color-aubergine)"
+          textHoverColor="var(--color-aubergine)"
+          border="1px solid var(--color-aubergine)"
+          height="48px"
+          padding="8px 20px"
+        />
       </LoginButtonDiv>
     </StyledForm>
   );

--- a/src/components/Login/styles.ts
+++ b/src/components/Login/styles.ts
@@ -26,7 +26,6 @@ export const FormActions = styled.div`
 
 export const LoginButtonDiv = styled.div`
   display: flex;
-  flex-direction: row;
   align-items: center;
   justify-content: center;
   gap: var(--spacing-16);

--- a/src/components/Login/styles.ts
+++ b/src/components/Login/styles.ts
@@ -26,5 +26,8 @@ export const FormActions = styled.div`
 
 export const LoginButtonDiv = styled.div`
   display: flex;
+  flex-direction: row;
+  align-items: center;
   justify-content: center;
+  gap: var(--spacing-16);
 `;


### PR DESCRIPTION
## Summary
- Adds a "Konto erstellen" / "Create account" button to the right of "Anmelden" on the login form, linking to `/register/agent`.
- Styled as a smaller, secondary button (transparent background, aubergine border/text) so it doesn't compete with the primary "Anmelden" submit button.
- `LoginButtonDiv` switched from a single centered button to a row layout with both buttons side by side.
- New `dashboard.login.createAccount` translation key added to `de` ("Konto erstellen") and `en` ("Create account").

Closes #816

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] Manually verified in a running dev server: button renders next to "Anmelden", correctly styled/sized, no console errors, and clicking it navigates to `/de/register/agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)