### PR TITLE
fix: hide "Find volunteers" button from agent users on Opportunity Profile

### DIFF
--- a/src/hooks/useOpportunityProfileSections.tsx
+++ b/src/hooks/useOpportunityProfileSections.tsx
@@ -116,12 +116,14 @@ export const useOpportunityProfileSections = (opportunity: ApiOpportunityGet | u
       {
         iconName: IconName.UsersThree,
         title: t("dashboard.opportunityProfile.volunteersSec.title"),
-        headerButtonName: volunteerId
-          ? t("dashboard.opportunityProfile.volunteersSec.suggestButtonName")
-          : t("dashboard.opportunityProfile.volunteersSec.findVolunteers"),
-        onHeaderButtonClick: volunteerId
-          ? () => setIsSuggestDialogOpen(true)
-          : () => router.push(`/${i18n.language}/dashboard/volunteers?opportunity=${opportunity.id}`),
+        ...(isAuthorized && {
+          headerButtonName: volunteerId
+            ? t("dashboard.opportunityProfile.volunteersSec.suggestButtonName")
+            : t("dashboard.opportunityProfile.volunteersSec.findVolunteers"),
+          onHeaderButtonClick: volunteerId
+            ? () => setIsSuggestDialogOpen(true)
+            : () => router.push(`/${i18n.language}/dashboard/volunteers?opportunity=${opportunity.id}`),
+        }),
         subComponent: (
           <>
             <OpportunityVolunteers opportunityId={opportunity.id} />


### PR DESCRIPTION
## Summary
- On an Opportunity Profile page, AGENT-role users viewing their own opportunity no longer see the "Ehrenamtliche finden" / "Find volunteers" (or "Suggest") header button on the Volunteers section — matching volunteers is a coordinator/admin-only action.
- The Volunteers section itself (Pending/Matched/Active/Past tabs) stays visible to agents so they can still see their volunteers' status.
- Gated `headerButtonName`/`onHeaderButtonClick` on `isAuthorized` (admin/coordinator) instead of `hasEditingRights` (which also included agents via `isOwnProfile`). `SectionCard` already renders the header button conditionally, so omitting the props is a clean no-op for agents.

Closes #833

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [ ] Manually verify: agent viewing own opportunity sees no "Find volunteers" button but still sees the volunteers section/tabs; coordinator/admin still see the button and it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)