### PR TITLE
fix: hide "Validated" status option from agent users in Change Status dialog

### DIFF
--- a/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/ChangeOpportunityStatusDialog.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/ChangeOpportunityStatusDialog.tsx
@@ -6,19 +6,23 @@ import { UseOpportunityStatusDialogReturn } from "./useOpportunityStatusDialog";
 
 type Props = {
   dialog: UseOpportunityStatusDialogReturn;
+  isAuthorized: boolean;
 };
 
 export const ChangeOpportunityStatusDialog = ({
   dialog: { isOpen, closeDialog, selected, setSelected, saveDialog, isSaveDisabled },
+  isAuthorized,
 }: Props) => {
   const { t } = useTranslation();
   const statusLabelMap = createOpportunityStatusLabelMap(t);
 
-  const options = Object.values(OpportunityManualStatusType).map((status) => ({
-    value: status,
-    label: statusLabelMap[status],
-    description: t(`dashboard.opportunityProfile.statusModal.options.${STATUS_DESCRIPTION_KEYS[status]}`),
-  }));
+  const options = Object.values(OpportunityManualStatusType)
+    .filter((status) => isAuthorized || status !== OpportunityManualStatusType.SEARCHING)
+    .map((status) => ({
+      value: status,
+      label: statusLabelMap[status],
+      description: t(`dashboard.opportunityProfile.statusModal.options.${STATUS_DESCRIPTION_KEYS[status]}`),
+    }));
 
   return (
     <ChangeStatusDialog

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
@@ -55,7 +55,7 @@ export const OpportunityHeader = ({ opportunity }: Props) => {
       subtitle={subtitle}
       after={
         <>
-          <ChangeOpportunityStatusDialog dialog={dialog} />
+          <ChangeOpportunityStatusDialog dialog={dialog} isAuthorized={isAuthorized} />
           {isTypeOpen && <ChangeOpportunityTypeDialog onClose={() => setIsTypeOpen(false)} opportunity={opportunity} />}
         </>
       }


### PR DESCRIPTION
## Summary
- Since #830, an agent/NGO user can change their own opportunity's status — but the "Change status" dialog listed all three options (New, **Validated**, Inactive) to every user regardless of role. Validating an opportunity should be a coordinator/admin-only action.
- `ChangeOpportunityStatusDialog` now takes an `isAuthorized` prop and filters out `OpportunityManualStatusType.SEARCHING` ("Validated"/"Validiert") from the selectable options when the viewer isn't a coordinator/admin.
- `OpportunityHeader.tsx` already computes `isAuthorized` (used for the volunteer-type edit gating) — threaded it through to the dialog.
- Agents still see New and Inactive as selectable options; coordinators/admins keep all three.

Closes #834

## Note — backend follow-up needed
This is a UI-only guard. Per the issue, `be#781` (agent PATCH of `statusOpportunity`) restricts *which field* an agent can patch but not *which value* they can set it to — an agent could still set `statusOpportunity` to the validated/searching state via a direct API call. Flagging so a companion backend fix can reject that.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [ ] Manually verify: agent viewing own opportunity's status dialog sees only New/Inactive; coordinator/admin still see all three including Validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)