### PR TITLE
feat: show all agent contacts + Add contact action on NGO profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "0.0.128",
+    "need4deed-sdk": "0.0.130",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1116,6 +1116,17 @@
         "cancel": "Abbrechen",
         "saveChanges": "Änderungen speichern",
         "edit": "Bearbeiten",
+        "additionalContacts": {
+          "title": "Weitere Kontakte"
+        },
+        "addContact": {
+          "button": "Kontakt hinzufügen",
+          "title": "Kontakt hinzufügen",
+          "submit": "Hinzufügen",
+          "addressStreet": "Straße",
+          "addressPostcode": "Postleitzahl",
+          "success": "Kontakt erfolgreich hinzugefügt"
+        },
         "validation": {
           "nameRequired": "Name ist erforderlich",
           "districtRequired": "Bezirk ist erforderlich",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1104,6 +1104,17 @@
         "cancel": "Cancel",
         "saveChanges": "Save changes",
         "edit": "Edit",
+        "additionalContacts": {
+          "title": "Other contacts"
+        },
+        "addContact": {
+          "button": "Add contact",
+          "title": "Add a contact",
+          "submit": "Add",
+          "addressStreet": "Street",
+          "addressPostcode": "Postcode",
+          "success": "Contact added successfully"
+        },
         "validation": {
           "nameRequired": "Name is required",
           "districtRequired": "District is required",

--- a/src/components/Dashboard/Profile/sections/ContactDetails/agent/AddContactDialog.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/agent/AddContactDialog.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import Button from "@/components/core/button/Button/Button";
+import { Modal } from "@/components/core/modal/Modal";
+import { EditableField } from "@/components/EditableField/EditableField";
+import { AgentRoles } from "@/config/constants";
+import { useCreateAgentContact } from "@/hooks/useCreateAgentContact";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Controller, ControllerRenderProps, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+import { ButtonRow, FormDetails } from "../../shared/styles";
+import { useEnumTranslation } from "../shared";
+import { AddContactFormData, createAddContactSchema } from "./addContactSchema";
+
+const Title = styled.h3`
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-24);
+  line-height: var(--line-height-32);
+  letter-spacing: var(--letter-spacing-tight);
+  color: var(--color-midnight);
+  margin: 0 0 var(--spacing-16);
+`;
+
+type Props = {
+  agentId: string;
+  onClose: () => void;
+};
+
+const roleKeys = Object.values(AgentRoles);
+
+export const AddContactDialog = ({ agentId, onClose }: Props) => {
+  const { t } = useTranslation();
+  const { mutate: createContact, isPending } = useCreateAgentContact(agentId);
+  const { options, toLabel, toKey } = useEnumTranslation(roleKeys, "dashboard.agentProfile.contactDetails.roles");
+
+  const schema = createAddContactSchema(t);
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<AddContactFormData>({
+    resolver: zodResolver(schema),
+    mode: "onChange",
+    defaultValues: {
+      firstName: "",
+      lastName: "",
+      role: "" as AgentRoles,
+      email: "",
+      phone: "",
+      addressStreet: "",
+      addressPostcode: "",
+    },
+  });
+
+  const onSubmit = (values: AddContactFormData) => {
+    createContact(values, { onSuccess: onClose });
+  };
+
+  return (
+    <Modal isOpen onClose={onClose}>
+      <Title>{t("dashboard.agentProfile.contactDetails.addContact.title")}</Title>
+      <FormDetails data-testid="agent-add-contact-dialog">
+        <Controller
+          name="firstName"
+          control={control}
+          render={({ field }: { field: ControllerRenderProps<AddContactFormData, "firstName"> }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t("dashboard.agentProfile.contactDetails.firstName")}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.firstName?.message}
+            />
+          )}
+        />
+        <Controller
+          name="lastName"
+          control={control}
+          render={({ field }: { field: ControllerRenderProps<AddContactFormData, "lastName"> }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t("dashboard.agentProfile.contactDetails.lastName")}
+              value={field.value}
+              setValue={field.onChange}
+              errorMessage={errors.lastName?.message}
+            />
+          )}
+        />
+        <Controller
+          name="role"
+          control={control}
+          render={({ field }: { field: ControllerRenderProps<AddContactFormData, "role"> }) => (
+            <EditableField
+              mode="edit"
+              type="radio-list"
+              label={t("dashboard.agentProfile.contactDetails.roles.label")}
+              value={field.value ? toLabel(field.value as AgentRoles) : ""}
+              setValue={(value) => field.onChange(toKey(value as string))}
+              options={options}
+              errorMessage={errors.role?.message}
+            />
+          )}
+        />
+        <Controller
+          name="email"
+          control={control}
+          render={({ field }: { field: ControllerRenderProps<AddContactFormData, "email"> }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t("dashboard.agentProfile.contactDetails.email")}
+              value={field.value ?? ""}
+              setValue={field.onChange}
+              errorMessage={errors.email?.message}
+            />
+          )}
+        />
+        <Controller
+          name="phone"
+          control={control}
+          render={({ field }: { field: ControllerRenderProps<AddContactFormData, "phone"> }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t("dashboard.agentProfile.contactDetails.mobile")}
+              value={field.value ?? ""}
+              setValue={field.onChange}
+              errorMessage={errors.phone?.message}
+            />
+          )}
+        />
+        <Controller
+          name="addressStreet"
+          control={control}
+          render={({ field }: { field: ControllerRenderProps<AddContactFormData, "addressStreet"> }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t("dashboard.agentProfile.contactDetails.addContact.addressStreet")}
+              value={field.value ?? ""}
+              setValue={field.onChange}
+              errorMessage={errors.addressStreet?.message}
+            />
+          )}
+        />
+        <Controller
+          name="addressPostcode"
+          control={control}
+          render={({ field }: { field: ControllerRenderProps<AddContactFormData, "addressPostcode"> }) => (
+            <EditableField
+              mode="edit"
+              type="text"
+              label={t("dashboard.agentProfile.contactDetails.addContact.addressPostcode")}
+              value={field.value ?? ""}
+              setValue={field.onChange}
+              errorMessage={errors.addressPostcode?.message}
+            />
+          )}
+        />
+      </FormDetails>
+
+      <ButtonRow>
+        <Button
+          text={t("dashboard.agentProfile.contactDetails.cancel")}
+          onClick={onClose}
+          width="auto"
+          padding="var(--volunteer-profile-section-card-header-button-padding)"
+          backgroundcolor="var(--color-white)"
+          textColor="var(--color-aubergine)"
+          border="var(--volunteer-profile-section-card-header-button-border)"
+        />
+        <Button
+          text={t("dashboard.agentProfile.contactDetails.addContact.submit")}
+          onClick={handleSubmit(onSubmit)}
+          width="auto"
+          disabled={!isValid || isPending}
+          padding="var(--volunteer-profile-section-card-header-button-padding)"
+        />
+      </ButtonRow>
+    </Modal>
+  );
+};

--- a/src/components/Dashboard/Profile/sections/ContactDetails/agent/AgentContactDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/agent/AgentContactDetails.tsx
@@ -108,7 +108,7 @@ export const AgentContactDetails = forwardRef<ContactDetailsRef, Props>(function
             isPending={isPending}
           />
         ) : (
-          <AgentContactDetailsDisplay keysToLabels={keysToLabels} />
+          <AgentContactDetailsDisplay agent={agent} keysToLabels={keysToLabels} />
         )}
       </FormContainer>
     </FormProvider>

--- a/src/components/Dashboard/Profile/sections/ContactDetails/agent/AgentContactDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/agent/AgentContactDetailsDisplay.tsx
@@ -1,59 +1,112 @@
+import Button from "@/components/core/button/Button/Button";
 import { EditableField } from "@/components/EditableField/EditableField";
 import { AgentRoles } from "@/config/constants";
+import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { ApiAgentProfileGet } from "../../../types";
 import { FieldWrapper, FormDetails } from "../../shared/styles";
+import { useEnumTranslation } from "../shared";
+import { AddContactDialog } from "./AddContactDialog";
 import { AgentContactDetailsFormData } from "./agentContactDetailsSchema";
 
 type Props = {
+  agent: ApiAgentProfileGet;
   keysToLabels: (keys: AgentRoles[]) => string[];
 };
 
-export const AgentContactDetailsDisplay = ({ keysToLabels }: Props) => {
+export const AgentContactDetailsDisplay = ({ agent, keysToLabels }: Props) => {
   const { t } = useTranslation();
   const { watch } = useFormContext<AgentContactDetailsFormData>();
   const values = watch();
+  const [isAddContactOpen, setIsAddContactOpen] = useState(false);
+  const { toLabel } = useEnumTranslation(Object.values(AgentRoles), "dashboard.agentProfile.contactDetails.roles");
 
   const fullName = values.firstName
     ? [values.firstName, values.middleName, values.lastName].filter(Boolean).join(" ")
     : "–";
 
+  // The representative is already shown (and editable) above via the form
+  // fields bound to `values`; this list surfaces every other AgentPerson
+  // membership so an agent can see all contacts on file, not just the one
+  // collapsed representative.
+  const otherContacts = (agent.contacts ?? []).filter((contact) => contact.person.id !== agent.representative?.id);
+
   return (
-    <FormDetails>
-      <FieldWrapper>
-        <>
-          <label>{t("dashboard.agentProfile.contactDetails.fullName")}</label>
-          <span>{fullName}</span>
-        </>
-      </FieldWrapper>
-      <EditableField
-        mode="display"
-        type="checkbox-list"
-        label={t("dashboard.agentProfile.contactDetails.roles.label")}
-        value={values.role ? keysToLabels([values?.role]) : []}
-        setValue={() => {}}
+    <>
+      <FormDetails>
+        <FieldWrapper>
+          <>
+            <label>{t("dashboard.agentProfile.contactDetails.fullName")}</label>
+            <span>{fullName}</span>
+          </>
+        </FieldWrapper>
+        <EditableField
+          mode="display"
+          type="checkbox-list"
+          label={t("dashboard.agentProfile.contactDetails.roles.label")}
+          value={values.role ? keysToLabels([values?.role]) : []}
+          setValue={() => {}}
+        />
+        <EditableField
+          mode="display"
+          type="text"
+          label={t("dashboard.agentProfile.contactDetails.email")}
+          value={values.email}
+          setValue={() => {}}
+        />
+        <EditableField
+          mode="display"
+          type="text"
+          label={t("dashboard.agentProfile.contactDetails.mobile")}
+          value={values.phone}
+          setValue={() => {}}
+        />
+        <EditableField
+          mode="display"
+          type="text"
+          label={t("dashboard.agentProfile.contactDetails.landline")}
+          value={values.landline || ""}
+          setValue={() => {}}
+        />
+      </FormDetails>
+
+      {otherContacts.length > 0 && (
+        <FormDetails data-testid="agent-other-contacts">
+          <FieldWrapper>
+            <label>{t("dashboard.agentProfile.contactDetails.additionalContacts.title")}</label>
+          </FieldWrapper>
+          {otherContacts.map((contact) => {
+            const contactName = [contact.person.firstName, contact.person.middleName, contact.person.lastName]
+              .filter(Boolean)
+              .join(" ");
+            return (
+              <FieldWrapper key={contact.id}>
+                <>
+                  <label>{contactName}</label>
+                  <span>
+                    {toLabel(contact.role)}
+                    {contact.person.email ? ` · ${contact.person.email}` : ""}
+                    {contact.person.phone ? ` · ${contact.person.phone}` : ""}
+                  </span>
+                </>
+              </FieldWrapper>
+            );
+          })}
+        </FormDetails>
+      )}
+
+      <Button
+        text={t("dashboard.agentProfile.contactDetails.addContact.button")}
+        onClick={() => setIsAddContactOpen(true)}
+        width="auto"
+        padding="var(--volunteer-profile-section-card-header-button-padding)"
+        backgroundcolor="var(--color-white)"
+        textColor="var(--color-aubergine)"
+        border="var(--volunteer-profile-section-card-header-button-border)"
       />
-      <EditableField
-        mode="display"
-        type="text"
-        label={t("dashboard.agentProfile.contactDetails.email")}
-        value={values.email}
-        setValue={() => {}}
-      />
-      <EditableField
-        mode="display"
-        type="text"
-        label={t("dashboard.agentProfile.contactDetails.mobile")}
-        value={values.phone}
-        setValue={() => {}}
-      />
-      <EditableField
-        mode="display"
-        type="text"
-        label={t("dashboard.agentProfile.contactDetails.landline")}
-        value={values.landline || ""}
-        setValue={() => {}}
-      />
-    </FormDetails>
+
+      {isAddContactOpen && <AddContactDialog agentId={String(agent.id)} onClose={() => setIsAddContactOpen(false)} />}
+    </>
   );
 };

--- a/src/components/Dashboard/Profile/sections/ContactDetails/agent/addContactSchema.ts
+++ b/src/components/Dashboard/Profile/sections/ContactDetails/agent/addContactSchema.ts
@@ -1,0 +1,20 @@
+import { AgentRoles, PHONE_NUMBER_REGEX } from "@/config/constants";
+import { z } from "zod";
+
+export const createAddContactSchema = (t: (key: string) => string) => {
+  return z.object({
+    firstName: z.string().min(1, t("dashboard.agentProfile.contactDetails.validation.nameRequired")),
+    lastName: z.string().min(1, t("dashboard.agentProfile.contactDetails.validation.nameRequired")),
+    role: z.enum(AgentRoles, { message: t("dashboard.agentProfile.contactDetails.validation.roleRequired") }),
+    email: z.email(t("dashboard.agentProfile.contactDetails.validation.emailInvalid")).optional().or(z.literal("")),
+    phone: z
+      .string()
+      .regex(PHONE_NUMBER_REGEX, t("dashboard.agentProfile.contactDetails.validation.mobileInvalid"))
+      .optional()
+      .or(z.literal("")),
+    addressStreet: z.string().optional().or(z.literal("")),
+    addressPostcode: z.string().optional().or(z.literal("")),
+  });
+};
+
+export type AddContactFormData = z.infer<ReturnType<typeof createAddContactSchema>>;

--- a/src/hooks/useCreateAgentContact.ts
+++ b/src/hooks/useCreateAgentContact.ts
@@ -1,0 +1,12 @@
+import { apiPathAgent } from "@/config/constants";
+import { useMutationQuery } from "@/hooks";
+import { ApiAgentContactPost, ApiAgentMembership } from "need4deed-sdk";
+
+export const useCreateAgentContact = (agentId: string) => {
+  return useMutationQuery<ApiAgentContactPost, ApiAgentMembership>({
+    apiPath: `${apiPathAgent}/${agentId}/contact`,
+    method: "post",
+    successMessage: "dashboard.agentProfile.contactDetails.addContact.success",
+    queryKeyToInvalidate: ["agent", agentId],
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,10 +2412,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.128:
-  version "0.0.128"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.128.tgz#b1c0443cb0d6d13b39cf60bb9862fee5a563f4a2"
-  integrity sha512-AczNANHKYaWIp+BweDZFCrlv3hHN1lLZDrFzDhfJD39SicLygCqd1NPMtVyIRH4trh6zZSj+2E1D4gKlIdKDUw==
+need4deed-sdk@0.0.130:
+  version "0.0.130"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.130.tgz#d8258b997c73dea5b123688845ccad1c1e93e2a5"
+  integrity sha512-rQoauUEjo6F0vK+ZH6OmAP+0Nr3kbkaK0VIJX8ctmjPBoqwSeSBipIGvELfg1XMo1c3m2kUR6FCjmDYabVAvLQ==
 
 next@15.3.8:
   version "15.3.8"


### PR DESCRIPTION
## Summary
Third and final repo in the multi-repo effort for #810 (support multiple contact persons on NGO/agent profile), following:
- need4deed-sdk 0.0.130 (`contacts: ApiAgentMembership[]` + `ApiAgentContactPost`)
- need4deed-org/be#782 (`GET /agent/:id` now serializes `contacts`; new `POST /agent/:id/contact`) — **not yet merged/deployed**, so contact creation won't succeed end-to-end until it lands.

Changes:
- `AgentContactDetailsDisplay` now lists every `AgentPerson` membership from `agent.contacts` (excluding the one already shown/editable above via the existing representative form) under an "Other contacts" heading, instead of only ever showing the single collapsed representative.
- New **"+ Add contact"** action opens `AddContactDialog` — a form (first/last name, role, email, phone, street, postcode) that posts via a new `useCreateAgentContact` hook to `POST /agent/:id/contact`, invalidating the `["agent", id]` query on success so the list refreshes.
- Editing the primary representative is unchanged — the existing form/hook (`useUpdateAgentContact`, `AgentContactDetailsEdit`) is untouched.
- Editing/removing additional contacts individually is **not** in this PR — per the issue's own "at minimum, adding should work; editing multiple ... can be generalized [later]" — left as a follow-up.
- Bumped `need4deed-sdk` to `0.0.130`.

## Not in this PR
- Individual edit/remove for non-primary contacts (follow-up).

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` — no new issues (3 pre-existing unrelated warnings)
- [x] Dev server boots cleanly with these changes, no console errors (verified via headless browser against the public login redirect)
- [ ] **Not verified end-to-end**: the agent profile page requires an authenticated AGENT/COORDINATOR session, which I don't have test credentials for in this environment, and the live backend this repo's `.env` points at doesn't have be#782 deployed yet (so `agent.contacts` isn't in its `GET /agent/:id` response and `POST /agent/:id/contact` would 404). Please manually verify the full flow (list rendering, add-contact dialog, success/error toasts) once be#782 is merged/deployed, ideally against a local `docker compose` stack running both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)