### PR TITLE
fix: translate "Select option(s)..." placeholder in EditableField

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -341,6 +341,8 @@
   "dashboard": {
     "common": {
       "loading": "Wird geladen...",
+      "selectOption": "Option auswählen...",
+      "selectOptions": "Optionen auswählen...",
       "datePrefix": {
         "appliedOn": "Beworben am",
         "matchedOn": "Zugeordnet am",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -335,6 +335,8 @@
   "dashboard": {
     "common": {
       "loading": "Loading...",
+      "selectOption": "Select option...",
+      "selectOptions": "Select options...",
       "datePrefix": {
         "appliedOn": "Applied on",
         "matchedOn": "Matched on",

--- a/src/components/EditableField/EditableField.tsx
+++ b/src/components/EditableField/EditableField.tsx
@@ -3,6 +3,7 @@ import { EMPTY_PLACEHOLDER_VALUE } from "@/config/constants";
 import { HasError, HasHint } from "@/types";
 import { MinusIcon, PlusIcon, XCircleIcon } from "@phosphor-icons/react";
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { IoIosArrowDown } from "react-icons/io";
 import styled from "styled-components";
 
@@ -302,6 +303,7 @@ export const EditableField = forwardRef(function EditableField<T extends string 
   }: EditableFieldProps<T>,
   ref: React.Ref<EditableFieldRef<T>>,
 ) {
+  const { t } = useTranslation();
   const [error, setError] = useState<string | null>(null);
   const [localValue, setLocalValue] = useState<T>(value);
   const [open, setOpen] = useState<boolean>(false);
@@ -504,8 +506,8 @@ export const EditableField = forwardRef(function EditableField<T extends string 
                 {type === "checkbox-list"
                   ? Array.isArray(localValue) && localValue.length > 0
                     ? localValue.join(", ")
-                    : "Select options..."
-                  : localValue || "Select option..."}
+                    : t("dashboard.common.selectOptions")
+                  : localValue || t("dashboard.common.selectOption")}
               </span>
 
               <Arrow className={open ? "open" : ""} />


### PR DESCRIPTION
## Summary
`EditableField`'s checkbox-list/radio-list dropdown placeholder ("Select option..." / "Select options...") was hardcoded in English regardless of the active locale — confirmed live: on the German UI it showed up untranslated (e.g. in the role picker of fe#844's new "Add contact" dialog). This is a pre-existing bug in the shared component itself, not something #844 introduced — every checkbox-list/radio-list field across the app was affected (any Dashboard/Profile edit form using that field type).

## Fix
- Added `dashboard.common.selectOption` / `dashboard.common.selectOptions` (alongside the existing `dashboard.common.loading` in that same generic namespace) to both `en` and `de` translation files.
- `EditableField.tsx` now uses `useTranslation()` and these keys instead of the two hardcoded literals.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` — no new issues (3 pre-existing unrelated warnings)
- [x] Verified live: this exact placeholder was showing untranslated on `/de/...` before the fix (screenshot taken while reviewing fe#844); confirmed the translation keys resolve correctly for both locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)