### PR TITLE
836: Fix to allow NGO user to edit own profile

### DIFF
--- a/src/hooks/useAgentProfileSections.tsx
+++ b/src/hooks/useAgentProfileSections.tsx
@@ -17,7 +17,7 @@ import { useAuth } from "./useAuth";
 
 export const useAgentProfileSections = (agent: ApiAgentProfileGet | undefined) => {
   const { t } = useTranslation();
-  const { isAuthorized: isAdminOrCoordinator, isOwnProfile } = useAuth(agent?.representative?.id);
+  const { isAuthorized: isAdminOrCoordinator, isOwnProfile } = useAuth(agent?.id);
   const hasEditingRights = isAdminOrCoordinator || isOwnProfile;
 
   const contactDetailsRef = useRef<EditableSectionRef>(null);

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,13 +1,15 @@
 import { Id, UserRole } from "need4deed-sdk";
 import { useCurrentUser } from "./useCurrentUser";
 
-export const useAuth = (contactPersonId?: Id) => {
+export const useAuth = (compareId?: Id) => {
   const user = useCurrentUser();
   const personId = user?.personId;
+  const agentId = user?.agentId;
 
   const isAuthorized = user?.role === UserRole.ADMIN || user?.role === UserRole.COORDINATOR;
   const isOwnProfile =
-    (user?.role === UserRole.VOLUNTEER || user?.role === UserRole.AGENT) && personId === contactPersonId;
+    (user?.role === UserRole.VOLUNTEER && personId === compareId) ||
+    (user?.role === UserRole.AGENT && agentId === compareId);
 
   return { isAuthorized, isOwnProfile };
 };

--- a/src/hooks/useOpportunityProfileSections.tsx
+++ b/src/hooks/useOpportunityProfileSections.tsx
@@ -21,7 +21,7 @@ export const useOpportunityProfileSections = (opportunity: ApiOpportunityGet | u
   const { t, i18n } = useTranslation();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { isAuthorized, isOwnProfile } = useAuth(opportunity?.contact.id);
+  const { isAuthorized, isOwnProfile } = useAuth(opportunity?.agent.id);
   const hasEditingRights = isAuthorized || isOwnProfile;
 
   const opportunityContactDetailsRef = useRef<EditableSectionRef>(null);


### PR DESCRIPTION
## Description
Changes `useAuth` to check only `agentId` if user is `agent`

## Related Issues
Closes #836 

## Changes
- Bullet list of meaningful changes (optional)

## Screenshots / Demos
<img width="734" height="654" alt="image" src="https://github.com/user-attachments/assets/05098a09-02c6-46bf-ad8a-2c0f765bbdc3" />



## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

