### PR TITLE
fix: main-communication validation always rejects a real language pick

### DIFF
--- a/src/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema.ts
@@ -14,14 +14,24 @@ const languageObjectSchema = z.object({
 
 type MainCommunicationLanguageOption = { id: number; title: string; isoCode?: string };
 
+// `title` is translated into whatever language the option list was fetched
+// in (German by default), so it's never the literal English word "german"/
+// "english" — isoCode is the reliable, locale-independent signal. The title
+// fallback (checking both English and German spellings) only matters for
+// callers/tests that don't supply isoCode.
+function toLangCode(option: MainCommunicationLanguageOption): "de" | "en" | null {
+  if (option.isoCode === "de") return "de";
+  if (option.isoCode === "en") return "en";
+  const title = option.title.toLowerCase();
+  if (["german", "deutsch"].includes(title)) return "de";
+  if (["english", "englisch"].includes(title)) return "en";
+  return null;
+}
+
 // The org's main communication language is German, with English as the only
 // secondary option — unlike "Residents speak", which allows any language.
-// isoCode is preferred when the option list provides it; title matching is
-// the fallback for callers/tests that only supply id+title.
 export function getMainCommunicationLanguageOptions<T extends MainCommunicationLanguageOption>(apiLanguages: T[]): T[] {
-  return apiLanguages.filter((l) =>
-    l.isoCode ? ["de", "en"].includes(l.isoCode) : ["german", "english"].includes(l.title.toLowerCase()),
-  );
+  return apiLanguages.filter((l) => toLangCode(l) !== null);
 }
 
 export const createOpportunityDetailsSchema = (
@@ -44,19 +54,6 @@ export const createOpportunityDetailsSchema = (
       // be flagged, not silently dropped below, or it would incorrectly
       // read as "none selected" and pass validation.
       const hasUnresolved = resolved.some((option) => !option);
-
-      // `title` is translated into whatever language the option list was
-      // fetched in (German by default), so it's never the literal English
-      // word "german"/"english" — match on isoCode instead, falling back to
-      // both spellings only for callers/tests that don't supply isoCode.
-      const toLangCode = (option: MainCommunicationLanguageOption): "de" | "en" | null => {
-        if (option.isoCode === "de") return "de";
-        if (option.isoCode === "en") return "en";
-        const title = option.title.toLowerCase();
-        if (["german", "deutsch"].includes(title)) return "de";
-        if (["english", "englisch"].includes(title)) return "en";
-        return null;
-      };
       const codes = new Set(
         resolved.filter((option): option is MainCommunicationLanguageOption => !!option).map(toLangCode),
       );

--- a/src/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema.ts
@@ -36,18 +36,33 @@ export const createOpportunityDetailsSchema = (
       const selected = langs.filter(({ language }) => !!language);
       if (selected.length === 0) return; // nothing picked — always valid
 
-      const resolved = selected.map(
-        ({ language }) => resolveFormLanguageToOption(language, mainCommunicationLanguageOptions, t)?.title,
+      const resolved = selected.map(({ language }) =>
+        resolveFormLanguageToOption(language, mainCommunicationLanguageOptions, t),
       );
       // A row that fails to resolve is a legacy/out-of-set language (saved
       // before this restriction existed, or no longer offered) — that must
-      // be flagged, not silently dropped from the title set below, or it
-      // would incorrectly read as "none selected" and pass validation.
-      const hasUnresolved = resolved.some((title) => !title);
-      const titles = new Set(resolved.filter((title): title is string => !!title).map((title) => title.toLowerCase()));
-      const isGermanOnly = titles.size === 1 && titles.has("german");
-      const isGermanAndEnglish = titles.size === 2 && titles.has("german") && titles.has("english");
-      if (hasUnresolved || !(isGermanOnly || isGermanAndEnglish)) {
+      // be flagged, not silently dropped below, or it would incorrectly
+      // read as "none selected" and pass validation.
+      const hasUnresolved = resolved.some((option) => !option);
+
+      // `title` is translated into whatever language the option list was
+      // fetched in (German by default), so it's never the literal English
+      // word "german"/"english" — match on isoCode instead, falling back to
+      // both spellings only for callers/tests that don't supply isoCode.
+      const toLangCode = (option: MainCommunicationLanguageOption): "de" | "en" | null => {
+        if (option.isoCode === "de") return "de";
+        if (option.isoCode === "en") return "en";
+        const title = option.title.toLowerCase();
+        if (["german", "deutsch"].includes(title)) return "de";
+        if (["english", "englisch"].includes(title)) return "en";
+        return null;
+      };
+      const codes = new Set(
+        resolved.filter((option): option is MainCommunicationLanguageOption => !!option).map(toLangCode),
+      );
+      const isGermanOnly = codes.size === 1 && codes.has("de");
+      const isGermanAndEnglish = codes.size === 2 && codes.has("de") && codes.has("en");
+      if (hasUnresolved || codes.has(null) || !(isGermanOnly || isGermanAndEnglish)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: t(`${i18nPrefix}.mainCommunicationInvalid`),


### PR DESCRIPTION
## Summary
Fixes #840 (Activities and Skills selected on New Opportunity form don't get saved) — but not for the reason the issue suspected.

**What I found via live reproduction** (ran this branch's `fe` against real `be` code pointed at the actual dev DB, drove the New Opportunity form as a real agent user, and captured the real network requests):

- The issue's own theory — a title↔id round-trip bug in the activities/skills `EditableField` mapping — does **not** hold up. Confirmed via network capture: `activityIds`/`skillIds` are sent correctly and persist correctly on `GET /opportunity/:id` when the request actually reaches the server.
- The **real** bug: `createOpportunityDetailsSchema`'s `mainCommunication` zod validation compared the resolved language option's `title` — which is translated into whatever language the option list was fetched in (German by default, e.g. `"Deutsch"`/`"Englisch"`) — against the literal English words `"german"`/`"english"`. That comparison can never match, so **selecting any main-communication language makes the whole form permanently invalid**. The "Möglichkeit erstellen" button isn't disabled and nothing blocks the click, so clicking submit silently no-ops — no toast, no error, no network request, nothing. Confirmed live: with German selected + activities/skills picked, clicking submit fired **zero requests**; with the main-communication field left empty, the exact same activities/skills selections submitted and persisted correctly (201).

Since selecting German is the natural, expected first step for creating an opportunity, this plausibly explains the reported "selections don't save" symptom at least as well as a fields-level bug would — the user picks language + activities + skills, submission silently does nothing, and whatever eventually gets saved (if anything) was likely a different, later attempt that dropped fields along the way.

Same root-cause pattern as #839 (title vs. hardcoded English word), just in a different validation path that fix didn't touch.

## Fix
`mainCommunication`'s validation now matches on `isoCode` ("de"/"en") instead of the translated title, falling back to checking both English and German spellings only for callers/tests that don't supply `isoCode`.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` — no new issues (3 pre-existing unrelated warnings)
- [x] **Live-verified end-to-end**: ran this fix against real `be` code + the real dev DB (via SSH tunnel), created a Regular opportunity as a real agent user with German main-communication + 2 activities + 2 skills selected — got a 201, and `GET /opportunity/:id` confirmed all three (`languages`, `activities`, `skills`) persisted correctly. Test data cleaned up afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)