### PR TITLE
fix: main communication language must be German, English, or both

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1339,7 +1339,7 @@
           "descriptionTooLong": "Beschreibung ist zu lang",
           "numberOfVolunteersRequired": "Anzahl der Ehrenamtlichen muss mindestens 1 sein",
           "languageRequired": "Mindestens eine Sprache ist erforderlich",
-          "mainCommunicationInvalid": "Hauptkommunikation muss ausschließlich Deutsch oder Deutsch und Englisch sein",
+          "mainCommunicationInvalid": "Hauptkommunikation muss Deutsch, Englisch oder beides sein",
           "availabilityRequired": "Mindestens ein Zeitfenster muss ausgewählt werden",
           "activitiesRequired": "Mindestens eine Aktivität ist erforderlich",
           "skillsRequired": "Mindestens eine Fähigkeit ist erforderlich"

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1327,7 +1327,7 @@
           "descriptionTooLong": "Description is too long",
           "numberOfVolunteersRequired": "Number of volunteers must be at least 1",
           "languageRequired": "At least one language is required",
-          "mainCommunicationInvalid": "Main communication must be German only, or German and English",
+          "mainCommunicationInvalid": "Main communication must be German, English, or both",
           "availabilityRequired": "At least one time slot must be selected",
           "activitiesRequired": "At least one activity is required",
           "skillsRequired": "At least one skill is required"

--- a/src/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema.ts
@@ -14,14 +14,19 @@ const languageObjectSchema = z.object({
 
 type MainCommunicationLanguageOption = { id: number; title: string; isoCode?: string };
 
+// isoCode is preferred when the option supplies it — `title` is whatever the
+// option list was translated into (e.g. "Deutsch"/"Englisch" for a German
+// request), never reliably the literal English words "german"/"english", so
+// title matching is only a fallback for callers/tests that omit isoCode.
+const isGermanOption = (l: MainCommunicationLanguageOption): boolean =>
+  l.isoCode ? l.isoCode === "de" : l.title.toLowerCase() === "german";
+const isEnglishOption = (l: MainCommunicationLanguageOption): boolean =>
+  l.isoCode ? l.isoCode === "en" : l.title.toLowerCase() === "english";
+
 // The org's main communication language is German, with English as the only
 // secondary option — unlike "Residents speak", which allows any language.
-// isoCode is preferred when the option list provides it; title matching is
-// the fallback for callers/tests that only supply id+title.
 export function getMainCommunicationLanguageOptions<T extends MainCommunicationLanguageOption>(apiLanguages: T[]): T[] {
-  return apiLanguages.filter((l) =>
-    l.isoCode ? ["de", "en"].includes(l.isoCode) : ["german", "english"].includes(l.title.toLowerCase()),
-  );
+  return apiLanguages.filter((l) => isGermanOption(l) || isEnglishOption(l));
 }
 
 export const createOpportunityDetailsSchema = (
@@ -36,18 +41,15 @@ export const createOpportunityDetailsSchema = (
       const selected = langs.filter(({ language }) => !!language);
       if (selected.length === 0) return; // nothing picked — always valid
 
-      const resolved = selected.map(
-        ({ language }) => resolveFormLanguageToOption(language, mainCommunicationLanguageOptions, t)?.title,
+      const resolvedOptions = selected.map(({ language }) =>
+        resolveFormLanguageToOption(language, mainCommunicationLanguageOptions, t),
       );
-      // A row that fails to resolve is a legacy/out-of-set language (saved
-      // before this restriction existed, or no longer offered) — that must
-      // be flagged, not silently dropped from the title set below, or it
-      // would incorrectly read as "none selected" and pass validation.
-      const hasUnresolved = resolved.some((title) => !title);
-      const titles = new Set(resolved.filter((title): title is string => !!title).map((title) => title.toLowerCase()));
-      const isGermanOnly = titles.size === 1 && titles.has("german");
-      const isGermanAndEnglish = titles.size === 2 && titles.has("german") && titles.has("english");
-      if (hasUnresolved || !(isGermanOnly || isGermanAndEnglish)) {
+      // No restriction on German vs. English vs. both — either works. A row
+      // that fails to resolve is a legacy/out-of-set language (saved before
+      // the dropdown was restricted to German/English, or no longer
+      // offered) — that's still invalid, since only these two are offered.
+      const hasUnresolved = resolvedOptions.some((opt) => !opt);
+      if (hasUnresolved) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: t(`${i18nPrefix}.mainCommunicationInvalid`),


### PR DESCRIPTION
## Summary
- Regression fix for #839: the dropdown filter (`getMainCommunicationLanguageOptions`) was already fixed to match languages by `isoCode` instead of `title`, since `/option/language` always returns translated titles (e.g. "Deutsch"/"Englisch"), never the literal English words "german"/"english". But the validation logic a few lines below still compared the resolved **title** against those literal English words, so selecting German alone always failed validation in production — blocking every save.
- Also relaxes the business rule per product decision: German alone, English alone, or both are all valid now. There's no requirement that German be included — only an out-of-set/legacy language (outside what the dropdown offers) is rejected.
- Updated the validation error message (en/de) to match.

## Companion PR
`be#TBD` (`need4deed-org/be`) relaxes the equivalent server-side check in `assertValidMainCommunicationLanguages` to match — without it, the backend would still reject English-alone submissions with a 400 even after this fix.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [ ] Manually verify: create/edit an opportunity, select German alone → saves; English alone → saves; both → saves; nothing → saves; an out-of-set language (if reachable) → still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)