### PR TITLE
fix: enforce a consistent 8-day accompanying appointment lead time

### DIFF
--- a/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
+++ b/src/components/Dashboard/NewOpportunity/NewOpportunity.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/Dashboard/Profile/sections/OpportunityDetails/opportunityDetailsSchema";
 import { resolveFormLanguageToOption } from "@/components/Dashboard/Profile/sections/OpportunityDetails/formatters";
 import { AccompanyingDetailsEdit } from "@/components/Dashboard/Profile/sections/AccompanyingDetails/AccompanyingDetailsEdit";
+import { getMinAppointmentDate } from "@/components/Dashboard/Profile/sections/AccompanyingDetails/helpers";
 import { FormDetails } from "@/components/Dashboard/Profile/sections/shared/styles";
 import { BackButton, PageContainer } from "@/components/Dashboard/Profile/styles";
 import { IconName } from "@/components/Dashboard/Profile/types";
@@ -483,7 +484,7 @@ export function NewOpportunity() {
     appointmentLanguageKeyToLabel[key] = label;
     appointmentLanguageLabelToKey[label] = key;
   });
-  const minAppointmentDate = useMemo(() => new Date(), []);
+  const minAppointmentDate = useMemo(() => getMinAppointmentDate(), []);
 
   const { mutate: createOpportunity, isPending } = useMutationQuery<OpportunityFormDataWithAgentSubmitter, unknown>({
     apiPath: `${apiPathOpportunity}/`,

--- a/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
+++ b/src/components/Dashboard/Profile/sections/AccompanyingDetails/helpers.ts
@@ -16,16 +16,11 @@ export const isAccompanyingType = (volunteerType: VolunteerStateTypeType | undef
   );
 };
 
+// Matches the legacy form's rule: an accompanying appointment must be at
+// least 8 calendar days out (day+1 through day+7 are disallowed).
 export const getMinAppointmentDate = (): Date => {
   const date = new Date();
-  let weekdaysAdded = 0;
-  while (weekdaysAdded < 7) {
-    date.setDate(date.getDate() + 1);
-    const dayOfWeek = date.getDay();
-    if (dayOfWeek !== 0 && dayOfWeek !== 6) {
-      weekdaysAdded++;
-    }
-  }
+  date.setDate(date.getDate() + 8);
   date.setHours(0, 0, 0, 0);
   return date;
 };


### PR DESCRIPTION
## Summary
Three entry points for an Accompanying opportunity's appointment date each enforced a different rule:
- **New Opportunity creation**: no lead-time restriction at all — a coordinator/agent could pick tomorrow, or today.
- **Editing an existing opportunity's Accompanying Details** and **the "Change type → Accompanying" dialog**: both used `getMinAppointmentDate()`, which counted 7 *weekdays* ahead (skipping Sat/Sun) instead of a flat calendar-day offset — landing anywhere from 9 to 11 calendar days out depending on today's weekday, and shifting week to week.

None matched the legacy form's actual rule: exactly 8 calendar days from now, every time.

## Fix
- `getMinAppointmentDate()` now returns `today + 8 calendar days` (flat offset, no weekday counting).
- `NewOpportunity.tsx` now calls the same shared helper instead of a bare `new Date()`, so all three entry points enforce the identical rule from one place.

Verified downstream: `minAppointmentDate` feeds directly into each form's `DatePicker`'s `minDate` prop — a real UI constraint, not just a display hint — and there's no separate/duplicated day-offset check elsewhere (e.g. in the zod schema) that also needed updating.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` — no new issues (3 pre-existing unrelated warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)