### PR TITLE
fix: optional-chain opportunity.agent.id for consistency with sibling

### DIFF
--- a/src/hooks/useOpportunityProfileSections.tsx
+++ b/src/hooks/useOpportunityProfileSections.tsx
@@ -21,7 +21,7 @@ export const useOpportunityProfileSections = (opportunity: ApiOpportunityGet | u
   const { t, i18n } = useTranslation();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { isAuthorized, isOwnProfile } = useAuth(opportunity?.agent.id);
+  const { isAuthorized, isOwnProfile } = useAuth(opportunity?.agent?.id);
   const hasEditingRights = isAuthorized || isOwnProfile;
 
   const opportunityContactDetailsRef = useRef<EditableSectionRef>(null);


### PR DESCRIPTION
## Summary
Small follow-up to #846 — that PR correctly threaded `opportunity.agent.id` into `useAuth` for the Opportunity Profile's `isOwnProfile` check, but only optional-chained the outer `opportunity`, not `.agent` itself:

```diff
- const { isAuthorized, isOwnProfile } = useAuth(opportunity?.agent.id);
+ const { isAuthorized, isOwnProfile } = useAuth(opportunity?.agent?.id);
```

The SDK type declares `agent: ApiOpportunityAgent` as required, and I traced `be`'s DTO chain (including the orphanage-agent fallback) — it looks like `be` guarantees every opportunity resolves to *some* agent today, so this likely isn't reachable in practice right now. But this exact file's sibling, `OpportunityHeader.tsx`, already treats `opportunity.agent` as possibly absent at runtime in two places (`opportunity.agent?.id`, and an explicit cast + `?.id` guard before rendering the agent link) — so this brings the new call site in line with that established defensive convention instead of relying solely on the type contract holding, for a one-character-cheap safety margin.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` — no new issues (3 pre-existing unrelated warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)