### PR TITLE
Redirect already-logged-in users away from /register/agent

### DIFF
--- a/src/components/AgentRegistration/AgentRegistration.tsx
+++ b/src/components/AgentRegistration/AgentRegistration.tsx
@@ -1,9 +1,11 @@
 "use client";
 import { Button } from "@/components/core/button";
-import { apiPathUser } from "@/config/constants";
+import { apiPathUser, DashboardRoutes } from "@/config/constants";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 import axios from "axios";
 import { UserRole } from "need4deed-sdk";
-import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { validateRACEmail } from "@/components/forms/validators";
 import { validateStep } from "./helpers";
@@ -24,12 +26,19 @@ import { AgentRegistrationData, defaultAgentRegistrationData } from "./types";
 const PENDING_ROLE_COOKIE = "n4d_pending_role=agent; path=/; max-age=86400; SameSite=Lax; Secure";
 
 export function AgentRegistration() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const router = useRouter();
+  const user = useCurrentUser(true);
   const [formData, setFormData] = useState<AgentRegistrationData>(defaultAgentRegistrationData);
   const [errors, setErrors] = useState<Partial<Record<keyof AgentRegistrationData, string>>>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+    router.push(`/${i18n.language}${DashboardRoutes.Home}`);
+  }, [user, i18n.language, router]);
 
   const update = (fields: Partial<AgentRegistrationData>) => {
     setFormData((prev) => ({ ...prev, ...fields }));
@@ -85,6 +94,10 @@ export function AgentRegistration() {
       setIsSubmitting(false);
     }
   };
+
+  if (user) {
+    return null;
+  }
 
   if (isSuccess) {
     return (

--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -70,8 +70,16 @@ axios.interceptors.response.use(
 
       clearAuthHint();
 
-      // Only redirect if we aren't already on the login page to avoid loops
-      if (!(window.location.pathname.includes("login") || window.location.pathname.includes("forms"))) {
+      // Only redirect if we aren't already on a public auth-flow/form entry page
+      // (login, or a standalone form like forms/volunteer or register/agent) —
+      // those pages shouldn't be hijacked by a stale/expired session.
+      if (
+        !(
+          window.location.pathname.includes("login") ||
+          window.location.pathname.includes("forms") ||
+          window.location.pathname.includes("register")
+        )
+      ) {
         toast.error("Session expired. Please log in again.");
         window.location.href = "/login";
       }


### PR DESCRIPTION
## Summary
- `AgentRegistration.tsx` now checks `useCurrentUser()` on mount and redirects to `/${lang}/dashboard` if a user is already authenticated, instead of rendering the NGO signup form.
- Reuses the existing auth-hint-gated `useCurrentUser()` hook (same one `LoginController` uses), so no unnecessary `/me` requests fire for anonymous visitors.

Closes #852

## Test plan
- [x] `yarn typecheck` passes
- [x] `yarn lint` passes (no new warnings)
- [ ] Manually verify: logged-out visitor to `/de/register/agent` still sees the form
- [ ] Manually verify: logged-in visitor to `/de/register/agent` is redirected to `/de/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)