### PR TITLE
fix: briefed checkmark never showed in opportunity's volunteer accordion

### DIFF
--- a/src/components/Dashboard/Profile/sections/OpportunityVolunteers/AccordionVolunteer.tsx
+++ b/src/components/Dashboard/Profile/sections/OpportunityVolunteers/AccordionVolunteer.tsx
@@ -2,11 +2,7 @@ import { CheckCircleIcon } from "@phosphor-icons/react";
 import { Heading4 } from "@/components/styled/text";
 import { defaultAvatarVolunteerProfile } from "@/config/constants";
 import { getImageUrl } from "@/utils";
-import {
-  ApiVolunteerOpportunityGet,
-  OpportunityVolunteerStatusType,
-  VolunteerStateCommunicationType,
-} from "need4deed-sdk";
+import { ApiVolunteerOpportunityGet, OpportunityVolunteerStatusType } from "need4deed-sdk";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { isBriefedAccompanying } from "../ProfileHeader/common";
@@ -35,13 +31,9 @@ export const AccordionVolunteer = ({
 }: Props) => {
   const { t, i18n } = useTranslation();
   const router = useRouter();
-  const { volunteerId, name, avatarUrl, engagement, volunteeringType } = volunteer;
+  const { volunteerId, name, avatarUrl, engagement, volunteeringType, communication } = volunteer;
 
-  // TODO: remove cast once SDK adds statusCommunication to ApiVolunteerOpportunityGet
-  const { statusCommunication } = volunteer as ApiVolunteerOpportunityGet & {
-    statusCommunication?: VolunteerStateCommunicationType;
-  };
-  const showBriefedCheck = isBriefedAccompanying(volunteeringType, statusCommunication);
+  const showBriefedCheck = isBriefedAccompanying(volunteeringType, communication);
 
   const handleGoToProfile = () => {
     router.push(`/${i18n.language}/dashboard/volunteers/${volunteerId}`);


### PR DESCRIPTION
## Summary
Closes [#870](https://github.com/need4deed-org/fe/issues/870).

The briefed checkmark (from #433) works correctly on a volunteer's own profile header, but never rendered in the Opportunity profile's matched-volunteers accordion.

## Root cause
`AccordionVolunteer.tsx` destructured a fabricated `statusCommunication` field via a type-widening cast (`volunteer as ApiVolunteerOpportunityGet & { statusCommunication?: ... }`). The SDK's real field on `ApiVolunteerOpportunityGet` is named `communication`, not `statusCommunication` — so the destructure always resolved to `undefined`, and `isBriefedAccompanying()` silently returned `false` regardless of the volunteer's actual communication status. The stale TODO comment referenced an SDK PR that had already shipped, just under a different field name than assumed.

## Fix
Destructure the real `communication` field directly (no cast needed — `volunteer` is already properly typed as `ApiVolunteerOpportunityGet`) and pass it to `isBriefedAccompanying`.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` (clean on the touched file; 3 pre-existing warnings elsewhere are unrelated)
- [ ] No live backend available in this environment to click through in a browser — please verify a briefed accompanying volunteer now shows the checkmark in an opportunity's matched-volunteers accordion before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)