### PR TITLE
Make agent type/services language-sensitive

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "0.0.133",
+    "need4deed-sdk": "0.0.136",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
+++ b/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
@@ -40,10 +40,10 @@ function buildNewAgent(formData: ProfileCompletionData): ApiAgentRegisterNew {
     title: formData.organizationName,
     // `info`/`languages: number[]` follow the registration contract — these
     // deliberately differ from the agent PATCH shape (`about`/`OptionById[]`).
-    type: formData.organizationType || undefined,
+    typeId: formData.organizationType || undefined,
     info: formData.about || undefined,
     website: formData.website || undefined,
-    services: formData.services.length > 0 ? formData.services : undefined,
+    serviceIds: formData.services.length > 0 ? formData.services : undefined,
     addressStreet: formData.addressStreet || undefined,
     addressPostcode: formData.addressPostcode || undefined,
     districtId: formData.districtId ?? undefined,
@@ -254,7 +254,9 @@ export function ProfileCompletion() {
             </div>
           ))}
 
-        {!isJoining && step === 2 && <OrgInfoStep data={formData} onChange={update} errors={errors} />}
+        {!isJoining && step === 2 && (
+          <OrgInfoStep data={formData} onChange={update} errors={errors} optionLists={optionLists} />
+        )}
         {!isJoining && step === 3 && <ServicesStep data={formData} onChange={update} optionLists={optionLists} />}
 
         <Actions>

--- a/src/components/AgentRegistration/helpers.ts
+++ b/src/components/AgentRegistration/helpers.ts
@@ -1,31 +1,4 @@
-import { AgentServiceType, AgentType } from "need4deed-sdk";
 import { AgentRegistrationData, ProfileCompletionData } from "./types";
-
-export const AGENT_TYPE_LABELS: Record<AgentType, string> = {
-  [AgentType.AE]: "AE",
-  [AgentType.GU1]: "GU1",
-  [AgentType.GU2]: "GU2",
-  [AgentType.GU2_PLUS]: "GU2+",
-  [AgentType.GU3]: "GU3",
-  [AgentType.NU]: "NU",
-  [AgentType.ASOG]: "ASOG",
-  [AgentType.COUNSELING_CENTER]: "Counseling Center",
-  [AgentType.TANDEM]: "Tandem",
-  [AgentType.MULTIPLE_SOCIAL_SUPPORT]: "Multiple Social Support",
-};
-
-export const AGENT_SERVICE_LABELS: Record<AgentServiceType, string> = {
-  [AgentServiceType.CHILDCARE]: "Childcare",
-  [AgentServiceType.WELFARE]: "Welfare",
-  [AgentServiceType.CONSULTATION]: "Consultation",
-  [AgentServiceType.VOLUNTARY_SUPPORT]: "Voluntary Support",
-  [AgentServiceType.TANDEM]: "Tandem",
-  [AgentServiceType.SPORT]: "Sport",
-  [AgentServiceType.TUTORING]: "Tutoring",
-  [AgentServiceType.REFUGEE_ACCOMMODATION]: "Refugee Accommodation",
-  [AgentServiceType.JOB_COACHING]: "Job Coaching",
-  [AgentServiceType.YOUTH]: "Youth",
-};
 
 export function validateStep(
   step: number,

--- a/src/components/AgentRegistration/steps/OrgInfoStep.tsx
+++ b/src/components/AgentRegistration/steps/OrgInfoStep.tsx
@@ -1,8 +1,7 @@
 "use client";
 import { FormInput } from "@/components/core/common";
-import { AgentType } from "need4deed-sdk";
+import { ApiOptionLists, EntityTableName } from "need4deed-sdk";
 import { useTranslation } from "react-i18next";
-import { AGENT_TYPE_LABELS } from "../helpers";
 import { FieldLabel, FieldWrapper, StepDescription, StepTitle, StyledSelect, StyledTextarea } from "../styled";
 import { ProfileCompletionData } from "../types";
 
@@ -12,10 +11,12 @@ type Props = {
   data: OrgData;
   onChange: (fields: Partial<OrgData>) => void;
   errors: Partial<Record<string, string>>;
+  optionLists?: ApiOptionLists;
 };
 
-export function OrgInfoStep({ data, onChange, errors }: Props) {
+export function OrgInfoStep({ data, onChange, errors, optionLists }: Props) {
   const { t } = useTranslation();
+  const agentTypes = optionLists?.[EntityTableName.AGENT_TYPE] ?? [];
 
   return (
     <div>
@@ -36,13 +37,13 @@ export function OrgInfoStep({ data, onChange, errors }: Props) {
         <FieldLabel>{t("agentRegistration.fields.organizationType")}</FieldLabel>
         <StyledSelect
           value={data.organizationType}
-          onChange={(e) => onChange({ organizationType: e.target.value as AgentType })}
+          onChange={(e) => onChange({ organizationType: e.target.value ? Number(e.target.value) : "" })}
           $hasError={!!errors.organizationType}
         >
           <option value="">{t("agentRegistration.fields.selectOrganizationType")}</option>
-          {Object.values(AgentType).map((type) => (
-            <option key={type} value={type}>
-              {AGENT_TYPE_LABELS[type]}
+          {agentTypes.map((type) => (
+            <option key={type.id} value={type.id}>
+              {type.title}
             </option>
           ))}
         </StyledSelect>

--- a/src/components/AgentRegistration/steps/ServicesStep.tsx
+++ b/src/components/AgentRegistration/steps/ServicesStep.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { ApiOptionLists, AgentServiceType, EntityTableName } from "need4deed-sdk";
+import { ApiOptionLists, EntityTableName } from "need4deed-sdk";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { FieldLabel, FieldWrapper, StepDescription, StepTitle } from "../styled";
@@ -38,11 +38,12 @@ type Props = {
 export function ServicesStep({ data, onChange, optionLists }: Props) {
   const { t } = useTranslation();
   const languages = optionLists?.[EntityTableName.LANGUAGE] ?? [];
+  const services = optionLists?.[EntityTableName.SERVICE] ?? [];
 
-  const toggleService = (service: AgentServiceType) => {
-    const updated = data.services.includes(service)
-      ? data.services.filter((s) => s !== service)
-      : [...data.services, service];
+  const toggleService = (serviceId: number) => {
+    const updated = data.services.includes(serviceId)
+      ? data.services.filter((s) => s !== serviceId)
+      : [...data.services, serviceId];
     onChange({ services: updated });
   };
 
@@ -61,14 +62,14 @@ export function ServicesStep({ data, onChange, optionLists }: Props) {
       <FieldWrapper>
         <FieldLabel>{t("agentRegistration.fields.services")}</FieldLabel>
         <CheckboxGrid>
-          {Object.values(AgentServiceType).map((service) => (
-            <CheckboxLabel key={service}>
+          {services.map((service) => (
+            <CheckboxLabel key={service.id}>
               <input
                 type="checkbox"
-                checked={data.services.includes(service)}
-                onChange={() => toggleService(service)}
+                checked={data.services.includes(service.id)}
+                onChange={() => toggleService(service.id)}
               />
-              {t(`dashboard.agents.filters.services.${service}`, { defaultValue: service })}
+              {service.title}
             </CheckboxLabel>
           ))}
         </CheckboxGrid>

--- a/src/components/AgentRegistration/types.ts
+++ b/src/components/AgentRegistration/types.ts
@@ -1,21 +1,14 @@
-import { AgentServiceType, AgentType } from "need4deed-sdk";
+import { ApiAgentRegisterNew } from "need4deed-sdk";
 
-// These types are not yet in need4deed-sdk — defined locally until the SDK is updated.
+export type { ApiAgentRegisterNew };
+
+// AgentMembershipStatus/ApiAgentRegisterResponse/ApiAgentMembership* are not
+// yet in need4deed-sdk (or differ slightly in optionality) — defined locally
+// until the SDK is updated. ApiAgentRegisterNew above IS in the SDK now
+// (typeId/serviceIds, not the old type/services enum fields).
 export enum AgentMembershipStatus {
   PENDING = "pending",
   ACTIVE = "active",
-}
-
-export interface ApiAgentRegisterNew {
-  title: string;
-  type?: AgentType;
-  info?: string;
-  website?: string;
-  services?: AgentServiceType[];
-  addressStreet?: string;
-  addressPostcode?: string;
-  districtId?: number;
-  languages?: number[];
 }
 
 export type ApiAgentRegister = { agent: ApiAgentRegisterNew } | { agentId: number };
@@ -52,10 +45,13 @@ export interface ProfileCompletionData {
   addressPostcode: string;
   districtId: number | null;
   organizationName: string;
-  organizationType: AgentType | "";
+  // AgentType option id, picked from GET /option's agent_type list — like
+  // clientLanguageIds below, ids rather than a translated title, since this
+  // step already has the full {id,title} option objects to pick from.
+  organizationType: number | "";
   about: string;
   website: string;
-  services: AgentServiceType[];
+  services: number[];
   clientLanguageIds: number[];
 }
 

--- a/src/components/Dashboard/Agents/AgentCard.tsx
+++ b/src/components/Dashboard/Agents/AgentCard.tsx
@@ -2,7 +2,7 @@
 
 import { MapPinIcon } from "@phosphor-icons/react";
 import { AgentTrustLevel } from "@/components/Dashboard/Profile/types/agent";
-import type { ApiAgentGetList, OptionItem } from "need4deed-sdk";
+import type { ApiAgentGetList, Lang, OptionItem } from "need4deed-sdk";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
 import { IconDiv } from "@/components/styled/container";
@@ -11,10 +11,11 @@ import {
   TRUST_LEVEL_OPTIONS,
 } from "@/components/Dashboard/Profile/sections/ProfileHeader/agent/constants";
 import { TrustLevelDropdown } from "@/components/Dashboard/Profile/sections/ProfileHeader/agent/TrustLevelDropdown";
+import { extractOptionTitle } from "@/components/Dashboard/Profile/sections/OpportunityDetails/formatters";
 import { Heading4, Paragraph } from "@/components/styled/text";
 import { useUpdateAgentStatus } from "@/hooks";
 import { getNormalizedAgent } from "./helpers";
-import { createAgentTypeMap, createServiceTypeMap, createVolunteerSearchMap } from "./constants";
+import { createVolunteerSearchMap } from "./constants";
 import { StatusBadge } from "../common/StatusBadge";
 import { Card, CardDetailsInfo, CardHeader, CardHeaderInfo, DistrictContainer, DistrictDiv } from "./styles";
 
@@ -26,15 +27,14 @@ interface Props {
 export const AgentCard = ({ agent, districtsList }: Props) => {
   const { t, i18n } = useTranslation();
 
-  const { id, title, district, volunteerSearch, serviceType, type, trustLevel } = getNormalizedAgent(agent);
+  const { id, title, district, volunteerSearch, services, type, trustLevel } = getNormalizedAgent(agent);
   const districtTitle = district?.id ? (districtsList?.find((d) => d.id === district.id)?.title ?? null) : null;
+  const lang = i18n.language as Lang;
 
   const { mutate: patchAgent } = useUpdateAgentStatus(agent.id);
 
   const volunteerSearchLabels = createVolunteerSearchMap(t);
   const trustLevelLabels = createTrustLevelLabelMap(t);
-  const serviceTypeLabels = createServiceTypeMap(t);
-  const agentTypeLabels = createAgentTypeMap(t);
 
   const profileUrl = id ? `/${i18n.language}/dashboard/agents/${id}` : "";
 
@@ -51,7 +51,7 @@ export const AgentCard = ({ agent, districtsList }: Props) => {
       </CardHeader>
       <CardDetailsInfo>
         <Heading4>{t("dashboard.agentProfile.type")}</Heading4>
-        <Paragraph> {agentTypeLabels[type]}</Paragraph>
+        <Paragraph> {extractOptionTitle(type, lang)}</Paragraph>
       </CardDetailsInfo>
       <CardDetailsInfo>
         <Heading4>{t("dashboard.agentProfile.volunteerSearch")}</Heading4>
@@ -66,11 +66,11 @@ export const AgentCard = ({ agent, districtsList }: Props) => {
           onChange={handleTrustLevelChange}
         />
       </CardDetailsInfo>
-      {serviceType?.length
-        ? serviceType?.map((service) => (
-            <CardDetailsInfo key={service}>
+      {services?.length
+        ? services.map((service) => (
+            <CardDetailsInfo key={service.id}>
               <Heading4>{t("dashboard.agentProfile.serviceType")}</Heading4>
-              <Paragraph>{serviceTypeLabels[service]}</Paragraph>
+              <Paragraph>{extractOptionTitle(service, lang)}</Paragraph>
             </CardDetailsInfo>
           ))
         : null}

--- a/src/components/Dashboard/Agents/AgentReadOnlyCard.tsx
+++ b/src/components/Dashboard/Agents/AgentReadOnlyCard.tsx
@@ -3,7 +3,8 @@ import { IconDiv } from "@/components/styled/container";
 import { Heading4, Paragraph } from "@/components/styled/text";
 import { Card, CardDetailsInfo, CardHeader, CardHeaderInfo, DistrictContainer, DistrictDiv } from "./styles";
 import { useTranslation } from "react-i18next";
-import { ApiAgentGetList, OptionItem } from "need4deed-sdk";
+import { ApiAgentGetList, Lang, OptionItem } from "need4deed-sdk";
+import { extractOptionTitle } from "@/components/Dashboard/Profile/sections/OpportunityDetails/formatters";
 
 interface Props {
   agent: ApiAgentGetList;
@@ -11,9 +12,10 @@ interface Props {
 }
 
 export const AgentReadOnlyCard = ({ agent, districtsList }: Props) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { title, district, type } = agent;
   const districtTitle = district?.id ? (districtsList?.find((d) => d.id === district.id)?.title ?? null) : null;
+  const lang = i18n.language as Lang;
   return (
     <Card $cursor="auto">
       <CardHeader>
@@ -23,7 +25,7 @@ export const AgentReadOnlyCard = ({ agent, districtsList }: Props) => {
       </CardHeader>
       <CardDetailsInfo>
         <Heading4>{t("dashboard.agentProfile.type")}</Heading4>
-        <Paragraph> {type}</Paragraph>
+        <Paragraph> {extractOptionTitle(type, lang)}</Paragraph>
       </CardDetailsInfo>
       <DistrictContainer>
         <DistrictDiv>

--- a/src/components/Dashboard/Agents/AgentReadOnlyTableRow.tsx
+++ b/src/components/Dashboard/Agents/AgentReadOnlyTableRow.tsx
@@ -1,22 +1,24 @@
-import { ApiAgentGetList, OptionItem } from "need4deed-sdk";
+import { ApiAgentGetList, Lang, OptionItem } from "need4deed-sdk";
+import { useTranslation } from "react-i18next";
 import { ClickableRow, TableCell } from "@/components/core/common/Table";
+import { extractOptionTitle } from "@/components/Dashboard/Profile/sections/OpportunityDetails/formatters";
 
 interface Props {
   agent: ApiAgentGetList;
   isLast: boolean;
-  typeLabels: Record<string, string>;
-  searchLabels: Record<string, string>;
   districtsList?: OptionItem[];
 }
 
 export function AgentReadOnlyTableRow({ agent, isLast, districtsList }: Props) {
+  const { i18n } = useTranslation();
   const { id, title, type, district } = agent;
   const districtTitle = district?.id ? (districtsList?.find((d) => d.id === district.id)?.title ?? null) : null;
+  const lang = i18n.language as Lang;
 
   return (
     <ClickableRow $isLast={isLast} $cursor={"auto"} data-testid={`agent-row-${id}`}>
       <TableCell data-testid={`agent-title-${id}`}>{title}</TableCell>
-      <TableCell data-testid={`agent-type-${id}`}>{type}</TableCell>
+      <TableCell data-testid={`agent-type-${id}`}>{extractOptionTitle(type, lang)}</TableCell>
       <TableCell data-testid={`agent-district-${id}`}>{districtTitle || "—"}</TableCell>
     </ClickableRow>
   );

--- a/src/components/Dashboard/Agents/AgentTableList.tsx
+++ b/src/components/Dashboard/Agents/AgentTableList.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { createAgentTableColumns, createReadOnlyAgentTableColumns } from "./agentsTableColumns";
 import { useMemo } from "react";
 import { AgentTableRow } from "./AgentTableRow";
-import { createAgentTypeMap, createVolunteerSearchMap } from "./constants";
+import { createVolunteerSearchMap } from "./constants";
 import { CopyButton } from "../common/CopyButton";
 import { AgentReadOnlyTableRow } from "./AgentReadOnlyTableRow";
 import { useAuth } from "@/hooks/useAuth";
@@ -47,7 +47,6 @@ export function AgentTableList({
     return createAgentTableColumns(t, copyButton);
   }, [t, onCopyEmails, isCopying]);
   const readOnlyColumns = useMemo(() => createReadOnlyAgentTableColumns(t), [t]);
-  const typeLabels = useMemo(() => createAgentTypeMap(t), [t]);
   const searchLabels = useMemo(() => createVolunteerSearchMap(t), [t]);
 
   return (
@@ -60,19 +59,11 @@ export function AgentTableList({
             key={agent.id}
             agent={agent}
             isLast={isLast}
-            typeLabels={typeLabels}
             searchLabels={searchLabels}
             districtsList={districtsList}
           />
         ) : (
-          <AgentReadOnlyTableRow
-            key={agent.id}
-            agent={agent}
-            isLast={isLast}
-            typeLabels={typeLabels}
-            searchLabels={searchLabels}
-            districtsList={districtsList}
-          />
+          <AgentReadOnlyTableRow key={agent.id} agent={agent} isLast={isLast} districtsList={districtsList} />
         )
       }
       count={count}

--- a/src/components/Dashboard/Agents/AgentTableRow.tsx
+++ b/src/components/Dashboard/Agents/AgentTableRow.tsx
@@ -1,26 +1,27 @@
 "use client";
 
-import type { ApiAgentGetList, OptionItem } from "need4deed-sdk";
+import type { ApiAgentGetList, Lang, OptionItem } from "need4deed-sdk";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
 import { AGENT_COL_WIDTHS } from "./agentsTableColumns";
 import { ClickableRow, TableCell } from "@/components/core/common/Table";
 import { WrapAnywhereCell } from "../common/EntityTableList/styles";
 import { CopyEmail } from "../common/CopyEmail";
+import { extractOptionTitle } from "@/components/Dashboard/Profile/sections/OpportunityDetails/formatters";
 
 interface TableRowProps {
   agent: ApiAgentGetList;
   isLast: boolean;
-  typeLabels: Record<string, string>;
   searchLabels: Record<string, string>;
   districtsList?: OptionItem[];
 }
 
-export function AgentTableRow({ agent, isLast, typeLabels, searchLabels, districtsList }: TableRowProps) {
+export function AgentTableRow({ agent, isLast, searchLabels, districtsList }: TableRowProps) {
   const { i18n } = useTranslation();
 
   const { id, title, type, volunteerSearch, district, activeVolunteers, numOpportunities, email } = agent;
   const districtTitle = district?.id ? (districtsList?.find((d) => d.id === district.id)?.title ?? null) : null;
+  const lang = i18n.language as Lang;
 
   const profileUrl = id ? `/${i18n.language}/dashboard/agents/${id}` : "";
 
@@ -30,7 +31,7 @@ export function AgentTableRow({ agent, isLast, typeLabels, searchLabels, distric
         {title}
       </TableCell>
       <TableCell $width={AGENT_COL_WIDTHS.type} data-testid={`agent-type-${id}`}>
-        {typeLabels[type] || type}
+        {extractOptionTitle(type, lang)}
       </TableCell>
       <TableCell $width={AGENT_COL_WIDTHS.volunteerSearch} data-testid={`agent-search-${id}`}>
         {searchLabels[volunteerSearch] || volunteerSearch}

--- a/src/components/Dashboard/Agents/Agents.tsx
+++ b/src/components/Dashboard/Agents/Agents.tsx
@@ -77,6 +77,8 @@ export const Agents = () => {
       const baseFilters = {
         ...prev,
         district: createFilterFromOption(apiFilterOptions, EntityTableName.DISTRICT),
+        type: createFilterFromOption(apiFilterOptions, EntityTableName.AGENT_TYPE),
+        services: createFilterFromOption(apiFilterOptions, EntityTableName.SERVICE),
       };
 
       return deserializeAgentFilters(baseFilters, searchParams);

--- a/src/components/Dashboard/Agents/Filters/constants.ts
+++ b/src/components/Dashboard/Agents/Filters/constants.ts
@@ -1,27 +1,13 @@
-import {
-  AgentEngagementStatusType,
-  AgentServiceType,
-  AgentType,
-  AgentVolunteerSearchType,
-  QueryParamsKeys,
-} from "need4deed-sdk";
+import { AgentEngagementStatusType, AgentVolunteerSearchType, QueryParamsKeys } from "need4deed-sdk";
 import { AgentCardsFilter } from "./types";
 
+// `type`/`services` are populated dynamically from GET /option (like
+// `district` below) once the translated AgentType/Service lists load — see
+// Agents.tsx's useEffect — rather than hardcoded from an enum.
 export const defaultAgentCardsFilter: AgentCardsFilter = {
   [QueryParamsKeys.SEARCH]: "",
   [QueryParamsKeys.DISTRICT]: {},
-  type: {
-    [AgentType.AE]: false,
-    [AgentType.ASOG]: false,
-    [AgentType.COUNSELING_CENTER]: false,
-    [AgentType.GU1]: false,
-    [AgentType.GU2]: false,
-    [AgentType.GU2_PLUS]: false,
-    [AgentType.GU3]: false,
-    [AgentType.MULTIPLE_SOCIAL_SUPPORT]: false,
-    [AgentType.NU]: false,
-    [AgentType.TANDEM]: false,
-  },
+  type: {},
   volunteerSearch: {
     [AgentVolunteerSearchType.SEARCHING]: false,
     [AgentVolunteerSearchType.NOT_NEEDED]: false,
@@ -33,16 +19,5 @@ export const defaultAgentCardsFilter: AgentCardsFilter = {
     [AgentEngagementStatusType.ACTIVE]: false,
     [AgentEngagementStatusType.UNRESPONSIVE]: false,
   },
-  services: {
-    [AgentServiceType.CHILDCARE]: false,
-    [AgentServiceType.CONSULTATION]: false,
-    [AgentServiceType.JOB_COACHING]: false,
-    [AgentServiceType.REFUGEE_ACCOMMODATION]: false,
-    [AgentServiceType.SPORT]: false,
-    [AgentServiceType.TANDEM]: false,
-    [AgentServiceType.TUTORING]: false,
-    [AgentServiceType.VOLUNTARY_SUPPORT]: false,
-    [AgentServiceType.WELFARE]: false,
-    [AgentServiceType.YOUTH]: false,
-  },
+  services: {},
 };

--- a/src/components/Dashboard/Agents/Filters/helpers.ts
+++ b/src/components/Dashboard/Agents/Filters/helpers.ts
@@ -16,14 +16,16 @@ export const createAgentFilterItems = (
     (key) => key,
   );
 
+  // `key` is already the translated title from GET /option (see
+  // Agents.tsx's createFilterFromOption), not an enum value — no i18n
+  // lookup needed. "Tandem" happens to be both an agent type and a
+  // service, so disambiguate the type one with a "Type" prefix.
   const typeFilters = generateNestedFilterControlItems(filter.type, setFilter, "type", (key, parent) => {
-    const fallbackPath = `dashboard.agents.filters.type.${key.toLocaleLowerCase()}`;
-
-    if (key === "tandem" && parent === "type") {
-      return `${t("dashboard.agents.table.type")} ${t(fallbackPath)}`;
+    if (key.toLowerCase() === "tandem" && parent === "type") {
+      return `${t("dashboard.agents.table.type")} ${key}`;
     }
 
-    return t(fallbackPath);
+    return key;
   });
 
   const volunteerSearchFilters = generateNestedFilterControlItems(
@@ -40,9 +42,8 @@ export const createAgentFilterItems = (
     (key) => t(`dashboard.agents.filters.engagementStatus.${key}`),
   );
 
-  const servicesFilters = generateNestedFilterControlItems(filter.services, setFilter, "services", (key) =>
-    t(`dashboard.agents.filters.services.${key}`),
-  );
+  // Same as `type` above: `key` is already the translated title.
+  const servicesFilters = generateNestedFilterControlItems(filter.services, setFilter, "services", (key) => key);
 
   return {
     districtFilters,

--- a/src/components/Dashboard/Agents/constants.ts
+++ b/src/components/Dashboard/Agents/constants.ts
@@ -1,34 +1,8 @@
-import { AgentServiceType, AgentType, AgentVolunteerSearchType } from "need4deed-sdk";
+import { AgentVolunteerSearchType } from "need4deed-sdk";
 import { TFunction } from "i18next";
-
-export const createAgentTypeMap = (t: TFunction): Record<AgentType, string> => ({
-  [AgentType.AE]: t("dashboard.agents.filters.type.ae"),
-  [AgentType.ASOG]: t("dashboard.agents.filters.type.asog"),
-  [AgentType.COUNSELING_CENTER]: t("dashboard.agents.filters.type.counseling-center"),
-  [AgentType.GU1]: t("dashboard.agents.filters.type.gu1"),
-  [AgentType.GU2]: t("dashboard.agents.filters.type.gu2"),
-  [AgentType.GU2_PLUS]: t("dashboard.agents.filters.type.gu2+"),
-  [AgentType.GU3]: t("dashboard.agents.filters.type.gu3"),
-  [AgentType.MULTIPLE_SOCIAL_SUPPORT]: t("dashboard.agents.filters.type.multiple-social-support"),
-  [AgentType.NU]: t("dashboard.agents.filters.type.nu"),
-  [AgentType.TANDEM]: t("dashboard.agents.filters.type.tandem"),
-});
 
 export const createVolunteerSearchMap = (t: TFunction): Record<AgentVolunteerSearchType, string> => ({
   [AgentVolunteerSearchType.SEARCHING]: t("dashboard.agentProfile.status.volunteerSearch.searching"),
   [AgentVolunteerSearchType.NOT_NEEDED]: t("dashboard.agentProfile.status.volunteerSearch.notNeeded"),
   [AgentVolunteerSearchType.VOLUNTEERS_FOUND]: t("dashboard.agentProfile.status.volunteerSearch.filled"),
-});
-
-export const createServiceTypeMap = (t: TFunction): Record<AgentServiceType, string> => ({
-  [AgentServiceType.CHILDCARE]: t("dashboard.agentProfile.status.serviceType.childcare"),
-  [AgentServiceType.CONSULTATION]: t("dashboard.agentProfile.status.serviceType.consultation"),
-  [AgentServiceType.JOB_COACHING]: t("dashboard.agentProfile.status.serviceType.jobCoaching"),
-  [AgentServiceType.REFUGEE_ACCOMMODATION]: t("dashboard.agentProfile.status.serviceType.refugeeAccommodation"),
-  [AgentServiceType.SPORT]: t("dashboard.agentProfile.status.serviceType.sport"),
-  [AgentServiceType.TANDEM]: t("dashboard.agentProfile.status.serviceType.tandem"),
-  [AgentServiceType.TUTORING]: t("dashboard.agentProfile.status.serviceType.tutoring"),
-  [AgentServiceType.VOLUNTARY_SUPPORT]: t("dashboard.agentProfile.status.serviceType.volunteerSupport"),
-  [AgentServiceType.WELFARE]: t("dashboard.agentProfile.status.serviceType.welfare"),
-  [AgentServiceType.YOUTH]: t("dashboard.agentProfile.status.serviceType.youth"),
 });

--- a/src/components/Dashboard/Agents/helpers.ts
+++ b/src/components/Dashboard/Agents/helpers.ts
@@ -1,13 +1,14 @@
 import {
   AgentVolunteerSearchType,
   ApiAgentGetList,
-  AgentServiceType,
   ApiOptionLists,
   AgentTrustType,
   ApiAgentGet,
   OptionById,
   QueryParamsKeys,
   AgentType,
+  Service,
+  EntityTableName,
 } from "need4deed-sdk";
 
 import { ReadonlyURLSearchParams } from "next/navigation";
@@ -17,13 +18,13 @@ type AgentListItem = ApiAgentGetList & Partial<ApiAgentGet>;
 
 export function getNormalizedAgent(agent: AgentListItem): Omit<
   AgentListItem,
-  "district" | "volunteerSearch" | "type" | "trustLevel" | "serviceType"
+  "district" | "volunteerSearch" | "type" | "trustLevel" | "services"
 > & {
   district: OptionById | undefined;
   volunteerSearch: AgentVolunteerSearchType;
   type: AgentType;
   trustLevel: AgentTrustType;
-  serviceType: AgentServiceType[] | undefined;
+  services: Service[] | undefined;
 } {
   return {
     ...agent,
@@ -31,7 +32,7 @@ export function getNormalizedAgent(agent: AgentListItem): Omit<
     district: agent.district ?? undefined,
     volunteerSearch: agent.volunteerSearch ?? AgentVolunteerSearchType.NOT_NEEDED,
     trustLevel: agent.trustLevel ? agent.trustLevel : AgentTrustType.UNKNOWN,
-    serviceType: agent.serviceType ?? undefined,
+    services: agent.services ?? undefined,
   };
 }
 
@@ -64,7 +65,11 @@ export function serializeAgentFilters(
   params.delete("type");
   Object.entries(filter.type).forEach(([key, value]) => {
     if (value === true) {
-      params.append("type", key);
+      const paramValue =
+        (options?.serializeToIDs &&
+          options.apiFilterOptions?.[EntityTableName.AGENT_TYPE]?.find((d) => d.title === key)?.id) ||
+        key;
+      params.append("type", String(paramValue));
     }
   });
 
@@ -85,7 +90,11 @@ export function serializeAgentFilters(
   params.delete("services");
   Object.entries(filter.services).forEach(([key, value]) => {
     if (value === true) {
-      params.append("services", key);
+      const paramValue =
+        (options?.serializeToIDs &&
+          options.apiFilterOptions?.[EntityTableName.SERVICE]?.find((d) => d.title === key)?.id) ||
+        key;
+      params.append("services", String(paramValue));
     }
   });
 

--- a/src/components/Dashboard/Profile/sections/OpportunityDetails/formatters.ts
+++ b/src/components/Dashboard/Profile/sections/OpportunityDetails/formatters.ts
@@ -26,13 +26,13 @@ export function formatLanguagesByPurpose(
     .join(", ");
 }
 
+export function extractOptionTitle(item: OptionById | undefined, lang: Lang): string {
+  if (!item?.title) return "";
+  return item.title[lang] ?? item.title[Lang.EN] ?? "";
+}
+
 export function extractOptionTitles(items: OptionById[], lang: Lang): string[] {
-  return items
-    .map((item) => {
-      if (!item.title) return "";
-      return item.title[lang] ?? item.title[Lang.EN] ?? "";
-    })
-    .filter(Boolean);
+  return items.map((item) => extractOptionTitle(item, lang)).filter(Boolean);
 }
 
 // Resolves a language form value back to its API option — the value is

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetails.tsx
@@ -1,9 +1,14 @@
 "use client";
-import { useApiLanguages } from "@/components/Dashboard/Profile/sections/VolunteerProfile/hooks";
+import {
+  useApiAgentTypes,
+  useApiLanguages,
+  useApiServices,
+} from "@/components/Dashboard/Profile/sections/VolunteerProfile/hooks";
+import { createMapping } from "@/components/Dashboard/Profile/sections/VolunteerProfile/mappingUtils";
 import { ApiAgentProfileGet } from "@/components/Dashboard/Profile/types";
 import { useUpdateOrganization } from "@/hooks/useUpdateOrganizationDetails";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { forwardRef, useImperativeHandle, useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FormContainer } from "../shared/styles";
@@ -28,20 +33,37 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
 
   useEditingChangeNotifier(isEditing, onEditingChange);
   const { data: apiLanguages } = useApiLanguages();
+  const { data: apiAgentTypes = [] } = useApiAgentTypes();
+  const { data: apiServices = [] } = useApiServices();
+  const agentTypeMapping = useMemo(() => createMapping(apiAgentTypes), [apiAgentTypes]);
+  const serviceMapping = useMemo(() => createMapping(apiServices), [apiServices]);
 
   const details = agent.agentDetails;
   const languagesForForm = toLanguagesForForm(apiLanguages, i18n.language);
   const schema = createOrganisationDetailsSchema(t);
 
-  const initialFormValues = {
-    ...details,
-    title: agent.title || "",
-    website: details?.website || "",
-    operator: details?.operator || agent.operator || "",
-    clientLanguages: apiLanguagesToFormValues(details?.clientLanguages),
-    addressStreet: details?.addressStreet ?? "",
-    addressPostcode: details?.addressPostcode ?? "",
-  };
+  // organizationType/services come back from GET /agent as { id, title: {en,de} }
+  // (both languages at once); resolve by id to the title already translated to
+  // the current UI language by the fetched AgentType/Service option lists, so
+  // the picker's options and the pre-selected value use the same strings.
+  const initialFormValues = useMemo(
+    () => ({
+      ...details,
+      title: agent.title || "",
+      website: details?.website || "",
+      operator: details?.operator || agent.operator || "",
+      clientLanguages: apiLanguagesToFormValues(details?.clientLanguages),
+      addressStreet: details?.addressStreet ?? "",
+      addressPostcode: details?.addressPostcode ?? "",
+      organizationType: details?.organizationType?.id
+        ? (agentTypeMapping.idToTitle[Number(details.organizationType.id)] ?? "")
+        : "",
+      services: (details?.services ?? [])
+        .map((service) => (service.id ? serviceMapping.idToTitle[Number(service.id)] : undefined))
+        .filter((title): title is string => Boolean(title)),
+    }),
+    [details, agent.title, agent.operator, agentTypeMapping, serviceMapping],
+  );
 
   const methods = useForm<OrganisationDetailsFormData>({
     resolver: zodResolver(schema),
@@ -55,12 +77,26 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
 
   useImperativeHandle(ref, () => ({ handleEditClick }));
 
+  // apiAgentTypes/apiServices resolve asynchronously after the form's initial
+  // mount, so the id->title lookups above are still empty when useForm first
+  // captures defaultValues (RHF freezes them at mount). Re-sync once the real
+  // data arrives, matching the pattern in RefugeeAccommodationCentre.tsx.
+  useEffect(() => {
+    if (isEditing) return;
+    reset(initialFormValues);
+  }, [initialFormValues, isEditing, reset]);
+
   const handleCancel = () => {
     reset();
     setIsEditing(false);
   };
 
   const onSubmit = (values: OrganisationDetailsFormData) => {
+    const typeId = agentTypeMapping.titleToId[values.organizationType];
+    const serviceIds = values.services
+      .map((title) => serviceMapping.titleToId[title])
+      .filter((id): id is number => id !== undefined);
+
     updateOrganization(
       {
         title: values.title,
@@ -68,6 +104,8 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
         website: values.website,
         addressStreet: values.addressStreet,
         addressPostcode: values.addressPostcode,
+        ...(typeId !== undefined && { typeId }),
+        serviceIds,
       },
       {
         onSuccess: () => {
@@ -84,6 +122,8 @@ export const OrganisationDetails = forwardRef<EditableSectionRef, Props>(functio
         {isEditing ? (
           <OrganisationDetailsEdit
             languagesForForm={languagesForForm}
+            organizationTypeOptions={apiAgentTypes.map((agentType) => agentType.title)}
+            servicesOptions={apiServices.map((service) => service.title)}
             onCancel={handleCancel}
             onSubmit={handleSubmit(onSubmit)}
           />

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsDisplay.tsx
@@ -63,7 +63,7 @@ export const OrganisationDetailsDisplay = ({ rawClientLanguages, address }: Prop
       />
       <EditableField
         mode="display"
-        type="text"
+        type="checkbox-list"
         label={t(`${i18nPrefix}.services`)}
         value={values.services}
         setValue={() => {}}

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsEdit.tsx
@@ -12,11 +12,19 @@ const i18nPrefix = "dashboard.agentProfile.organisationDetails";
 
 type Props = {
   languagesForForm: Option[];
+  organizationTypeOptions: string[];
+  servicesOptions: string[];
   onCancel: () => void;
   onSubmit: () => void;
 };
 
-export const OrganisationDetailsEdit = ({ languagesForForm, onCancel, onSubmit }: Props) => {
+export const OrganisationDetailsEdit = ({
+  languagesForForm,
+  organizationTypeOptions,
+  servicesOptions,
+  onCancel,
+  onSubmit,
+}: Props) => {
   const { t } = useTranslation();
   const {
     control,
@@ -102,10 +110,11 @@ export const OrganisationDetailsEdit = ({ languagesForForm, onCancel, onSubmit }
           render={({ field }) => (
             <EditableField
               mode="edit"
-              type="text"
+              type="radio-list"
               label={t(`${i18nPrefix}.organisationType`)}
               value={field.value}
               setValue={field.onChange}
+              options={organizationTypeOptions}
               errorMessage={errors.organizationType?.message}
             />
           )}
@@ -130,10 +139,11 @@ export const OrganisationDetailsEdit = ({ languagesForForm, onCancel, onSubmit }
           render={({ field }) => (
             <EditableField
               mode="edit"
-              type="text"
+              type="checkbox-list"
               label={t(`${i18nPrefix}.services`)}
               value={field.value}
               setValue={field.onChange}
+              options={servicesOptions}
               errorMessage={errors.services?.message}
             />
           )}

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/organisationDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/organisationDetailsSchema.ts
@@ -1,5 +1,4 @@
 import { LanguageLevel } from "@/types";
-import { AgentType } from "need4deed-sdk";
 import { z } from "zod";
 
 const languageObjectSchema = z.object({
@@ -24,9 +23,11 @@ export const createOrganisationDetailsSchema = (t: (key: string) => string) => {
       }),
     addressStreet: z.string(),
     addressPostcode: z.string(),
-    organizationType: z.enum(AgentType),
+    // Stores the translated title (like `district` elsewhere), resolved
+    // back to an id at submit time via AgentType/Service option mappings.
+    organizationType: z.string().min(1, required),
     operator: z.string().min(1, required),
-    services: z.string().min(1, required),
+    services: z.array(z.string()).min(1, required),
     clientLanguages: z.array(languageObjectSchema).min(1, t(`${i18nPrefix}.clientLanguagesRequired`)),
   });
 };

--- a/src/components/Dashboard/Profile/sections/VolunteerProfile/hooks.ts
+++ b/src/components/Dashboard/Profile/sections/VolunteerProfile/hooks.ts
@@ -7,7 +7,7 @@ export type ApiLanguageOption = {
   isoCode?: string;
 };
 
-type ResourceType = "language" | "activity" | "skill" | "district";
+type ResourceType = "language" | "activity" | "skill" | "district" | "agent_type" | "service";
 
 function useApiResource(resource: ResourceType) {
   const { data, isLoading, isError } = useGetQuery<Record<ResourceType, ApiLanguageOption[]>>({
@@ -27,3 +27,5 @@ export const useApiLanguages = () => useApiResource("language");
 export const useApiActivities = () => useApiResource("activity");
 export const useApiSkills = () => useApiResource("skill");
 export const useApiDistricts = () => useApiResource("district");
+export const useApiAgentTypes = () => useApiResource("agent_type");
+export const useApiServices = () => useApiResource("service");

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,10 +2412,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.133:
-  version "0.0.133"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.133.tgz#b61648c86139474938aac531d16205a4f55a260f"
-  integrity sha512-VewV+N4If/SdpuVpAiHZgil9q8t3Qn4JKoitRibvYetED1oYodQeAsgnFf4XvkC1F1SLx1A7kfHCKRWe00nyKg==
+need4deed-sdk@0.0.136:
+  version "0.0.136"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.136.tgz#331130387c520bffbf55d118e801abd844d95f3d"
+  integrity sha512-OeYBZnAb+d/hMC8FArJ+PD42oXg04BZgj36aqggx61LYGAINtiMb7aE6vG/h5yoTCrTkvG0doQa8HXqfF1tFMw==
 
 next@15.3.8:
   version "15.3.8"


### PR DESCRIPTION
## Summary
- Consumes `need4deed-sdk@0.0.136`'s new `AgentType`/`Service` reference-data contract (`{id, title: {en,de}}`) in place of the old raw enum values.
- Agents list (cards, table, read-only views), the Filters panel (Type/Services checkboxes), the admin Organisation Details form (display + edit), and the public agent registration wizard (Org Info + Services steps) now render and submit fetched, translated options instead of hardcoded enum-key label maps.
- Filter serialization resolves a translated title back to its numeric id before hitting the backend (mirrors the existing `district` filter precedent).
- Fixes a pre-existing "never duplicate SDK types" violation in `AgentRegistration/types.ts` (`ApiAgentRegisterNew` was locally redefined; now imported from the SDK).

Closes need4deed-org/fe#868.

## Test plan
- [x] `yarn typecheck` clean
- [x] `yarn lint` clean (no new warnings)
- [x] Manual browser verification (en + de) against a live `be` backend:
  - [x] Agents list: Type column shows real translated text, updates on language switch
  - [x] Filters panel: Type/Services checkboxes show translated labels; filtering by a type/service correctly resolves to id and narrows the list
  - [x] Agent profile Organisation Details: display mode shows translated type/services; edit mode pre-fills the type dropdown and services checkbox-list with the agent's current values and saves correctly
  - [x] Public registration wizard: Org Info type dropdown and Services checkbox grid are populated from the real fetched, translated option lists (not a hardcoded English list)