### PR TITLE
Render multiple agent-address match candidates

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -2039,6 +2039,7 @@
       "title": "Konto-Einrichtung abschließen",
       "subtitle": "Erzählen Sie uns von Ihrer Organisation.",
       "matchFound": "Wir haben eine Organisation gefunden, die zu dieser Adresse passt: {{name}}. Möchten Sie diese verwenden?",
+      "matchesFound": "Wir haben {{count}} Organisationen gefunden, die zu dieser Adresse passen. Wählen Sie Ihre aus oder erstellen Sie eine neue.",
       "useThisOrg": "Ja, diese verwenden",
       "skip": "Nein, manuell eingeben",
       "matched": "Organisation gefunden: {{name}}",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -2038,11 +2038,9 @@
     "completion": {
       "title": "Konto-Einrichtung abschließen",
       "subtitle": "Erzählen Sie uns von Ihrer Organisation.",
-      "matchFound": "Wir haben eine Organisation gefunden, die zu dieser Adresse passt: {{name}}. Möchten Sie diese verwenden?",
-      "matchesFound": "Wir haben {{count}} Organisationen gefunden, die zu dieser Adresse passen. Wählen Sie Ihre aus oder erstellen Sie eine neue.",
-      "useThisOrg": "Ja, diese verwenden",
+      "matchesFound_one": "Wir haben {{count}} Organisation gefunden, die zu dieser Adresse passt. Wählen Sie Ihre aus oder erstellen Sie eine neue.",
+      "matchesFound_other": "Wir haben {{count}} Organisationen gefunden, die zu dieser Adresse passen. Wählen Sie Ihre aus oder erstellen Sie eine neue.",
       "skip": "Nein, manuell eingeben",
-      "matched": "Organisation gefunden: {{name}}",
       "titleTaken": "Eine Organisation mit diesem Namen existiert bereits.",
       "joinInstead": "Stattdessen beitreten",
       "requestToJoin": "Beitritt anfragen",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1660,6 +1660,7 @@
       "title": "Finish setting up your account",
       "subtitle": "Tell us about your organisation.",
       "matchFound": "We found an organisation matching this address: {{name}}. Would you like to use it?",
+      "matchesFound": "We found {{count}} organisations matching this address. Select yours, or continue creating a new one.",
       "useThisOrg": "Yes, use this",
       "skip": "No, enter manually",
       "matched": "Organisation matched: {{name}}",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1659,11 +1659,9 @@
     "completion": {
       "title": "Finish setting up your account",
       "subtitle": "Tell us about your organisation.",
-      "matchFound": "We found an organisation matching this address: {{name}}. Would you like to use it?",
-      "matchesFound": "We found {{count}} organisations matching this address. Select yours, or continue creating a new one.",
-      "useThisOrg": "Yes, use this",
+      "matchesFound_one": "We found {{count}} organisation matching this address. Select yours, or continue creating a new one.",
+      "matchesFound_other": "We found {{count}} organisations matching this address. Select yours, or continue creating a new one.",
       "skip": "No, enter manually",
-      "matched": "Organisation matched: {{name}}",
       "titleTaken": "An organisation with this name already exists.",
       "joinInstead": "Join it instead",
       "requestToJoin": "Request to join",

--- a/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
+++ b/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
@@ -72,7 +72,7 @@ export function ProfileCompletion() {
     apiPath: apiPathOption,
   });
 
-  const { matched, selectedAgent, showBanner, confirmMatch, dismissMatch } = useAgentAddressLookup(
+  const { matches, selectedAgent, showBanner, selectMatch, dismissMatch } = useAgentAddressLookup(
     formData.addressStreet,
     formData.addressPostcode,
     token,
@@ -238,16 +238,37 @@ export function ProfileCompletion() {
                   placeHolder={t("agentRegistration.fields.addressStreet")}
                   errors={errors.addressStreet ? [errors.addressStreet] : []}
                 />
-                {showBanner && (
+                {showBanner && matches.length === 1 && (
                   <MatchBanner $matched={false}>
-                    <span>{t("agentRegistration.completion.matchFound", { name: matched!.title })}</span>
+                    <span>{t("agentRegistration.completion.matchFound", { name: matches[0].title })}</span>
                     <MatchActions>
-                      <SmallButton $primary onClick={confirmMatch}>
+                      <SmallButton $primary onClick={() => selectMatch(matches[0])}>
                         {t("agentRegistration.completion.useThisOrg")}
                       </SmallButton>
                       <SmallButton onClick={dismissMatch}>{t("agentRegistration.completion.skip")}</SmallButton>
                     </MatchActions>
                   </MatchBanner>
+                )}
+
+                {showBanner && matches.length > 1 && (
+                  <>
+                    <MatchBanner $matched={false}>
+                      <span>{t("agentRegistration.completion.matchesFound", { count: matches.length })}</span>
+                    </MatchBanner>
+                    {matches.map((agent) => (
+                      <MatchBanner key={agent.id} $matched={false}>
+                        <span>{agent.title}</span>
+                        <MatchActions>
+                          <SmallButton $primary onClick={() => selectMatch(agent)}>
+                            {t("agentRegistration.completion.useThisOrg")}
+                          </SmallButton>
+                        </MatchActions>
+                      </MatchBanner>
+                    ))}
+                    <MatchActions>
+                      <SmallButton onClick={dismissMatch}>{t("agentRegistration.completion.skip")}</SmallButton>
+                    </MatchActions>
+                  </>
                 )}
               </FieldWrapper>
               <AddressStep data={formData} onChange={update} errors={errors} optionLists={optionLists} hideStreet />

--- a/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
+++ b/src/components/AgentRegistration/ProfileCompletion/ProfileCompletion.tsx
@@ -31,7 +31,7 @@ import {
   Wrapper,
 } from "../styled";
 import { defaultProfileCompletionData, ProfileCompletionData, TOTAL_COMPLETION_STEPS } from "../types";
-import { CheckMark, MatchBanner, MatchActions, SmallButton } from "./styled";
+import { CheckMark, MatchBanner, MatchActions, MatchListCopy, MatchRow, SmallButton } from "./styled";
 import { useAgentAddressLookup } from "./useAgentAddressLookup";
 import { setAuthHint } from "@/utils/helpers";
 
@@ -74,7 +74,6 @@ export function ProfileCompletion() {
 
   const { matches, selectedAgent, showBanner, selectMatch, dismissMatch } = useAgentAddressLookup(
     formData.addressStreet,
-    formData.addressPostcode,
     token,
     (m) => update({ addressStreet: m.title }),
   );
@@ -238,35 +237,20 @@ export function ProfileCompletion() {
                   placeHolder={t("agentRegistration.fields.addressStreet")}
                   errors={errors.addressStreet ? [errors.addressStreet] : []}
                 />
-                {showBanner && matches.length === 1 && (
-                  <MatchBanner $matched={false}>
-                    <span>{t("agentRegistration.completion.matchFound", { name: matches[0].title })}</span>
-                    <MatchActions>
-                      <SmallButton $primary onClick={() => selectMatch(matches[0])}>
-                        {t("agentRegistration.completion.useThisOrg")}
-                      </SmallButton>
-                      <SmallButton onClick={dismissMatch}>{t("agentRegistration.completion.skip")}</SmallButton>
-                    </MatchActions>
-                  </MatchBanner>
-                )}
-
-                {showBanner && matches.length > 1 && (
+                {showBanner && (
                   <>
-                    <MatchBanner $matched={false}>
-                      <span>{t("agentRegistration.completion.matchesFound", { count: matches.length })}</span>
-                    </MatchBanner>
+                    <MatchListCopy>
+                      {t("agentRegistration.completion.matchesFound", { count: matches.length })}
+                    </MatchListCopy>
                     {matches.map((agent) => (
-                      <MatchBanner key={agent.id} $matched={false}>
-                        <span>{agent.title}</span>
-                        <MatchActions>
-                          <SmallButton $primary onClick={() => selectMatch(agent)}>
-                            {t("agentRegistration.completion.useThisOrg")}
-                          </SmallButton>
-                        </MatchActions>
-                      </MatchBanner>
+                      <MatchRow key={agent.id} type="button" onClick={() => selectMatch(agent)}>
+                        {agent.title}
+                      </MatchRow>
                     ))}
                     <MatchActions>
-                      <SmallButton onClick={dismissMatch}>{t("agentRegistration.completion.skip")}</SmallButton>
+                      <SmallButton $primary onClick={dismissMatch}>
+                        {t("agentRegistration.completion.skip")}
+                      </SmallButton>
                     </MatchActions>
                   </>
                 )}
@@ -308,7 +292,7 @@ export function ProfileCompletion() {
               backgroundcolor="var(--color-aubergine)"
               textColor="var(--color-white)"
               onClick={handleNext}
-              disabled={tokenMissing}
+              disabled={tokenMissing || (step === 1 && showBanner)}
             />
           )}
         </Actions>

--- a/src/components/AgentRegistration/ProfileCompletion/styled.ts
+++ b/src/components/AgentRegistration/ProfileCompletion/styled.ts
@@ -18,10 +18,39 @@ export const MatchBanner = styled.div<MatchBannerProps>`
   color: var(--color-midnight);
 `;
 
+// Plain descriptive copy above the match list — must not read as a CTA the
+// way MatchBanner's colored/bordered box does; the row below is the CTA.
+export const MatchListCopy = styled.p`
+  font-size: 0.9375rem;
+  color: var(--color-grey-500);
+  margin: 8px 0 4px;
+`;
+
 export const CheckMark = styled.span`
   font-size: 1.25rem;
   color: var(--color-success, #16a34a);
   flex-shrink: 0;
+`;
+
+// A single candidate in the address-match picker: the whole row is the
+// call-to-action (click to select), not a row + separate button.
+export const MatchRow = styled.button`
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 12px 16px;
+  border-radius: 8px;
+  margin-top: 6px;
+  font-size: 0.9375rem;
+  cursor: pointer;
+  background: var(--color-white);
+  border: 1px solid var(--color-grey-200);
+  color: var(--color-midnight);
+
+  &:hover {
+    background: var(--color-orchid-light, #faf5ff);
+    border-color: var(--color-aubergine);
+  }
 `;
 
 export const MatchActions = styled.div`

--- a/src/components/AgentRegistration/ProfileCompletion/useAgentAddressLookup.ts
+++ b/src/components/AgentRegistration/ProfileCompletion/useAgentAddressLookup.ts
@@ -11,30 +11,27 @@ type AgentSearchMatch = { id: number; title: string };
 // (the COORDINATOR-only GET /agent is not available to a registrant).
 export function useAgentAddressLookup(
   addressStreet: string,
-  addressPostcode: string,
   token: string | null,
   onConfirm?: (matched: AgentSearchMatch) => void,
 ) {
   const [selectedAgent, setSelectedAgent] = useState<AgentSearchMatch | null>(null);
   const [dismissedAddress, setDismissedAddress] = useState<string | null>(null);
   const debouncedAddress = useDebounce(addressStreet.trim(), 400);
-  const debouncedPostcode = useDebounce(addressPostcode.trim(), 400);
 
-  const enabled = debouncedAddress.length >= 3 && !!debouncedPostcode && !!token;
+  const enabled = debouncedAddress.length >= 3 && !!token;
 
   const { data } = useGetQuery<AgentSearchMatch[]>({
-    queryKey: ["agent-register-search", debouncedAddress, debouncedPostcode],
+    queryKey: ["agent-register-search", debouncedAddress],
     apiPath: `${apiPathAgentRegister}/search?token=${encodeURIComponent(
       token ?? "",
-    )}&street=${encodeURIComponent(debouncedAddress)}&postcode=${encodeURIComponent(debouncedPostcode)}`,
+    )}&street=${encodeURIComponent(debouncedAddress)}`,
     staleTime: cacheTTL,
     enabled,
     addLang: false,
   });
 
-  // The API returns the decisive match (exact/legacy) first, followed by any
-  // other street-prefix candidates — but callers should not assume a single
-  // "the" match anymore, since more than one org can share a partial address.
+  // The API returns every matching candidate, not a single "the" match —
+  // more than one org can share a partial street.
   const matches = enabled ? (data ?? []) : [];
 
   const isDismissed = dismissedAddress === debouncedAddress;

--- a/src/components/AgentRegistration/ProfileCompletion/useAgentAddressLookup.ts
+++ b/src/components/AgentRegistration/ProfileCompletion/useAgentAddressLookup.ts
@@ -22,7 +22,7 @@ export function useAgentAddressLookup(
 
   const enabled = debouncedAddress.length >= 3 && !!debouncedPostcode && !!token;
 
-  const { data: matches } = useGetQuery<AgentSearchMatch[]>({
+  const { data } = useGetQuery<AgentSearchMatch[]>({
     queryKey: ["agent-register-search", debouncedAddress, debouncedPostcode],
     apiPath: `${apiPathAgentRegister}/search?token=${encodeURIComponent(
       token ?? "",
@@ -32,16 +32,18 @@ export function useAgentAddressLookup(
     addLang: false,
   });
 
-  const matched = enabled && matches && matches.length > 0 ? matches[0] : null;
+  // The API returns the decisive match (exact/legacy) first, followed by any
+  // other street-prefix candidates — but callers should not assume a single
+  // "the" match anymore, since more than one org can share a partial address.
+  const matches = enabled ? (data ?? []) : [];
 
   const isDismissed = dismissedAddress === debouncedAddress;
-  const isMatch = !!matched && selectedAgent?.id === matched.id;
-  const showBanner = !!matched && !isMatch && !isDismissed;
+  const isMatch = !!selectedAgent && matches.some((m) => m.id === selectedAgent.id);
+  const showBanner = matches.length > 0 && !isMatch && !isDismissed;
 
-  const confirmMatch = () => {
-    if (!matched) return;
-    setSelectedAgent(matched);
-    onConfirm?.(matched);
+  const selectMatch = (agent: AgentSearchMatch) => {
+    setSelectedAgent(agent);
+    onConfirm?.(agent);
   };
 
   const dismissMatch = () => {
@@ -50,12 +52,11 @@ export function useAgentAddressLookup(
   };
 
   return {
-    matched,
-    matches: enabled ? (matches ?? []) : [],
+    matches,
     selectedAgent,
     isMatch,
     showBanner,
-    confirmMatch,
+    selectMatch,
     dismissMatch,
   };
 }


### PR DESCRIPTION
## Description

**Updated** — the original single/multi-banner approach was redone per direct feedback after using the actual picker. This now matches the redesigned backend (need4deed-org/be#801: `GET /agent/register/search` drops postcode and returns every matching candidate, prefix-matched on `address.street` or contains-matched on `title`).

- `useAgentAddressLookup`: dropped `addressPostcode` entirely (param, debounce, query string, gating). Search fires once `street` is 3+ characters, full stop.
- `ProfileCompletion`: always renders as a plain list — one header line at the top, each candidate as a clickable row (the row **is** the CTA, no separate per-row button), one "No, enter manually" action at the bottom.
- Visual hierarchy fix: the header is plain descriptive copy (new `MatchListCopy`, matches this step's existing description styling) instead of a colored banner that read as a CTA; the actual CTA ("No, enter manually") is now styled `$primary` so it reads as the deliberate action it is.
- Pluralization fix: replaced a hardcoded-plural string with i18next's `_one`/`_other` key suffixes (`matchesFound_one`/`matchesFound_other`, en + de) — verified against a real i18next instance for count=1 and count=3 in both languages, no plural logic in the component itself.
- UX guard: the "Next" button is now disabled while the candidate list is still open, so a registrant can't move on without either picking an org or explicitly dismissing.

No new UI library or styling primitives — reuses/extends the existing `MatchBanner`/`MatchActions`/`SmallButton` family plus one new `MatchRow` (clickable row) and `MatchListCopy` (plain copy line). There's no Figma spec for this state, so this is a functional, low-risk layout rather than a designed one.

## Related Issues
Closes #874

## Changes
- `useAgentAddressLookup.ts`: dropped postcode entirely
- `ProfileCompletion.tsx`: list-only rendering, restyled header/CTA, disabled "Next" while list is open
- `styled.ts`: new `MatchRow`, `MatchListCopy`
- `public/locales/{en,de}/translations.json`: `matchesFound_one`/`matchesFound_other`; removed now-dead `matchFound`/`useThisOrg`/`completion.matched` keys

## Screenshots / Demos
Not captured — full picker QA needs a running backend with seeded matching agents and a real verify token. Verified instead: `yarn typecheck`/`yarn lint` clean, translation files parse, i18next plural resolution checked directly against a live i18next instance (all 4 combinations), and the address-completion page renders without error.

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [x] Tests added/updated — n/a, no test framework configured in this repo
- [ ] Documentation updated
- [x] CI passes (pending)
