### PR TITLE
fix: German NGO name field says "Vereinsname", should say "Einrichtungsname"

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1152,7 +1152,7 @@
       },
       "organisationDetails": {
         "title": "Details zur Organisation",
-        "ngoTitle": "Vereinsname",
+        "ngoTitle": "Einrichtungsname",
         "edit": "Bearbeiten",
         "about": "Über uns",
         "website": "Webseite",


### PR DESCRIPTION
## Summary
Closes #878.

One-line translation fix: the NGO/agent profile's Organisation Details section labels the NGO/agent's name (title) field "Vereinsname" (association/club name) in German — should be "Einrichtungsname" (institution/facility name), consistent with the rest of the platform's terminology already fixed in the #726 wording audit (e.g. "agent"/"agents" → "Einrichtung/Projekt" / "Einrichtungen/Projekte").

## Change
`public/locales/de/translations.json` — `dashboard.agentProfile.organisationDetails.ngoTitle`: `"Vereinsname"` → `"Einrichtungsname"`.

## Test plan
- [x] Confirmed valid JSON after the edit
- [x] Confirmed no other "Vereinsname" occurrences remain anywhere in the German translation file

🤖 Generated with [Claude Code](https://claude.com/claude-code)