### PR TITLE
843: remove required field from website in OrganisationDetails

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1147,7 +1147,7 @@
         "address": "Address",
         "organisationType": "Type of organisation",
         "operator": "Operator / Träger",
-        "services": "Leistungen",
+        "services": "Services",
         "clientLanguages": "Client languages",
         "cancel": "Cancel",
         "saveChanges": "Save changes",

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsDisplay.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsDisplay.tsx
@@ -37,7 +37,7 @@ export const OrganisationDetailsDisplay = ({ rawClientLanguages, address }: Prop
         mode="display"
         type="text"
         label={t(`${i18nPrefix}.website`)}
-        value={values.website}
+        value={values.website ?? ""}
         setValue={() => {}}
       />
       <EditableField

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsEdit.tsx
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/OrganisationDetailsEdit.tsx
@@ -70,7 +70,7 @@ export const OrganisationDetailsEdit = ({
               mode="edit"
               type="text"
               label={t(`${i18nPrefix}.website`)}
-              value={field.value}
+              value={field.value ?? ""}
               setValue={field.onChange}
               errorMessage={errors.website?.message}
             />

--- a/src/components/Dashboard/Profile/sections/OrganisationDetails/organisationDetailsSchema.ts
+++ b/src/components/Dashboard/Profile/sections/OrganisationDetails/organisationDetailsSchema.ts
@@ -17,10 +17,10 @@ export const createOrganisationDetailsSchema = (t: (key: string) => string) => {
     about: z.string().min(1, required),
     website: z
       .string()
-      .min(1, required)
-      .refine((val) => urlRegex.test(val), {
+      .refine((val) => !val || urlRegex.test(val), {
         message: t(`${i18nPrefix}.websiteInvalid`),
-      }),
+      })
+      .optional(),
     addressStreet: z.string(),
     addressPostcode: z.string(),
     // Stores the translated title (like `district` elsewhere), resolved


### PR DESCRIPTION
## Description
Removes required and adds optional to website in OrganisationSchema for Agent

## Related Issues
Closes #843 (dropdown label was added by [PR 873](https://github.com/need4deed-org/fe/pull/873))

## Changes
- Bullet list of meaningful changes (optional)

## Screenshots / Demos
If UI-related, add before/after or GIFs.

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

