### PR TITLE
Show localized invalid-organization-email copy instead of raw backend message

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -2055,7 +2055,8 @@
       "passwordMismatch": "Die Passwörter stimmen nicht überein",
       "phoneTooShort": "Die Telefonnummer muss mindestens 7 Zeichen lang sein",
       "emailDomainNotAllowed": "Ihre E-Mail-Domain ist nicht auf unserer genehmigten NGO-Liste. Bitte verwenden Sie die E-Mail-Adresse Ihrer Organisation.",
-      "missingToken": "Dein Registrierungslink ist ungültig oder abgelaufen. Bitte verwende den Link aus deiner Bestätigungs-E-Mail."
+      "missingToken": "Dein Registrierungslink ist ungültig oder abgelaufen. Bitte verwende den Link aus deiner Bestätigungs-E-Mail.",
+      "invalidOrganizationEmail": "Es wurde eine ungültige Organisations-E-Mail-Adresse angegeben."
     },
     "success": {
       "title": "Registrierung erfolgreich!",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1676,7 +1676,8 @@
       "passwordMismatch": "Passwords do not match",
       "phoneTooShort": "Phone number must be at least 7 characters",
       "emailDomainNotAllowed": "Your email domain is not on our approved NGO list. Please use your organisation email address.",
-      "missingToken": "Your registration link is invalid or has expired. Please use the link from your verification email."
+      "missingToken": "Your registration link is invalid or has expired. Please use the link from your verification email.",
+      "invalidOrganizationEmail": "Invalid organization email."
     },
     "success": {
       "title": "Registration successful!",

--- a/src/components/AgentRegistration/AgentRegistration.tsx
+++ b/src/components/AgentRegistration/AgentRegistration.tsx
@@ -100,8 +100,11 @@ export function AgentRegistration() {
     } catch (err) {
       let message = t("message.errorGeneric");
       if (axios.isAxiosError(err)) {
-        const data = err.response?.data as { message?: string } | undefined;
-        message = data?.message ?? message;
+        const data = err.response?.data as { error?: string; message?: string } | undefined;
+        message =
+          data?.error === "InvalidOrganizationEmailError"
+            ? t("agentRegistration.errors.invalidOrganizationEmail")
+            : (data?.message ?? message);
       }
       setSubmitError(message);
     } finally {


### PR DESCRIPTION
## Description

`AgentRegistration.tsx`'s submit-error handling displayed whatever the backend put in `data.message` verbatim, with no i18n involved at all — so an unrecognized/untrusted organization email domain showed the raw backend diagnostic string ("Resource not found", then later "Unrecognized or untrusted organization email domain." once need4deed-org/be#803 landed) instead of a translated, user-facing message.

## Related Issues
Closes #876
Depends on: need4deed-org/be#803 (adds the `InvalidOrganizationEmailError` class and fixes the `error` field being silently stripped from all error responses)

## Changes
- `AgentRegistration.tsx`: discriminates on `data?.error === "InvalidOrganizationEmailError"` and shows the new localized copy instead of the raw passthrough. All other error cases on this form are unchanged (still raw passthrough).
- New i18n key `agentRegistration.errors.invalidOrganizationEmail`:
  - en: "Invalid organization email."
  - de: "Es wurde eine ungültige Organisations-E-Mail-Adresse angegeben."

## Non-goals

The broader gap this surfaced — raw backend error messages aren't i18n-able, and this pattern (raw passthrough / fragile message-string-matching / this one-off class-name check) is duplicated ad hoc across `useMutationQuery`, `useGetQuery`, `LoadingErrorWrapper`, and both AgentRegistration forms — is backlogged separately as #883, scoped out of this PR by explicit decision (keep this fix narrow).

## Screenshots / Demos
Not captured — verified instead via direct `curl` against the live `be` container confirming the response shape, and `yarn lint`/`yarn typecheck` clean, i18n keys parse and resolve correctly for both locales.

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [x] Tests added/updated — n/a, no test framework configured in this repo
- [ ] Documentation updated
- [x] CI passes (pending)
