### PR TITLE
800: removes Suggest button when already matched 

### DIFF
--- a/src/components/Dashboard/Profile/sections/OpportunityVolunteers/OpportunityVolunteers.tsx
+++ b/src/components/Dashboard/Profile/sections/OpportunityVolunteers/OpportunityVolunteers.tsx
@@ -1,10 +1,8 @@
-import { apiPathOpportunity, cacheTTL } from "@/config/constants";
-import { useGetQuery } from "@/hooks/useGetQuery";
 import {
   useDeleteOpportunityVolunteer,
   useUpdateOpportunityVolunteerStatus,
 } from "@/hooks/useUpdateOpportunityVolunteerStatus";
-import { ApiVolunteerOpportunityGet, Id, OpportunityVolunteerStatusType } from "need4deed-sdk";
+import { Id, OpportunityVolunteerStatusType } from "need4deed-sdk";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { SectionEmptyState } from "../shared/styles";
@@ -12,6 +10,7 @@ import { Tabs } from "../shared/Tabs";
 import { ITEM_STATUS_REMOVED, TAB_STATUS_ORDER, useTabTransitions } from "../shared/useTabTransitions";
 import { AccordionVolunteer } from "./AccordionVolunteer";
 import { OpportunityVolunteersContainer } from "./styles";
+import { useGetVolunteerOpportunityLinked } from "@/hooks/useGetVolunteerOpportunityLinked";
 
 export const OpportunityVolunteers = ({
   opportunityId,
@@ -24,12 +23,7 @@ export const OpportunityVolunteers = ({
 
   const queryKey = ["opportunity-volunteers", String(opportunityId)];
 
-  const { data, isLoading } = useGetQuery<ApiVolunteerOpportunityGet[]>({
-    queryKey,
-    apiPath: `${apiPathOpportunity}/${opportunityId}/volunteer-linked`,
-    staleTime: cacheTTL,
-    enabled: !!opportunityId,
-  });
+  const { data, isLoading } = useGetVolunteerOpportunityLinked(opportunityId);
 
   const volunteers = useMemo(() => data ?? [], [data]);
 

--- a/src/hooks/useGetVolunteerOpportunityLinked.ts
+++ b/src/hooks/useGetVolunteerOpportunityLinked.ts
@@ -1,0 +1,26 @@
+import { ApiVolunteerOpportunityGet, Id } from "need4deed-sdk";
+import { useGetQuery } from "./useGetQuery";
+import { apiPathOpportunity, cacheTTL } from "@/config/constants";
+import { useEffect, useState } from "react";
+
+export const useGetVolunteerOpportunityLinked = (opportunityId: Id, volunteerId?: string) => {
+  const [isAlreadyMatched, setIsAlreadyMatch] = useState<boolean>(false);
+
+  const { data, isLoading } = useGetQuery<ApiVolunteerOpportunityGet[]>({
+    queryKey: ["opportunity-volunteers", String(opportunityId)],
+    apiPath: `${apiPathOpportunity}/${opportunityId}/volunteer-linked`,
+    staleTime: cacheTTL,
+    enabled: !!opportunityId,
+  });
+
+  useEffect(() => {
+    if (!volunteerId || isLoading) return;
+    const volunteerIds = data?.map((vol) => vol.volunteerId);
+    if (volunteerIds?.includes(Number(volunteerId))) {
+      setIsAlreadyMatch(true);
+    }
+    return () => setIsAlreadyMatch(false);
+  }, [data, isLoading, volunteerId, opportunityId]);
+
+  return { data, isLoading, isAlreadyMatched };
+};

--- a/src/hooks/useGetVolunteerOpportunityLinked.ts
+++ b/src/hooks/useGetVolunteerOpportunityLinked.ts
@@ -1,11 +1,8 @@
 import { ApiVolunteerOpportunityGet, Id } from "need4deed-sdk";
 import { useGetQuery } from "./useGetQuery";
 import { apiPathOpportunity, cacheTTL } from "@/config/constants";
-import { useEffect, useState } from "react";
 
 export const useGetVolunteerOpportunityLinked = (opportunityId: Id, volunteerId?: string) => {
-  const [isAlreadyMatched, setIsAlreadyMatch] = useState<boolean>(false);
-
   const { data, isLoading } = useGetQuery<ApiVolunteerOpportunityGet[]>({
     queryKey: ["opportunity-volunteers", String(opportunityId)],
     apiPath: `${apiPathOpportunity}/${opportunityId}/volunteer-linked`,
@@ -13,14 +10,8 @@ export const useGetVolunteerOpportunityLinked = (opportunityId: Id, volunteerId?
     enabled: !!opportunityId,
   });
 
-  useEffect(() => {
-    if (!volunteerId || isLoading) return;
-    const volunteerIds = data?.map((vol) => vol.volunteerId);
-    if (volunteerIds?.includes(Number(volunteerId))) {
-      setIsAlreadyMatch(true);
-    }
-    return () => setIsAlreadyMatch(false);
-  }, [data, isLoading, volunteerId, opportunityId]);
+  const isAlreadyMatched =
+    !isLoading && !!volunteerId && (data ?? []).some((vol) => vol.volunteerId === Number(volunteerId));
 
   return { data, isLoading, isAlreadyMatched };
 };

--- a/src/hooks/useOpportunityProfileSections.tsx
+++ b/src/hooks/useOpportunityProfileSections.tsx
@@ -19,6 +19,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "./useAuth";
+import { useGetVolunteerOpportunityLinked } from "./useGetVolunteerOpportunityLinked";
 
 export const useOpportunityProfileSections = (opportunity: ApiOpportunityGet | undefined) => {
   const { t, i18n } = useTranslation();
@@ -45,6 +46,7 @@ export const useOpportunityProfileSections = (opportunity: ApiOpportunityGet | u
 
   const volunteerId = searchParams.get("volunteer") ?? undefined;
   const volunteer = useGetVolunteer(volunteerId);
+  const { isAlreadyMatched } = useGetVolunteerOpportunityLinked(opportunity?.id ?? 0, volunteerId);
 
   const { mutate: suggestMutate } = useSuggestVolunteerOpportunity(() => {
     setIsSuggestDialogOpen(false);
@@ -124,14 +126,15 @@ export const useOpportunityProfileSections = (opportunity: ApiOpportunityGet | u
       {
         iconName: IconName.UsersThree,
         title: t("dashboard.opportunityProfile.volunteersSec.title"),
-        ...(isAuthorized && {
-          headerButtonName: volunteerId
-            ? t("dashboard.opportunityProfile.volunteersSec.suggestButtonName")
-            : t("dashboard.opportunityProfile.volunteersSec.findVolunteers"),
-          onHeaderButtonClick: volunteerId
-            ? () => setIsSuggestDialogOpen(true)
-            : () => router.push(`/${i18n.language}/dashboard/volunteers?opportunity=${opportunity.id}`),
-        }),
+        ...(isAuthorized &&
+          !isAlreadyMatched && {
+            headerButtonName: volunteerId
+              ? t("dashboard.opportunityProfile.volunteersSec.suggestButtonName")
+              : t("dashboard.opportunityProfile.volunteersSec.findVolunteers"),
+            onHeaderButtonClick: volunteerId
+              ? () => setIsSuggestDialogOpen(true)
+              : () => router.push(`/${i18n.language}/dashboard/volunteers?opportunity=${opportunity.id}`),
+          }),
         subComponent: (
           <>
             <OpportunityVolunteers opportunityId={opportunity.id} hasEditingRights={hasEditingRights} />


### PR DESCRIPTION
## Description
Adds a `useGetVolunteerOpportunityLinked` hook with `boolean` to check whether `opportunity` has already been matched with `volunteer`. 

Originally issue stated adding a specific error message instead but I felt this was a better fix and we can use the hook for future cases (it was also a suggest fix within the same issue)

## Related Issues
Closes #800 

## Changes

- Adds new hook
- Adds condition to `useOpportunityProfileSections` hook
- Replaces `useGetQuery` with new hook on `OpportunityVolunteers.tsx`

## Screenshots / Demos
With volunteer already matched with opportunity

<img width="1116" height="628" alt="image" src="https://github.com/user-attachments/assets/7fb0f85b-f0ce-4fbb-83dc-9439dd1e6408" />

With same volunteer not matched with opportunity

<img width="1000" height="554" alt="image" src="https://github.com/user-attachments/assets/31189811-72bb-43b3-8b96-d630a47c83a6" />

## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

