### PR TITLE
886: fixes missing district in Agent profile in English locale

### DIFF
--- a/src/components/Dashboard/Profile/sections/ProfileHeader/agent/AgentHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/agent/AgentHeader.tsx
@@ -23,8 +23,8 @@ type Props = {
 };
 
 export const AgentHeader = ({ agent }: Props) => {
-  const { t, i18n } = useTranslation();
-  const districtLabel = getDistrictLabel(agent.district, i18n.language);
+  const { t } = useTranslation();
+  const districtLabel = getDistrictLabel(agent.district);
   const dialog = useAgentEngagementStatusDialog(agent);
   const { mutate: patchAgent } = useUpdateAgentStatus(agent.id);
   const { isAuthorized } = useAuth();

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/agent/constants.ts
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/agent/constants.ts
@@ -1,6 +1,5 @@
 import { EMPTY_PLACEHOLDER_VALUE } from "@/config/constants";
 import { TFunction } from "i18next";
-import { Lang } from "need4deed-sdk";
 import { AgentEngagementStatus, AgentTrustLevel, AgentVolunteerSearch, ApiAgentProfileGet } from "../../../types/agent";
 
 export const createEngagementStatusLabelMap = (t: TFunction): Record<AgentEngagementStatus, string> => ({
@@ -40,7 +39,7 @@ export const createTrustLevelLabelMap = (t: TFunction): Record<AgentTrustLevel, 
   [AgentTrustLevel.HIGH]: t("dashboard.agentProfile.status.trustLevel.high"),
 });
 
-export const getDistrictLabel = (district: ApiAgentProfileGet["district"], language: string): string => {
+export const getDistrictLabel = (district: ApiAgentProfileGet["district"]): string => {
   const { title } = district || {};
-  return title?.[language as Lang] ?? title?.en ?? EMPTY_PLACEHOLDER_VALUE;
+  return title?.de ?? title?.en ?? EMPTY_PLACEHOLDER_VALUE;
 };


### PR DESCRIPTION
## Description
There is no or fewer `en keys` within the `district object`  whereas `de` key is ever present

This PR replaces `title[locale]` with first value `title.de` and then fallback to `title.en` if not present and then to placeholder.

I'm not sure to be honest why we have `en` and `de` keys for districts.

e.g. Neukölln is still Neukölln not matter the language. We wouldn't say "New Cologne" in English

## Related Issues
Closes #886 

## Changes
- Bullet list of meaningful changes (optional)

## Screenshots / Demos
<img width="1222" height="521" alt="image" src="https://github.com/user-attachments/assets/b3fa8488-61c9-408b-a4f2-ddd6ae34e13b" />

## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

