### PR TITLE
732: adds unmatch to all tabs & unmatch confirm dialog

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -649,7 +649,9 @@
         "notAMatchSuccess": "Entfernt",
         "markAsActiveSuccess": "Als aktiv markiert",
         "markAsPastSuccess": "Als vergangen markiert",
-        "emptyState": "Noch keine Einträge in dieser Kategorie"
+        "emptyState": "Noch keine Einträge in dieser Kategorie",
+        "unmatchDialogTitle": "Zuordnung aufheben",
+        "unmatchDialogDescription": "Möchten Sie die Zuordnung für diese Person wirklich aufheben?"
       },
       "contactDetails": {
         "title": "Kontaktdaten",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -642,7 +642,9 @@
         "notAMatchSuccess": "Removed",
         "markAsActiveSuccess": "Marked as active",
         "markAsPastSuccess": "Marked as past",
-        "emptyState": "No items in this category yet"
+        "emptyState": "No items in this category yet",
+        "unmatchDialogTitle": "Confirm Unmatch",
+        "unmatchDialogDescription": "Are you sure you want to unmatch this volunteer?"
       },
       "contactDetails": {
         "title": "Contact details",

--- a/src/components/Dashboard/Profile/sections/shared/AccordionActions.tsx
+++ b/src/components/Dashboard/Profile/sections/shared/AccordionActions.tsx
@@ -4,9 +4,11 @@ import { useTranslation } from "react-i18next";
 import { Button } from "@/components/core/button";
 
 import { Actions } from "./accordionStyles";
+import { ConfirmationDialog } from "./ConfirmationDialog";
+import { useState } from "react";
 
 type AccordionActionsProps = {
-  onNotAMatch?: () => void;
+  onNotAMatch: () => void;
   onMatch?: () => void;
   onMarkAsActive?: () => void;
   onMarkAsPast?: () => void;
@@ -14,20 +16,30 @@ type AccordionActionsProps = {
 
 export const AccordionActions = ({ onNotAMatch, onMatch, onMarkAsActive, onMarkAsPast }: AccordionActionsProps) => {
   const { t } = useTranslation();
+  const [showConfirmDialog, setShowConfirmDialog] = useState<boolean>(false);
 
   return (
     <Actions>
-      {onNotAMatch && (
-        <Button
-          onClick={onNotAMatch}
-          text={t("dashboard.volunteerProfile.opportunitiesSec.notAMatch")}
-          height="var(--volunteer-profile-opportunities-accordion-actions-button-height)"
-          textFontSize="var(--volunteer-profile-opportunities-accordion-actions-button-textFontSize)"
-          textColor="var(--color-aubergine)"
-          backgroundcolor="var(--color-white)"
-          border="var(--volunteer-profile-opportunities-accordion-actions-button-border)"
+      {showConfirmDialog && (
+        <ConfirmationDialog
+          title={t("dashboard.volunteerProfile.opportunitiesSec.unmatchDialogTitle")}
+          message={t("dashboard.volunteerProfile.opportunitiesSec.unmatchDialogDescription")}
+          onCancel={() => setShowConfirmDialog(false)}
+          onConfirm={() => {
+            onNotAMatch();
+            setShowConfirmDialog(false);
+          }}
         />
       )}
+      <Button
+        onClick={() => setShowConfirmDialog(true)}
+        text={t("dashboard.volunteerProfile.opportunitiesSec.notAMatch")}
+        height="var(--volunteer-profile-opportunities-accordion-actions-button-height)"
+        textFontSize="var(--volunteer-profile-opportunities-accordion-actions-button-textFontSize)"
+        textColor="var(--color-aubergine)"
+        backgroundcolor="var(--color-white)"
+        border="var(--volunteer-profile-opportunities-accordion-actions-button-border)"
+      />
       {onMatch && (
         <Button
           onClick={onMatch}
@@ -78,7 +90,7 @@ export const StatusAccordionActions = ({
     return <AccordionActions onNotAMatch={onNotAMatch} onMarkAsActive={onMarkAsActive} />;
   }
   if (currentStatus === OpportunityVolunteerStatusType.ACTIVE) {
-    return <AccordionActions onMarkAsPast={onMarkAsPast} />;
+    return <AccordionActions onNotAMatch={onNotAMatch} onMarkAsPast={onMarkAsPast} />;
   }
   return null;
 };


### PR DESCRIPTION
## Description
Adds `Unmatch` button to all tabs on OpportunityVolunteers on Agent profile.
Also add `Dialog` to confirm unmatch

## Related Issues
Closes #732 

## Changes
- Bullet list of meaningful changes (optional)

## Screenshots / Demos
<img width="821" height="592" alt="image" src="https://github.com/user-attachments/assets/b7eef0f7-49be-45f2-ab14-68ae3c8528a1" />

<img width="825" height="598" alt="image" src="https://github.com/user-attachments/assets/a9e0ad2c-eaf5-4dfc-a580-4d7484676e9d" />

_German_
<img width="904" height="556" alt="image" src="https://github.com/user-attachments/assets/3289a7af-ab97-4179-86db-a223e6ee1fba" />

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

