### PR TITLE
feat: make the asset CDN origin a build input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 ARG API_URL=http://localhost:8000
+ARG NEXT_PUBLIC_CLOUDFRONT_URL=https://d2nwrdddg8skub.cloudfront.net/images
+ARG NEXT_PUBLIC_CLOUDFRONT_DATA_URL=https://d2nwrdddg8skub.cloudfront.net/data
 
 COPY package.json yarn.lock* ./
 RUN yarn install --frozen-lockfile
@@ -10,8 +12,8 @@ COPY . .
 
 ENV API_URL=${API_URL}
 ENV NEXT_TELEMETRY_DISABLED=1
-ENV NEXT_PUBLIC_CLOUDFRONT_URL=https://d2nwrdddg8skub.cloudfront.net/images
-ENV NEXT_PUBLIC_CLOUDFRONT_DATA_URL=https://d2nwrdddg8skub.cloudfront.net/data
+ENV NEXT_PUBLIC_CLOUDFRONT_URL=${NEXT_PUBLIC_CLOUDFRONT_URL}
+ENV NEXT_PUBLIC_CLOUDFRONT_DATA_URL=${NEXT_PUBLIC_CLOUDFRONT_DATA_URL}
 
 RUN yarn build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 services:
-
- be:
+  be:
     container_name: be
     depends_on:
       bootstrap:
@@ -25,7 +24,7 @@ services:
       - DB_SCHEMA=public
     ports:
       - 8000:8000
- bootstrap:
+  bootstrap:
     container_name: data-bootstrap
     depends_on:
       db:
@@ -39,7 +38,7 @@ services:
       - DB_PASSWORD=postgres
       - DB_NAME=postgres
       - DB_SCHEMA=public
- db:
+  db:
     container_name: db
     image: postgres:17.2
     ports:
@@ -56,13 +55,16 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
- fe:
+  fe:
     build:
       context: .
       dockerfile: Dockerfile
       args:
         NODE_ENV: ${NODE_ENV:-development}
         API_URL: "http://be:8000"
+        # NEXT_PUBLIC_* is inlined at build time; env_file cannot set these.
+        NEXT_PUBLIC_CLOUDFRONT_URL: ${NEXT_PUBLIC_CLOUDFRONT_URL:-https://d2nwrdddg8skub.cloudfront.net/images}
+        NEXT_PUBLIC_CLOUDFRONT_DATA_URL: ${NEXT_PUBLIC_CLOUDFRONT_DATA_URL:-https://d2nwrdddg8skub.cloudfront.net/data}
     container_name: fe
     ports:
       - "3000:3000"

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,16 @@ import { apiPrefix } from "@/config/constants";
 import type { NextConfig } from "next";
 
 const apiURL = process.env.API_URL || "http://localhost:5000";
-const CLOUDFRONT_HOSTNAME = "d2nwrdddg8skub.cloudfront.net";
+const DEFAULT_ASSET_URL = "https://d2nwrdddg8skub.cloudfront.net/images";
+
+function assetHostname(): string {
+  const url = process.env.NEXT_PUBLIC_CLOUDFRONT_URL || DEFAULT_ASSET_URL;
+  try {
+    return new URL(url).hostname;
+  } catch {
+    throw new Error(`NEXT_PUBLIC_CLOUDFRONT_URL is not a valid URL: "${url}"`);
+  }
+}
 
 const nextConfig: NextConfig = {
   typescript: { ignoreBuildErrors: true },
@@ -24,7 +33,7 @@ const nextConfig: NextConfig = {
     return [{ source: `/${apiPrefix}/:path*`, destination: `${apiURL}/:path*` }];
   },
   images: {
-    domains: [CLOUDFRONT_HOSTNAME],
+    domains: [assetHostname()],
   },
   output: "standalone",
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,10 +2,17 @@ import { apiPrefix } from "@/config/constants";
 import type { NextConfig } from "next";
 
 const apiURL = process.env.API_URL || "http://localhost:5000";
+// Keep in sync with the Dockerfile's NEXT_PUBLIC_CLOUDFRONT_URL default.
 const DEFAULT_ASSET_URL = "https://d2nwrdddg8skub.cloudfront.net/images";
 
 function assetHostname(): string {
-  const url = process.env.NEXT_PUBLIC_CLOUDFRONT_URL || DEFAULT_ASSET_URL;
+  const configured = process.env.NEXT_PUBLIC_CLOUDFRONT_URL;
+  // Set-but-empty would leave app code emitting root-relative image paths
+  // while this allowlist silently kept the default host.
+  if (configured !== undefined && configured.trim() === "") {
+    throw new Error("NEXT_PUBLIC_CLOUDFRONT_URL is set but empty");
+  }
+  const url = configured || DEFAULT_ASSET_URL;
   try {
     return new URL(url).hostname;
   } catch {


### PR DESCRIPTION
## Why

The CloudFront distribution is hardcoded in two places, so repointing the frontend at a different asset host means editing source: `next.config.ts` holds the hostname for the image allowlist, and the `Dockerfile` bakes the asset URLs as fixed `ENV`s. `src/config/constants.ts` already reads the env vars correctly; only the build inputs were stuck.

## What changes

- `Dockerfile`: the two asset URLs become `ARG`s with the current CloudFront values as defaults, matching how `API_URL` is already handled.
- `next.config.ts`: the image-allowlist hostname is derived from `NEXT_PUBLIC_CLOUDFRONT_URL` rather than repeated, with the current value as fallback. A malformed URL fails the build.
- A set-but-empty value is rejected, because `next.config` would keep the default host while app code emitted root-relative paths: every CDN image 404s with a green build.
- `docker-compose.yml` passes the args through, since `NEXT_PUBLIC_*` is inlined at build time and `env_file` arrives too late to have any effect. The file's indentation is normalised to two spaces in passing, which is most of the diff noise there.

Env var names are unchanged: renaming to something provider-neutral touches every consumer plus the deploy secrets, and is cosmetic relative to the migration.

## Verification

`yarn build` green with defaults; with the override, the new hostname is baked into the server chunks; malformed and empty values both fail the build. Lint and typecheck clean.

## Note for the maintainers

This repo has no image build/publish workflow (only lint and build-check), and `ghcr.io/need4deed-org/fe:develop` returns 404 from the registry. The frontend cannot be deployed until that pipeline exists; worth raising separately.
