### PR TITLE
fix: ngo list text overlapping

### DIFF
--- a/src/components/Dashboard/Agents/AgentReadOnlyTableRow.tsx
+++ b/src/components/Dashboard/Agents/AgentReadOnlyTableRow.tsx
@@ -2,6 +2,7 @@ import { ApiAgentGetList, Lang, OptionItem } from "need4deed-sdk";
 import { useTranslation } from "react-i18next";
 import { ClickableRow, TableCell } from "@/components/core/common/Table";
 import { extractOptionTitle } from "@/components/Dashboard/Profile/sections/OpportunityDetails/formatters";
+import { WrapAnywhereCell } from "../common/EntityTableList/styles";
 
 interface Props {
   agent: ApiAgentGetList;
@@ -17,8 +18,8 @@ export function AgentReadOnlyTableRow({ agent, isLast, districtsList }: Props) {
 
   return (
     <ClickableRow $isLast={isLast} $cursor={"auto"} data-testid={`agent-row-${id}`}>
-      <TableCell data-testid={`agent-title-${id}`}>{title}</TableCell>
-      <TableCell data-testid={`agent-type-${id}`}>{extractOptionTitle(type, lang)}</TableCell>
+      <WrapAnywhereCell data-testid={`agent-title-${id}`}>{title}</WrapAnywhereCell>
+      <WrapAnywhereCell data-testid={`agent-type-${id}`}>{extractOptionTitle(type, lang)}</WrapAnywhereCell>
       <TableCell data-testid={`agent-district-${id}`}>{districtTitle || "—"}</TableCell>
     </ClickableRow>
   );

--- a/src/components/Dashboard/Agents/AgentTableRow.tsx
+++ b/src/components/Dashboard/Agents/AgentTableRow.tsx
@@ -42,12 +42,12 @@ export function AgentTableRow({ agent, isLast, searchLabels, districtsList, onSe
 
   return (
     <ClickableRow {...rowProps} $isLast={isLast} data-testid={`agent-row-${id}`}>
-      <TableCell $width={AGENT_COL_WIDTHS.title} data-testid={`agent-title-${id}`}>
+      <WrapAnywhereCell $width={AGENT_COL_WIDTHS.title} data-testid={`agent-title-${id}`}>
         {title}
-      </TableCell>
-      <TableCell $width={AGENT_COL_WIDTHS.type} data-testid={`agent-type-${id}`}>
+      </WrapAnywhereCell>
+      <WrapAnywhereCell $width={AGENT_COL_WIDTHS.type} data-testid={`agent-type-${id}`}>
         {extractOptionTitle(type, lang)}
-      </TableCell>
+      </WrapAnywhereCell>
       <TableCell $width={AGENT_COL_WIDTHS.volunteerSearch} data-testid={`agent-search-${id}`}>
         {searchLabels[volunteerSearch] || volunteerSearch}
       </TableCell>


### PR DESCRIPTION
## Description
fix display bug where text in NGO list view overflow their columns and overlap with subsequent columns.
the issue only seems to appear when viewing the page in German rather than English, probably because of the longer words which do not have spaces.


## Related Issues
Closes #897

## Changes
- replace `TableCell` with `WrapAnywhereCell` on the Title and Type columns in `src/components/Dashboard/Agents/AgentTableRow.tsx`, since  `WrapAnywhereCell` was already imported in the file.
- same change in `src/components/Dashboard/Agents/AgentReadOnlyTableRow.tsx`.

## Screenshots / Demos
<img width="600" alt="Screenshot_3-8-2026_21020_localhost" src="https://github.com/user-attachments/assets/08da1e40-9a19-4350-92ed-a2ad4ddb7114" />



