### PR TITLE
895: feat adds NGO selector on Opp profile

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1217,6 +1217,7 @@
       },
       "statusUpdateSuccess": "Status der ehrenamtlichen Tätigkeit erfolgreich aktualisiert",
       "change_status": "Status ändern",
+      "change_ngo": "Einrichtung/Projekt ändern",
       "typeUpdateSuccess": "Art der Tätigkeit erfolgreich aktualisiert",
       "change_type": "Typ ändern",
       "typeModal": {
@@ -1245,6 +1246,11 @@
           "inactive": "Inaktiv",
           "inactive_description": "Diese ehrenamtliche Tätigkeit ist nicht mehr aktuell."
         }
+      },
+      "ngoModal": {
+        "title": "Einrichtung/Projekt ändern",
+        "save": "Speichern",
+        "cancel": "Abbrechen"
       },
       "contactDetailsTitle": "Kontaktdaten",
       "editButtonName": "Bearbeiten",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1205,6 +1205,7 @@
       },
       "statusUpdateSuccess": "Opportunity status updated successfully",
       "change_status": "Change status",
+      "change_ngo": "Change NGO",
       "typeUpdateSuccess": "Opportunity type updated successfully",
       "change_type": "Change type",
       "typeModal": {
@@ -1233,6 +1234,11 @@
           "inactive": "Inactive",
           "inactive_description": "The opportunity is no longer active."
         }
+      },
+      "ngoModal": {
+        "title": "Change NGO",
+        "save": "Save",
+        "cancel": "Cancel"
       },
       "contactDetailsTitle": "Contact details",
       "editButtonName": "Edit",

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/common/ChangeStatusDialog.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/common/ChangeStatusDialog.tsx
@@ -16,14 +16,14 @@ import {
   RadioOption,
 } from "./dialogStyles";
 
-type StatusOption<T extends string> = {
+type StatusOption<T extends string | number> = {
   value: T;
   label: string;
   description: string;
   extra?: ReactNode;
 };
 
-type Props<T extends string> = {
+type Props<T extends string | number> = {
   testId: string;
   isOpen: boolean;
   title: string;
@@ -38,7 +38,7 @@ type Props<T extends string> = {
   cancelLabel: string;
 };
 
-export const ChangeStatusDialog = <T extends string>({
+export const ChangeStatusDialog = <T extends string | number>({
   testId,
   isOpen,
   title,
@@ -61,12 +61,7 @@ export const ChangeStatusDialog = <T extends string>({
           {options.map(({ value, label, description, extra }) => (
             <OptionItem key={value}>
               <RadioOption>
-                <input
-                  type="radio"
-                  name={radioName}
-                  checked={selected === value}
-                  onChange={() => onSelect(value)}
-                />
+                <input type="radio" name={radioName} checked={selected === value} onChange={() => onSelect(value)} />
                 <OptionLabel>{label}</OptionLabel>
               </RadioOption>
               <OptionDescription>{description}</OptionDescription>

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/common/useStatusDialog.ts
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/common/useStatusDialog.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-export type UseStatusDialogReturn<T extends string> = {
+export type UseStatusDialogReturn<T extends string | number> = {
   isOpen: boolean;
   selected: T;
   original: T;
@@ -11,13 +11,13 @@ export type UseStatusDialogReturn<T extends string> = {
   setSelected: (value: T) => void;
 };
 
-type StatusDialogConfig<T extends string> = {
+type StatusDialogConfig<T extends string | number> = {
   initial: T;
   onSave: (value: T, callbacks: { onSuccess: () => void }) => void;
   isSaveDisabled?: (selected: T, original: T) => boolean;
 };
 
-export const useStatusDialog = <T extends string>({
+export const useStatusDialog = <T extends string | number>({
   initial,
   onSave,
   isSaveDisabled: customIsSaveDisabled,

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/ChangeOpportunityAgentDialog.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/ChangeOpportunityAgentDialog.tsx
@@ -1,0 +1,41 @@
+"use client";
+import { useTranslation } from "react-i18next";
+import { ChangeStatusDialog } from "../common";
+import { UseOpportunityAgentDialogReturn } from "./useOpportunityAgentDialog";
+import { ApiAgentGet } from "need4deed-sdk";
+
+type Props = {
+  dialog: UseOpportunityAgentDialogReturn;
+  currentAgents: ApiAgentGet[];
+};
+
+export const ChangeOpportunityAgentDialog = ({
+  dialog: { isOpen, closeDialog, selected, setSelected, saveDialog, isSaveDisabled },
+  currentAgents,
+}: Props) => {
+  const { t } = useTranslation();
+
+  const options = currentAgents
+    ?.filter((agent) => Boolean(agent?.id))
+    ?.map((agent) => ({
+      value: agent?.id,
+      label: agent?.title,
+      description: agent?.agentDetails.about,
+    }));
+  return (
+    <ChangeStatusDialog
+      testId="change-agent-dialog"
+      isOpen={isOpen}
+      title={t("dashboard.opportunityProfile.ngoModal.title")}
+      options={options}
+      selected={selected}
+      onSelect={setSelected}
+      onSave={saveDialog}
+      onCancel={closeDialog}
+      isSaveDisabled={isSaveDisabled}
+      radioName="agentId"
+      saveLabel={t("dashboard.opportunityProfile.ngoModal.save")}
+      cancelLabel={t("dashboard.opportunityProfile.ngoModal.cancel")}
+    />
+  );
+};

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/ChangeOpportunityAgentDialog.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/ChangeOpportunityAgentDialog.tsx
@@ -20,7 +20,7 @@ export const ChangeOpportunityAgentDialog = ({
     ?.map((agent) => ({
       value: agent?.id,
       label: agent?.title,
-      description: agent?.agentDetails.about,
+      description: agent?.agentDetails?.about,
     }));
   return (
     <ChangeStatusDialog

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/OpportunityHeader.tsx
@@ -20,21 +20,26 @@ import { createOpportunityStatusLabelMap } from "./constants";
 import { useOpportunityStatusDialog } from "./useOpportunityStatusDialog";
 import { useAuth } from "@/hooks/useAuth";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { ChangeOpportunityAgentDialog } from "./ChangeOpportunityAgentDialog";
+import { useOpportunityAgentDialog } from "./useOpportunityAgentDialog";
+import { useGetCurrentAgent } from "@/hooks/useGetCurrentAgent";
 
 type Props = {
   opportunity: ApiOpportunityGet;
 };
 
 export const OpportunityHeader = ({ opportunity }: Props) => {
-  const { isAuthorized } = useAuth();
+  const { isAuthorized, isOwnProfile } = useAuth(opportunity.agent?.id);
   const currentUser = useCurrentUser();
+  const { currentAgents } = useGetCurrentAgent();
   // Coordinator/admin may edit any opportunity; an agent may only change the
   // status of an opportunity belonging to their own agent (mirrors the be
   // ownership check on PATCH /opportunity/:id).
   const canChangeStatus =
     isAuthorized || (currentUser?.role === UserRole.AGENT && currentUser?.agentId === opportunity.agent?.id);
   const { t, i18n } = useTranslation();
-  const dialog = useOpportunityStatusDialog(opportunity);
+  const dialogStatus = useOpportunityStatusDialog(opportunity);
+  const dialogAgent = useOpportunityAgentDialog(opportunity);
   const [isTypeOpen, setIsTypeOpen] = useState(false);
   const statusLabelMap = createOpportunityStatusLabelMap(t);
   const volunteerTypeLabelMap = createVolunteerTypeLabelMap(t);
@@ -55,18 +60,19 @@ export const OpportunityHeader = ({ opportunity }: Props) => {
       subtitle={subtitle}
       after={
         <>
-          <ChangeOpportunityStatusDialog dialog={dialog} isAuthorized={isAuthorized} />
+          <ChangeOpportunityStatusDialog dialog={dialogStatus} isAuthorized={isAuthorized} />
           {isTypeOpen && <ChangeOpportunityTypeDialog onClose={() => setIsTypeOpen(false)} opportunity={opportunity} />}
+          <ChangeOpportunityAgentDialog dialog={dialogAgent} currentAgents={currentAgents} />
         </>
       }
     >
       <StatusRowField
         title={t("dashboard.opportunityProfile.currentStatus")}
-        status={dialog.selected}
-        label={statusLabelMap[dialog.selected]}
+        status={dialogStatus.selected}
+        label={statusLabelMap[dialogStatus.selected]}
         action={
           canChangeStatus && (
-            <EditButton onClick={dialog.openDialog}>{t("dashboard.opportunityProfile.change_status")}</EditButton>
+            <EditButton onClick={dialogStatus.openDialog}>{t("dashboard.opportunityProfile.change_status")}</EditButton>
           )
         }
       />
@@ -101,6 +107,12 @@ export const OpportunityHeader = ({ opportunity }: Props) => {
       {(opportunity.agent as typeof opportunity.agent & { id?: number })?.id && (
         <StatusRowField
           title={t("dashboard.opportunityProfile.agent")}
+          action={
+            isOwnProfile &&
+            currentAgents.length > 1 && (
+              <EditButton onClick={dialogAgent.openDialog}>{t("dashboard.opportunityProfile.change_ngo")}</EditButton>
+            )
+          }
           extra={
             <AgentLink
               href={`/${i18n.language}/dashboard/agents/${(opportunity.agent as typeof opportunity.agent & { id?: number }).id}`}

--- a/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/useOpportunityAgentDialog.ts
+++ b/src/components/Dashboard/Profile/sections/ProfileHeader/opportunity/useOpportunityAgentDialog.ts
@@ -1,0 +1,18 @@
+import { ApiOpportunityGet } from "need4deed-sdk";
+import { useStatusDialog, UseStatusDialogReturn } from "../common/useStatusDialog";
+import { useTransferOpportunityToAgent } from "@/hooks/useTransferOpportunityToAgent";
+
+export type UseOpportunityAgentDialogReturn = UseStatusDialogReturn<number>;
+
+export const useOpportunityAgentDialog = (opportunity: ApiOpportunityGet) => {
+  const { mutate: updateAgent } = useTransferOpportunityToAgent(Number(opportunity.id));
+
+  const onSave = (id: number, { onSuccess }: { onSuccess: () => void }) => {
+    updateAgent({ agent: { id } }, { onSuccess });
+  };
+
+  return useStatusDialog({
+    initial: opportunity.agent?.id,
+    onSave,
+  });
+};

--- a/src/hooks/useGetCurrentAgent.ts
+++ b/src/hooks/useGetCurrentAgent.ts
@@ -17,7 +17,7 @@ export const useGetCurrentAgent = () => {
 
   const agentId = user?.agentId;
   // test here for multiple ngos, add more agentids
-  const agentIds = [agentId, 2, 3];
+  const agentIds = [agentId];
 
   const { data: agent, isLoading: agentLoading } = useGetQuery<ApiAgentGet>({
     queryKey: ["agent", String(agentId)],

--- a/src/hooks/useGetCurrentAgent.ts
+++ b/src/hooks/useGetCurrentAgent.ts
@@ -1,6 +1,7 @@
 import { apiPathAgent, apiPathMe, AUTH_HINT_COOKIE_NAME, cacheTTL, USER_QUERY_KEY } from "@/config/constants";
 import { useGetQuery } from "@/hooks";
 import { getCookie } from "@/utils/helpers";
+import { useQueries } from "@tanstack/react-query";
 import { ApiAgentGet, ApiUserGet } from "need4deed-sdk";
 
 export const useGetCurrentAgent = () => {
@@ -15,6 +16,8 @@ export const useGetCurrentAgent = () => {
   });
 
   const agentId = user?.agentId;
+  // test here for multiple ngos, add more agentids
+  const agentIds = [agentId, 2, 3];
 
   const { data: agent, isLoading: agentLoading } = useGetQuery<ApiAgentGet>({
     queryKey: ["agent", String(agentId)],
@@ -24,5 +27,20 @@ export const useGetCurrentAgent = () => {
     addLang: false,
   });
 
-  return { agent, agentId, isLoading: userLoading || (!!agentId && agentLoading) };
+  const agentQueries = useQueries({
+    queries: agentIds.map((id) => ({
+      queryKey: ["agent", String(id)],
+      queryFn: async () => {
+        const res = await fetch(`${apiPathAgent}/${id}`);
+        if (!res.ok) throw new Error("Failed to fetch agent");
+        return res.json();
+      },
+      staleTime: cacheTTL,
+      enabled: !!id,
+    })),
+  });
+
+  const currentAgents = agentQueries.map((q) => q.data?.data) ?? [];
+
+  return { agent, agentId, isLoading: userLoading || (!!agentId && agentLoading), currentAgents };
 };

--- a/src/hooks/useGetCurrentAgent.ts
+++ b/src/hooks/useGetCurrentAgent.ts
@@ -4,7 +4,6 @@ import { useGetQuery } from "@/hooks";
 import { getCookie } from "@/utils/helpers";
 import { useQueries } from "@tanstack/react-query";
 import { ApiUserGet } from "need4deed-sdk";
-import { useState } from "react";
 
 export const useGetCurrentAgent = () => {
   const isLoggedIn = getCookie(AUTH_HINT_COOKIE_NAME) === "true";

--- a/src/hooks/useGetCurrentAgent.ts
+++ b/src/hooks/useGetCurrentAgent.ts
@@ -30,7 +30,6 @@ export const useGetCurrentAgent = () => {
         } catch (error) {
           console.error(`Error fetching agent with ID ${id}:`, error);
           throw error;
-        } finally {
         }
       },
       staleTime: cacheTTL,

--- a/src/hooks/useGetCurrentAgent.ts
+++ b/src/hooks/useGetCurrentAgent.ts
@@ -7,8 +7,6 @@ import { ApiUserGet } from "need4deed-sdk";
 import { useState } from "react";
 
 export const useGetCurrentAgent = () => {
-  const [isAgentsLoading, setIsAgentsLoading] = useState(false);
-
   const isLoggedIn = getCookie(AUTH_HINT_COOKIE_NAME) === "true";
 
   const { data: user, isLoading: userLoading } = useGetQuery<ApiUserGet & { agentId?: number }>({
@@ -27,7 +25,6 @@ export const useGetCurrentAgent = () => {
     queries: agentIds.map((id) => ({
       queryKey: ["agent", String(id)],
       queryFn: async () => {
-        setIsAgentsLoading(true);
         try {
           const response = await axios.get(`${apiPathAgent}/${id}`);
           return response.data;
@@ -35,7 +32,6 @@ export const useGetCurrentAgent = () => {
           console.error(`Error fetching agent with ID ${id}:`, error);
           throw error;
         } finally {
-          setIsAgentsLoading(false);
         }
       },
       staleTime: cacheTTL,
@@ -47,7 +43,7 @@ export const useGetCurrentAgent = () => {
 
   return {
     agentId,
-    isLoading: userLoading || (agentIds.length > 0 && isAgentsLoading),
+    isLoading: userLoading || agentQueries.some((q) => q.isLoading),
     currentAgents,
   };
 };

--- a/src/hooks/useGetCurrentAgent.ts
+++ b/src/hooks/useGetCurrentAgent.ts
@@ -2,6 +2,7 @@ import { apiPathAgent, apiPathMe, AUTH_HINT_COOKIE_NAME, cacheTTL, USER_QUERY_KE
 import { useGetQuery } from "@/hooks";
 import { getCookie } from "@/utils/helpers";
 import { useQueries } from "@tanstack/react-query";
+import axios from "axios";
 import { ApiAgentGet, ApiUserGet } from "need4deed-sdk";
 
 export const useGetCurrentAgent = () => {
@@ -17,7 +18,7 @@ export const useGetCurrentAgent = () => {
 
   const agentId = user?.agentId;
   // test here for multiple ngos, add more agentids
-  const agentIds = [agentId];
+  const agentIds = [agentId, 2, 3];
 
   const { data: agent, isLoading: agentLoading } = useGetQuery<ApiAgentGet>({
     queryKey: ["agent", String(agentId)],
@@ -31,16 +32,15 @@ export const useGetCurrentAgent = () => {
     queries: agentIds.map((id) => ({
       queryKey: ["agent", String(id)],
       queryFn: async () => {
-        const res = await fetch(`${apiPathAgent}/${id}`);
-        if (!res.ok) throw new Error("Failed to fetch agent");
-        return res.json();
+        const response = await axios.get(`${apiPathAgent}/${id}`);
+        return response.data;
       },
       staleTime: cacheTTL,
       enabled: !!id,
     })),
   });
 
-  const currentAgents = agentQueries.map((q) => q.data?.data) ?? [];
+  const currentAgents = agentQueries.map((q) => q.data?.data);
 
   return { agent, agentId, isLoading: userLoading || (!!agentId && agentLoading), currentAgents };
 };

--- a/src/hooks/useGetCurrentAgent.ts
+++ b/src/hooks/useGetCurrentAgent.ts
@@ -1,11 +1,14 @@
+import axios from "axios";
 import { apiPathAgent, apiPathMe, AUTH_HINT_COOKIE_NAME, cacheTTL, USER_QUERY_KEY } from "@/config/constants";
 import { useGetQuery } from "@/hooks";
 import { getCookie } from "@/utils/helpers";
 import { useQueries } from "@tanstack/react-query";
-import axios from "axios";
-import { ApiAgentGet, ApiUserGet } from "need4deed-sdk";
+import { ApiUserGet } from "need4deed-sdk";
+import { useState } from "react";
 
 export const useGetCurrentAgent = () => {
+  const [isAgentsLoading, setIsAgentsLoading] = useState(false);
+
   const isLoggedIn = getCookie(AUTH_HINT_COOKIE_NAME) === "true";
 
   const { data: user, isLoading: userLoading } = useGetQuery<ApiUserGet & { agentId?: number }>({
@@ -18,22 +21,22 @@ export const useGetCurrentAgent = () => {
 
   const agentId = user?.agentId;
   // test here for multiple ngos, add more agentids
-  const agentIds = [agentId, 2, 3];
-
-  const { data: agent, isLoading: agentLoading } = useGetQuery<ApiAgentGet>({
-    queryKey: ["agent", String(agentId)],
-    apiPath: `${apiPathAgent}/${agentId}`,
-    staleTime: cacheTTL,
-    enabled: !!agentId,
-    addLang: false,
-  });
+  const agentIds = [agentId];
 
   const agentQueries = useQueries({
     queries: agentIds.map((id) => ({
       queryKey: ["agent", String(id)],
       queryFn: async () => {
-        const response = await axios.get(`${apiPathAgent}/${id}`);
-        return response.data;
+        setIsAgentsLoading(true);
+        try {
+          const response = await axios.get(`${apiPathAgent}/${id}`);
+          return response.data;
+        } catch (error) {
+          console.error(`Error fetching agent with ID ${id}:`, error);
+          throw error;
+        } finally {
+          setIsAgentsLoading(false);
+        }
       },
       staleTime: cacheTTL,
       enabled: !!id,
@@ -42,5 +45,9 @@ export const useGetCurrentAgent = () => {
 
   const currentAgents = agentQueries.map((q) => q.data?.data);
 
-  return { agent, agentId, isLoading: userLoading || (!!agentId && agentLoading), currentAgents };
+  return {
+    agentId,
+    isLoading: userLoading || (agentIds.length > 0 && isAgentsLoading),
+    currentAgents,
+  };
 };


### PR DESCRIPTION
## Description
Adds ability for NGO users associated with multiple NGOs to change NGO on `opportunity` profile

Please note:

- Full implementation is blocked by `be` [Issue 809](https://github.com/need4deed-org/be/issues/809)
- Other feature requests of `fe` [Issue 895](https://github.com/need4deed-org/fe/issues/895) are not addressed
Though this compliments [PR 902](https://github.com/need4deed-org/fe/pull/902) and [PR 904](https://github.com/need4deed-org/fe/pull/904) 

## Related Issues
Closes 4. on #895 

## Changes
- Bullet list of meaningful changes (optional)

## Screenshots / Demos

### Single NGO

<img width="1498" height="710" alt="image" src="https://github.com/user-attachments/assets/d27634df-4869-41a1-b426-825663a25b0d" />

### Multiple NGOs

https://github.com/user-attachments/assets/fea97d6f-c6be-46bc-9012-5f4429f7a37e


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

