### PR TITLE
895: feat adds fetch all opp for multi-ngos on Dashboard

### DIFF
--- a/src/components/Dashboard/Home/AgentOpportunityCards.tsx
+++ b/src/components/Dashboard/Home/AgentOpportunityCards.tsx
@@ -1,25 +1,21 @@
 "use client";
-import { apiPathAgent, apiPathOption, cacheTTL } from "@/config/constants";
+import { apiPathOption } from "@/config/constants";
 import { useGetCurrentAgent } from "@/hooks/useGetCurrentAgent";
 import { useGetQuery } from "@/hooks";
-import { ApiOptionLists, ApiOpportunityGetList, ApiVolunteerOpportunityGetList } from "need4deed-sdk";
+import { ApiOptionLists, ApiVolunteerOpportunityGetList } from "need4deed-sdk";
 import { OpportunityCard } from "../Opportunities/OpportunityCard";
 import { useTranslation } from "react-i18next";
 import { Heading4 } from "@/components/styled/text";
 import { DashboardCardContainer } from "./styles";
+import { useGetMultiOpportunityLinked } from "@/hooks/useGetMultiOpportunityLinked";
 
 export function AgentOpportunityCards() {
   const { t } = useTranslation();
   const { agentId } = useGetCurrentAgent();
 
   const { data: apiFilterOptions } = useGetQuery<ApiOptionLists>({ queryKey: ["options"], apiPath: apiPathOption });
-  const { data: opportunities, isLoading } = useGetQuery<ApiOpportunityGetList[]>({
-    queryKey: ["agent-opportunities", String(agentId)],
-    apiPath: `${apiPathAgent}/${agentId}/opportunity-linked`,
-    staleTime: cacheTTL,
-    enabled: !!agentId,
-    addLang: false,
-  });
+
+  const { allLinkedOpportunities: opportunities, isLoading } = useGetMultiOpportunityLinked([agentId ?? 0]);
 
   const activitiesList = apiFilterOptions?.activity ?? undefined;
   const districtsList = apiFilterOptions?.district ?? undefined;
@@ -28,7 +24,7 @@ export function AgentOpportunityCards() {
 
   return (
     <DashboardCardContainer>
-      {opportunities?.map((opp) => (
+      {opportunities.map((opp) => (
         <OpportunityCard
           key={String(opp.id)}
           opportunity={opp as ApiVolunteerOpportunityGetList}

--- a/src/hooks/useGetMultiOpportunityLinked.ts
+++ b/src/hooks/useGetMultiOpportunityLinked.ts
@@ -1,0 +1,32 @@
+import { apiPathAgent, cacheTTL } from "@/config/constants";
+import { useQueries } from "@tanstack/react-query";
+import { useState } from "react";
+
+export const useGetMultiOpportunityLinked = (agentIds: number[]) => {
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const oppLinkedQueries = useQueries({
+    queries: agentIds?.map((id) => ({
+      queryKey: ["agent-opportunities", String(id)],
+      queryFn: async () => {
+        setIsLoading(true);
+        const res = await fetch(`${apiPathAgent}/${id}/opportunity-linked`);
+        if (!res.ok) {
+          setIsLoading(false);
+          throw new Error("Failed to fetch opportunity");
+        }
+        setIsLoading(false);
+        return res.json();
+      },
+      staleTime: cacheTTL,
+      enabled: !!id,
+    })),
+  });
+
+  const allLinkedOpportunities = oppLinkedQueries.flatMap((q) => q.data?.data).filter((q) => Boolean(q)) ?? [];
+
+  return {
+    allLinkedOpportunities,
+    isLoading,
+  };
+};

--- a/src/hooks/useGetMultiOpportunityLinked.ts
+++ b/src/hooks/useGetMultiOpportunityLinked.ts
@@ -1,7 +1,6 @@
 import { apiPathAgent, cacheTTL } from "@/config/constants";
 import { useQueries } from "@tanstack/react-query";
 import axios from "axios";
-import { useState } from "react";
 
 export const useGetMultiOpportunityLinked = (agentIds: number[]) => {
   const oppLinkedQueries = useQueries({
@@ -13,7 +12,7 @@ export const useGetMultiOpportunityLinked = (agentIds: number[]) => {
           if (!res) {
             throw new Error("Failed to fetch opportunity");
           }
-          return res;
+          return res.data;
         } catch (error) {
           console.error(`Error fetching agent with ID ${id}:`, error);
           throw error;
@@ -24,7 +23,7 @@ export const useGetMultiOpportunityLinked = (agentIds: number[]) => {
     })),
   });
 
-  const allLinkedOpportunities = oppLinkedQueries.flatMap((q) => q.data?.data).filter((q) => Boolean(q)) ?? [];
+  const allLinkedOpportunities = oppLinkedQueries.flatMap((q) => q.data?.data).filter((q) => Boolean(q));
 
   return {
     allLinkedOpportunities,

--- a/src/hooks/useGetMultiOpportunityLinked.ts
+++ b/src/hooks/useGetMultiOpportunityLinked.ts
@@ -1,22 +1,23 @@
 import { apiPathAgent, cacheTTL } from "@/config/constants";
 import { useQueries } from "@tanstack/react-query";
+import axios from "axios";
 import { useState } from "react";
 
 export const useGetMultiOpportunityLinked = (agentIds: number[]) => {
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-
   const oppLinkedQueries = useQueries({
     queries: agentIds?.map((id) => ({
       queryKey: ["agent-opportunities", String(id)],
       queryFn: async () => {
-        setIsLoading(true);
-        const res = await fetch(`${apiPathAgent}/${id}/opportunity-linked`);
-        if (!res.ok) {
-          setIsLoading(false);
-          throw new Error("Failed to fetch opportunity");
+        try {
+          const res = await axios.get(`${apiPathAgent}/${id}/opportunity-linked`);
+          if (!res) {
+            throw new Error("Failed to fetch opportunity");
+          }
+          return res;
+        } catch (error) {
+          console.error(`Error fetching agent with ID ${id}:`, error);
+          throw error;
         }
-        setIsLoading(false);
-        return res.json();
       },
       staleTime: cacheTTL,
       enabled: !!id,
@@ -27,6 +28,6 @@ export const useGetMultiOpportunityLinked = (agentIds: number[]) => {
 
   return {
     allLinkedOpportunities,
-    isLoading,
+    isLoading: oppLinkedQueries.some((q) => q.isLoading),
   };
 };


### PR DESCRIPTION
## Description
Fetches all opportunities linked to NGO-account if they have multiple NGOs associated with them

Please note:

- Full implementation is blocked by `be` [Issue 809](https://github.com/need4deed-org/be/issues/809)
- Compliments [PR 902](https://github.com/need4deed-org/fe/pull/902), [PR 906](https://github.com/need4deed-org/fe/pull/906) and  [PR 904](https://github.com/need4deed-org/fe/pull/904)

## Related Issues
Closes 2 of issue #895 

## Changes
- Bullet list of meaningful changes (optional)

## Screenshots / Demos

### Single NGO `agentId 1`

<img width="1497" height="669" alt="image" src="https://github.com/user-attachments/assets/6c53e01b-5f24-4087-8a58-1e92c3d87687" />

### Multiple NGOs `agentId 1, agentId 2, agentId 3 ` (Zoomed out)

<img width="1512" height="669" alt="image" src="https://github.com/user-attachments/assets/20cb57e2-aadf-433f-8148-c31e861533fb" />


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

