### PR TITLE
READMe update: Add command to build sdk before installing with yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,34 +74,25 @@ git clone https://github.com/need4deed-org/be.git
 git clone https://github.com/need4deed-org/sdk.git
 ```
 
-### 2. Keep SDK in Sync
+---
 
-We **don’t fetch the SDK** — we link it locally.
+## 🌐 Modifying API types
 
-1. Pull the latest SDK changes:
+The `sdk` repo contains the API types that are used by `be` and `fe`. These are published as an npm package `need4deed-sdk`. The following points must be considered before modifying these types.
 
-   ```bash
-   cd sdk
-   git pull origin <branch>
-   ```
+1. Modifying the API types in `sdk` must be followed by republishing the `need4deed-sdk` package to the npm registry.
+   https://www.npmjs.com/package/need4deed-sdk
 
-2. Build the sdk package by navigating to the sdk folder and then
+2. The `fe`, `be` and `sdk` should then be upgraded using the following command.
 
-   ```bash
-   cd ../sdk
-   yarn run build
-   ```
+```bash
+yarn upgrade need4deed-sdk --latest
+```
 
-3. Then in the FE:
+### 🚧 Avoid workarounds
 
-   ```bash
-   cd ../fe
-   yarn install ../sdk
-   ```
-
-4. Make sure all repos (`fe`, `be`, `sdk`) are checked out to the same branch name for consistency. Note that the sdk repo may not have the same branch name since the types don't change as frequently as the frontend and backend code.
-
-> 💡 If you see TypeScript errors, ensure your local SDK and backend are aligned and up to date.
+- Linking the `sdk` locally will result in updated package references in the `package.json` file which will diverge from the published stable version of the `need4deed-sdk` This may result in production failures and is best avoided.
+- Using local type definitions and other workarounds is not acceptable.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ This project uses [`next/font`](https://nextjs.org/docs/app/building-your-applic
 
 To learn more about Next.js, take a look at the following resources:
 
-* [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-* [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
+- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
@@ -44,7 +44,7 @@ It is actively developed and will eventually include our public landing page (cu
 
 | Repository                                            | Description                                           |
 | ----------------------------------------------------- | ----------------------------------------------------- |
-| [`backend`](https://github.com/need4deed-org/be) | Node.js / TypeScript API backend                      |
+| [`backend`](https://github.com/need4deed-org/be)      | Node.js / TypeScript API backend                      |
 | [`sdk`](https://github.com/need4deed-org/sdk)         | Shared TypeScript types and helpers used by FE and BE |
 | [`website`](https://github.com/need4deed-org/website) | Legacy React/Vite landing page (currently frozen)     |
 
@@ -85,14 +85,21 @@ We **don’t fetch the SDK** — we link it locally.
    git pull origin <branch>
    ```
 
-2. Then in the FE:
+2. Build the sdk package by navigating to the sdk folder and then
+
+   ```bash
+   cd ../sdk
+   yarn run build
+   ```
+
+3. Then in the FE:
 
    ```bash
    cd ../fe
    yarn install ../sdk
    ```
 
-3. Make sure all repos (`fe`, `be`, `sdk`) are checked out to the same branch name for consistency.
+4. Make sure all repos (`fe`, `be`, `sdk`) are checked out to the same branch name for consistency. Note that the sdk repo may not have the same branch name since the types don't change as frequently as the frontend and backend code.
 
 > 💡 If you see TypeScript errors, ensure your local SDK and backend are aligned and up to date.
 
@@ -103,9 +110,9 @@ We **don’t fetch the SDK** — we link it locally.
 All designs and layouts are defined in **Figma**.
 Before implementing or modifying any UI component:
 
-* Follow the design from the official Figma project shared by the Need4Deed design team
-* Match typography, spacing, and component structure
-* Discuss any changes or deviations with the design team before merging
+- Follow the design from the official Figma project shared by the Need4Deed design team
+- Match typography, spacing, and component structure
+- Discuss any changes or deviations with the design team before merging
 
 > Keeping the FE aligned with Figma ensures consistency and quality across our app.
 
@@ -113,9 +120,9 @@ Before implementing or modifying any UI component:
 
 ## 🧪 Development Notes
 
-* You can manually open the specific page you’re working on via its local URL (e.g. `http://localhost:3000/dashboard`)
-* The FE app will gradually incorporate the public landing page currently hosted on Amplify/S3
-* The `website` repo is frozen until the merge into this app is complete
+- You can manually open the specific page you’re working on via its local URL (e.g. `http://localhost:3000/dashboard`)
+- The FE app will gradually incorporate the public landing page currently hosted on Amplify/S3
+- The `website` repo is frozen until the merge into this app is complete
 
 ---
 
@@ -135,16 +142,14 @@ We welcome all contributions — from bug fixes to feature development.
 
 4. **Commit your changes**
    Follow our commit message style guide:
-
-   * Use present tense (“Add feature” not “Added feature”)
-   * Use imperative mood (“Fix bug” not “Fixes bug”)
-   * Keep it short (under 72 chars)
-   * Prefix with an emoji when relevant:
-
-     * 🎨 — style/format improvements
-     * 🐛 — bug fix
-     * 📝 — docs
-     * 🔥 — removing code/files
+   - Use present tense (“Add feature” not “Added feature”)
+   - Use imperative mood (“Fix bug” not “Fixes bug”)
+   - Keep it short (under 72 chars)
+   - Prefix with an emoji when relevant:
+     - 🎨 — style/format improvements
+     - 🐛 — bug fix
+     - 📝 — docs
+     - 🔥 — removing code/files
 
 5. **Push** your branch and open a **Pull Request** to `main`
 
@@ -154,9 +159,9 @@ We welcome all contributions — from bug fixes to feature development.
 
 ## 🐞 Reporting Bugs & Suggesting Features
 
-* Use the **Issues** tab in this repository
-* Check existing issues before opening a new one
-* Use the provided templates for **bug reports** and **feature requests**
+- Use the **Issues** tab in this repository
+- Check existing issues before opening a new one
+- Use the provided templates for **bug reports** and **feature requests**
 
 ---
 
@@ -165,4 +170,4 @@ We welcome all contributions — from bug fixes to feature development.
 By contributing, you agree that your contributions are licensed under our
 [Commons Clause + MIT License](LICENSE).
 
---- 
+---


### PR DESCRIPTION
## Description
Hi, I am a new contributor to this project and while running the dev server I found that a step was missing from the readme file. Cloning the `sdk` repo won't have the `dist` folder in the sdk repo. I have added the step and the command to address this. It may seem like a minor issue but can be an obstacle for first time contributors like myself.

## Related Issues
There are currently no related issues that I came across. 

## Changes
- Adds a step in the readme file to build the sdk package before installing it.

## Screenshots / Demos
##### Before
<img width="875" height="618" alt="Screenshot 2026-08-05 at 9 44 37 pm" src="https://github.com/user-attachments/assets/df40645e-ea32-4c4c-9533-21c372c581cc" />


##### After
<img width="875" height="618" alt="Screenshot 2026-08-05 at 9 44 37 pm" src="https://github.com/user-attachments/assets/18cd1687-4d8b-411a-a18d-c719164568f2" />


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [x] Documentation updated
- [x] CI passes

