### PR TITLE
add four new appreciation options to the dialog

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -1017,7 +1017,7 @@
         "need4deedCertificate": "Need4Deed-Zertifikat",
         "cap": "Cap",
         "notebook": "Notizbuch",
-        "cityCertificate": "Städtisches Zertifikat"
+        "cityCertificate": "Senatsurkunde"
       },
       "addAppreciation": "Anerkennung hinzufügen",
       "editAppreciation": "Anerkennung bearbeiten",

--- a/src/components/Dashboard/Profile/sections/Appreciation/AppreciationDialog.tsx
+++ b/src/components/Dashboard/Profile/sections/Appreciation/AppreciationDialog.tsx
@@ -44,6 +44,16 @@ const APPRECIATION_TYPES = [
     value: VolunteerStateAppreciationType.BENEFIT_CARD,
     labelKey: "dashboard.appreciationSection.typeOptions.benefitCard",
   },
+  {
+    value: VolunteerStateAppreciationType.NEED4DEED_CERTIFICATE,
+    labelKey: "dashboard.appreciationSection.typeOptions.need4deedCertificate",
+  },
+  { value: VolunteerStateAppreciationType.CAP, labelKey: "dashboard.appreciationSection.typeOptions.cap" },
+  { value: VolunteerStateAppreciationType.NOTEBOOK, labelKey: "dashboard.appreciationSection.typeOptions.notebook" },
+  {
+    value: VolunteerStateAppreciationType.CITY_CERTIFICATE,
+    labelKey: "dashboard.appreciationSection.typeOptions.cityCertificate",
+  },
 ];
 
 type DeliveryStatusOptionProps = {
@@ -77,12 +87,7 @@ function DeliveryStatusOption({
 }: DeliveryStatusOptionProps) {
   return (
     <>
-      <SelectableOption
-        isSelected={isSelected}
-        label={label}
-        onClick={onSelect}
-        data-testid={`sub-option-${status}`}
-      />
+      <SelectableOption isSelected={isSelected} label={label} onClick={onSelect} data-testid={`sub-option-${status}`} />
       {showDatePicker && (
         <DateFieldWrapper data-testid={testId}>
           <DatePickerWithLabel


### PR DESCRIPTION
## Description
Adds the four new options to the Add Appreciation dialog: Need4Deed certificate, cap, notebook and city certificate. Previously, only tote bag, t-shirt, and benefit card were offered.

 **Blocked on the backend.** 
Saving one of the new options currently returns a 400. `sdk-types.json` in the backend still lists only the old three values, so the request is rejected during validation. Issue: [837](https://github.com/need4deed-org/be/issues/837). Everything else is in place; the database migration and the SDK both have all seven.

## Related Issues
Closes #872

## Changes
- Four entries added to `APPRECIATION_TYPES` in `AppreciationDialog.tsx`
- German `cityCertificate` corrected to Senatsurkunde


## Screenshots / Demos
<img width="1366" height="768" alt="Screenshot from 2026-08-05 22-55-29" src="https://github.com/user-attachments/assets/5120d30d-f8bb-4eea-826e-a86cd5456b92" />



## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

