### PR TITLE
920: fix new opportunity's appointment/event date registering a day early

### DIFF
--- a/src/components/Dashboard/NewOpportunity/helper.ts
+++ b/src/components/Dashboard/NewOpportunity/helper.ts
@@ -1,4 +1,5 @@
 import { ApiLanguageOption } from "@/components/Dashboard/Profile/sections/VolunteerProfile/hooks";
+import { format } from "date-fns";
 import { TFunction } from "i18next";
 import {
   OptionItem,
@@ -68,14 +69,18 @@ export function buildCreatePayload(
   const skillIds = toOptionItems(detailsData.skills, apiSkills).map((i) => i.id);
   const timeslots = isEvent ? null : availabilityToTimeslots(detailsData.availability);
 
+  // eventDate/appointmentDate are local-midnight Date objects from the date
+  // picker (react-day-picker) — extract the *local* calendar date here, not
+  // its UTC date, or a positive UTC offset (Europe/Berlin is always +1/+2)
+  // reads back the previous day (fe#920).
   const onetime_date_time =
     isEvent && detailsData.eventDate
-      ? `${detailsData.eventDate.toISOString().split("T")[0]}T${detailsData.eventTime || "00:00"}:00`
+      ? `${format(detailsData.eventDate, "yyyy-MM-dd")}T${detailsData.eventTime || "00:00"}:00`
       : null;
 
   const accomp_datetime =
     isAccompanying && accompData?.appointmentDate
-      ? `${accompData.appointmentDate.toISOString().split("T")[0]}T${accompData.appointmentTime || "00:00"}:00`
+      ? `${format(accompData.appointmentDate, "yyyy-MM-dd")}T${accompData.appointmentTime || "00:00"}:00`
       : null;
 
   return {


### PR DESCRIPTION
## Description
When creating an accompanying or event-type opportunity via the dashboard's "New Opportunity" form, the saved date was a day before the actually-picked date.

## Root cause
`buildCreatePayload` (`src/components/Dashboard/NewOpportunity/helper.ts`) extracted the date via:
```ts
`${accompData.appointmentDate.toISOString().split("T")[0]}T${accompData.appointmentTime || "00:00"}:00`
```
`appointmentDate`/`eventDate` are local-midnight `Date` objects from the date picker (`react-day-picker`). `.toISOString()` always converts to UTC — for Europe/Berlin (always a positive UTC offset, +1 or +2), local midnight on day N is 22:00/23:00 UTC on day N-1, so `.split("T")[0]` read off the previous day. This happened on every creation, not just at certain times.

This was initially misdiagnosed as a `be`-side timezone bug (be#873, PR closed) before tracing the actual round-trip and finding this.

## Related Issues
Closes https://github.com/need4deed-org/fe/issues/920

## Changes
- `buildCreatePayload`: extract the date via `date-fns`'s `format(date, "yyyy-MM-dd")` (local calendar date) instead of `.toISOString().split("T")[0]` (UTC date), for both `accomp_datetime` and `onetime_date_time`.

## Testing
- `yarn typecheck` — clean
- `yarn lint` — no new warnings (4 pre-existing `react-hooks/exhaustive-deps` warnings elsewhere, unrelated)
- No automated test added — this repo has no test runner installed (checked: no vitest/jest in devDependencies, no existing `*.test.ts`/`*.spec.ts` files anywhere), consistent with existing convention.
- Not manually verified in a running browser — recommend confirming with a real create-opportunity flow before merging.

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated (no test runner in this repo)
- [ ] Documentation updated
- [x] CI passes