### PR TITLE
fix: English error messages for some components and hooks

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1556,17 +1556,17 @@
       },
       "dataProtectionLink": "Click here for our Privacy Policy",
       "dataProtectionOfficer": "Data Protection Officer"
-    },
-    "message": {
-      "successful": "Successful",
-      "errorGeneric": "Something went wrong!",
-      "validationFailed": "Validation failed",
-      "uploadSuccess": "Document uploaded successfully!",
-      "deleteSuccess": "Document deleted successfully!",
-      "uploadError": "Upload failed. Please try again.",
-      "deleteError": "Delete failed. Please try again.",
-      "previewError": "Preview failed. Please try again."
     }
+  },
+  "message": {
+    "successful": "Successful",
+    "errorGeneric": "Something went wrong!",
+    "validationFailed": "Validation failed",
+    "uploadSuccess": "Document uploaded successfully!",
+    "deleteSuccess": "Document deleted successfully!",
+    "uploadError": "Upload failed. Please try again.",
+    "deleteError": "Delete failed. Please try again.",
+    "previewError": "Preview failed. Please try again."
   },
   "racGuidelines": {
     "heading": "Need4Deed Guidelines",


### PR DESCRIPTION
## Description
- Please read #926 for context. 
This PR fixes #926 by changing the en translation json to remove `message` from `legal` to the root of json. 

## Related Issues
Closes #926 

## Changes
Previous JSONPath of message was: `legal.message`
After this PR it will be: `message` 

## Screenshots / Demos
<img width="1350" height="987" alt="Screenshot 2026-08-12 at 8 58 12 pm" src="https://github.com/user-attachments/assets/a12c4d0e-ed55-4045-8121-ac67027c5880" />


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

