### PR TITLE
🐛 Fix category card text overflow

### DIFF
--- a/src/components/VolunteeringCategories/CategoryCard.tsx
+++ b/src/components/VolunteeringCategories/CategoryCard.tsx
@@ -7,7 +7,7 @@ import { BaseCard, IconDiv } from "../styled/container";
 const Card = styled(BaseCard)`
   background-color: var(--color-sand);
   width: var(--homepage-volunteering-category-card-width);
-  height: var(--homepage-volunteering-category-card-height);
+  min-height: var(--homepage-volunteering-category-card-height);
   padding-top: var(--homepage-volunteering-category-card-padding-top);
   padding-right: var(--homepage-volunteering-category-card-padding-right);
   padding-bottom: var(--homepage-volunteering-category-card-padding-bottom);


### PR DESCRIPTION
## Description
Fixes the volunteering category cards on the landing page so longer text no longer overflows the card container. Replaced the fixed `height` with `min-height`, allowing cards to grow with their content.

## Related Issues
Closes #914

## Changes
- Replaced fixed `height` with `min-height` in `CategoryCard`
- Verified the card expands correctly for longer content, including German text

## Screenshots / Demos

### Before
<img width="623" height="645" alt="before" src="https://github.com/user-attachments/assets/bd974a01-3c73-43b1-90b4-090ef4a4975e" />

### After
<img width="1588" height="1274" alt="after" src="https://github.com/user-attachments/assets/8dadef18-d7bc-41db-9ef8-c4db340c3252" />


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes