### PR TITLE
exclude inactive records from default volunteer and opportunity views

### DIFF
--- a/src/components/Dashboard/Opportunities/Filters/constants.ts
+++ b/src/components/Dashboard/Opportunities/Filters/constants.ts
@@ -54,6 +54,8 @@ export const DEFAULT_OPPORTUNITY_STATUSES = Object.values(OpportunityStatusType)
   (status) => status !== OpportunityStatusType.INACTIVE,
 );
 
+export const STATUS_PARAM = "status";
+
 export const SEPARATOR = "~";
 export type AvailabilityKeys = keyof OpportunityCardsFilter["availability"];
 export type AvailabilitySubKeys = TimeSlot | ByDay | OccasionalType;

--- a/src/components/Dashboard/Opportunities/Filters/constants.ts
+++ b/src/components/Dashboard/Opportunities/Filters/constants.ts
@@ -17,6 +17,7 @@ export const defaultOpportunityCardsFilter: OpportunityCardsFilter = {
     [OpportunityStatusType.NEW]: false,
     [OpportunityStatusType.SEARCHING]: false,
     [OpportunityStatusType.ACTIVE]: false,
+    [OpportunityStatusType.INACTIVE]: false,
     [OpportunityStatusType.PAST]: false,
   },
   type: {
@@ -47,6 +48,11 @@ export const defaultOpportunityCardsFilter: OpportunityCardsFilter = {
     },
   },
 };
+
+// Every status except inactive. Derived so new SDK values are visible by default
+export const DEFAULT_OPPORTUNITY_STATUSES = Object.values(OpportunityStatusType).filter(
+  (status) => status !== OpportunityStatusType.INACTIVE,
+);
 
 export const SEPARATOR = "~";
 export type AvailabilityKeys = keyof OpportunityCardsFilter["availability"];

--- a/src/components/Dashboard/Opportunities/OpportunityListController.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityListController.tsx
@@ -8,7 +8,7 @@ import { AppointmentSort, isAppointmentSort, serializeOpportunityFilters } from 
 import { OpportunityCardList } from "./OpportunityCardList";
 import { ViewMode } from "../common/types";
 import { OpportunityTableList } from "./OpportunityTableList";
-import { DEFAULT_OPPORTUNITY_STATUSES } from "./Filters/constants";
+import { DEFAULT_OPPORTUNITY_STATUSES, STATUS_PARAM } from "./Filters/constants";
 
 type OpportunityWithAccompanying = ApiVolunteerOpportunityGetList & {
   accompanyingDetails?: { appointmentDate?: string };
@@ -61,8 +61,8 @@ export function OpportunityListController({
     serializedFilter.set("volunteer", volunteerId);
   }
 
-  if (!serializedFilter.has("status")) {
-    DEFAULT_OPPORTUNITY_STATUSES.forEach((defaultStatus) => serializedFilter.append("status", defaultStatus));
+  if (!serializedFilter.has(STATUS_PARAM)) {
+    DEFAULT_OPPORTUNITY_STATUSES.forEach((defaultStatus) => serializedFilter.append(STATUS_PARAM, defaultStatus));
   }
 
   const backendSortOrder = isAppointmentSort(sortOrder) ? SortOrder.NewToOld : (sortOrder as SortOrder);

--- a/src/components/Dashboard/Opportunities/OpportunityListController.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityListController.tsx
@@ -8,6 +8,7 @@ import { AppointmentSort, isAppointmentSort, serializeOpportunityFilters } from 
 import { OpportunityCardList } from "./OpportunityCardList";
 import { ViewMode } from "../common/types";
 import { OpportunityTableList } from "./OpportunityTableList";
+import { DEFAULT_OPPORTUNITY_STATUSES } from "./Filters/constants";
 
 type OpportunityWithAccompanying = ApiVolunteerOpportunityGetList & {
   accompanyingDetails?: { appointmentDate?: string };
@@ -58,6 +59,10 @@ export function OpportunityListController({
 
   if (volunteerId) {
     serializedFilter.set("volunteer", volunteerId);
+  }
+
+  if (!serializedFilter.has("status")) {
+    DEFAULT_OPPORTUNITY_STATUSES.forEach((defaultStatus) => serializedFilter.append("status", defaultStatus));
   }
 
   const backendSortOrder = isAppointmentSort(sortOrder) ? SortOrder.NewToOld : (sortOrder as SortOrder);

--- a/src/components/Dashboard/Opportunities/helpers.ts
+++ b/src/components/Dashboard/Opportunities/helpers.ts
@@ -9,7 +9,7 @@ import {
   SortOrder,
 } from "need4deed-sdk";
 import { ReadonlyURLSearchParams } from "next/navigation";
-import { AvailabilityKeys, AvailabilitySubKeys, SEPARATOR } from "./Filters/constants";
+import { AvailabilityKeys, AvailabilitySubKeys, SEPARATOR, STATUS_PARAM } from "./Filters/constants";
 import { OpportunityCardsFilter } from "./Filters/types";
 import { format } from "date-fns";
 import { utcHhmmToLocal } from "@/utils";
@@ -81,10 +81,10 @@ export function serializeOpportunityFilters(
     }
   });
 
-  params.delete("status");
+  params.delete(STATUS_PARAM);
   Object.entries(filter.status).forEach(([key, value]) => {
     if (value === true) {
-      params.append("status", key);
+      params.append(STATUS_PARAM, key);
     }
   });
 
@@ -135,7 +135,7 @@ export function deserializeOpportunityFilters(
     newFilter.language[l] = true;
   });
 
-  const queryStatus = searchParams.getAll("status");
+  const queryStatus = searchParams.getAll(STATUS_PARAM);
   queryStatus.forEach((s) => {
     newFilter.status[s] = true;
   });

--- a/src/components/Dashboard/Volunteers/Filters/constants.tsx
+++ b/src/components/Dashboard/Volunteers/Filters/constants.tsx
@@ -59,6 +59,11 @@ export const defaultVolunteerCardsFilter: VolunteerCardsFilter = {
   },
 };
 
+// Every engagement except inactive. Derived so new SDK values are visible by default
+export const DEFAULT_VOLUNTEER_ENGAGEMENTS = Object.values(VolunteerStateEngagementType).filter(
+  (engagement) => engagement !== VolunteerStateEngagementType.INACTIVE,
+);
+
 export const SEPARATOR = "~";
 export type AvailabilityKeys = keyof VolunteerCardsFilter["availability"];
 export type AvailabilitySubKeys = TimeSlot | ByDay | OccasionalType;

--- a/src/components/Dashboard/Volunteers/VolunteerListController.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerListController.tsx
@@ -42,6 +42,8 @@ export function VolunteerListController({
     serializedFilter.set("opportunity", opportunityId);
   }
 
+  const emailsFilter = new URLSearchParams(serializedFilter);
+
   if (!serializedFilter.has(QueryParamsKeys.ENGAGEMENT)) {
     DEFAULT_VOLUNTEER_ENGAGEMENTS.forEach((defaultEngagement) =>
       serializedFilter.append(QueryParamsKeys.ENGAGEMENT, defaultEngagement.replace(/^vol-/, "")),
@@ -64,7 +66,7 @@ export function VolunteerListController({
     staleTime: cacheTTL,
   });
   const volunteers = data || [];
-  const { handleCopyEmails, isCopying } = useCopyEmails(apiPathVolunteer, "volunteer-emails", serializedFilter);
+  const { handleCopyEmails, isCopying } = useCopyEmails(apiPathVolunteer, "volunteer-emails", emailsFilter);
   const user = useCurrentUser();
   const canSeeContactColumns = user?.role === UserRole.COORDINATOR || user?.role === UserRole.ADMIN;
 

--- a/src/components/Dashboard/Volunteers/VolunteerListController.tsx
+++ b/src/components/Dashboard/Volunteers/VolunteerListController.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { DashboardListLoading } from "@/components/Dashboard/common/DashboardListLoading";
 import { apiPathVolunteer, cacheTTL, CARD_LIMIT, TABLE_LIMIT } from "@/config/constants";
 import { useGetQuery, usePageParam } from "@/hooks";
-import { ApiOptionLists, ApiVolunteerGetList, SortOrder, UserRole } from "need4deed-sdk";
+import { ApiOptionLists, ApiVolunteerGetList, QueryParamsKeys, SortOrder, UserRole } from "need4deed-sdk";
 import { VolunteerCardsFilter } from "./Filters/types";
 import { serializeFilters } from "./helpers";
 import { VolunteerCardList } from "./VolunteerCardList";
@@ -11,6 +11,7 @@ import { VolunteerTableList } from "./VolunteerTableList";
 import { ViewMode } from "../common/types";
 import { useCopyEmails } from "@/hooks/useCopyEmails";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { DEFAULT_VOLUNTEER_ENGAGEMENTS } from "./Filters/constants";
 
 interface VolunteerListControllerProps {
   setNumOfVols: (numOfVols: number) => void;
@@ -40,6 +41,13 @@ export function VolunteerListController({
   if (opportunityId) {
     serializedFilter.set("opportunity", opportunityId);
   }
+
+  if (!serializedFilter.has(QueryParamsKeys.ENGAGEMENT)) {
+    DEFAULT_VOLUNTEER_ENGAGEMENTS.forEach((defaultEngagement) =>
+      serializedFilter.append(QueryParamsKeys.ENGAGEMENT, defaultEngagement.replace(/^vol-/, "")),
+    );
+  }
+
   const params = {
     limit,
     page: currentPage,


### PR DESCRIPTION
## Description
Inactive volunteers and inactive opportunities no longer show up in the dashboard by default, and are not counted in the results number at the top. Ticking "Inactive" in the filters brings them back.

The reason nothing was filtered before: the query only got a `status` (or `engagement`) param for boxes the user had ticked. On a fresh page load, nothing is ticked, so no param was sent at all, so the server had nothing to filter by and returned everything.

The fix supplies a default set when the user has selected nothing, and it does that at the API call site rather than inside the shared serializer. 

Both default lists are derived from the SDK enums rather than written by hand, so a new status added later shows up by default instead of silently disappearing.

The counts needed no work. `count` comes back from the server with the filtered list, so filtering the query filters the count.

useCopyEmails gets a snapshot of the filter taken before the defaults are applied, so copy-all still includes inactive volunteers

**Also open:** the issue only mentions inactive, so past opportunities are still visible by default. I was on the fence about including opp-past too and went with what the issue says. Happy to add it, it is one line.

## Related Issues
Closes #637 

## Changes
- Restored the Inactive option to the opportunity status filter. It was added by #435 on 4 May and removed by #734 (`834888b4`) on 24 June, when the SDK had temporarily dropped `OpportunityStatusType.INACTIVE`. The SDK has the value back, and the `opp-inactive` translation keys were still in both locale files, so this is a one-line revert.
- `DEFAULT_OPPORTUNITY_STATUSES` and `DEFAULT_VOLUNTEER_ENGAGEMENTS`, both derived from the SDK enums
- Both list controllers supply those defaults when no filter is selected
- The volunteer side strips the `vol-` prefix the same way the existing serializer does, since the backend re-adds it



## Screenshots / Demos

https://github.com/user-attachments/assets/a05d0a24-03a4-4b25-a8b9-abaca752ccdd




## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

