### PR TITLE
🔥 Remove out-of-scope landing page stubs

### DIFF
--- a/src/components/Website/Landing/Landing.tsx
+++ b/src/components/Website/Landing/Landing.tsx
@@ -4,12 +4,9 @@ import { FooterPartnersSection } from "@/components/FooterPartners";
 import { Header } from "@/components/Header";
 import N4DLogo from "@/components/Layout/PageLayout/logos/N4DLogo";
 import { ProcessStepsSection } from "@/components/ProcessSteps";
-import { RacSection } from "@/components/RacSection";
 import { AppContainer } from "@/components/styled/container";
 import { TestimonialsSection } from "@/components/Testimonials";
 import { VolunteeringCategoriesSection } from "@/components/VolunteeringCategories";
-import { VolunteeringOpportunitiesSection } from "@/components/VolunteeringOpportunities/VolunteeringOpportunitiesSection";
-
 import { ScreenTypes } from "@/config/constants";
 import { useScreenType } from "@/context/DeviceContext";
 import { Lang } from "need4deed-sdk";
@@ -31,11 +28,9 @@ export function Landing({ lang }: { lang: Lang }) {
       <Hero />
       <VolunteeringCategoriesSection />
       {/* Transferred Components */}
-      <VolunteeringOpportunitiesSection />
       <EventsSection />
       <TestimonialsSection lang={lang} />
       <ProcessStepsSection />
-      <RacSection />
       {/* Render the existing component like the previous */}
       <FooterPartnersSection />
     </AppContainer>


### PR DESCRIPTION
## Description
Removes the out-of-scope placeholder sections from the landing page so the "Coming Soon" stubs are no longer rendered.

The underlying component files were kept unchanged. VolunteeringOpportunitiesSection has future work tracked in #135, while RacSection currently has no associated tracking issue.

## Related Issues
Closes #918

## Changes
- Removed `VolunteeringOpportunitiesSection` from `Landing.tsx`
- Removed `RacSection` from `Landing.tsx`
- Removed the corresponding unused imports
- Kept the underlying component files unchanged

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes
