### PR TITLE
Add fe image build workflow

### DIFF
--- a/.github/workflows/build-fe.yaml
+++ b/.github/workflows/build-fe.yaml
@@ -1,0 +1,32 @@
+name: build-fe
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push fe image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/fe:develop
+          build-args: |
+            API_URL=http://be:8000
+            NEXT_PUBLIC_CLOUDFRONT_URL=https://cdn.need4deed.org/images
+            NEXT_PUBLIC_CLOUDFRONT_DATA_URL=https://cdn.need4deed.org/data
+            GIT_COMMIT_SHA=${{ github.sha }}


### PR DESCRIPTION
Adds `.github/workflows/build-fe.yaml`: a manually triggered (`workflow_dispatch`) workflow that builds the fe container image and publishes it to `ghcr.io/need4deed-org/fe:develop`.

This is the image serving production at `app.need4deed.org` right now, currently built from my fork because the org repo has no image workflow. Merging this (and running it once) lets the org build its own fe image, which is one of the steps to move production fully onto org-owned repos - see need4deed-org/infra#7 and the pins in its `overlays/prod/kustomization.yaml`.

Notes on the baked build args (Next.js `NEXT_PUBLIC_*` values are fixed at build time, so they live here, not in the deployment env):

- `API_URL=http://be:8000`: the fe server proxies `/api/*` to the be service in-cluster; the browser stays same-origin, so no public API host is needed.
- `NEXT_PUBLIC_CLOUDFRONT_URL` / `NEXT_PUBLIC_CLOUDFRONT_DATA_URL` point at `cdn.need4deed.org`, the Traefik->cdn-proxy route to Infomaniak Object Storage.
- `GIT_COMMIT_SHA` is stamped for traceability.

The GHCR namespace comes from `github.repository_owner`, so the same file builds to the org namespace here and to a fork's namespace when run there. Publishing uses the workflow's own `GITHUB_TOKEN` (`packages: write`); no new secrets needed.

Closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)