### PR TITLE
Fix build-fe's checkout + commit SHA for cross-repo workflow_call

### DIFF
--- a/.github/workflows/build-fe.yaml
+++ b/.github/workflows/build-fe.yaml
@@ -17,7 +17,19 @@ jobs:
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
+      # Explicit repository+ref: a reusable workflow called cross-repo
+      # (infra's release-prod.yaml does) checks out the CALLER's repo by
+      # default, not this one.
       - uses: actions/checkout@v4
+        with:
+          repository: need4deed-org/fe
+          ref: develop
+
+      # github.sha would be the CALLER's commit in a cross-repo
+      # workflow_call, not this repo's - resolve the real one explicitly
+      # so GIT_COMMIT_SHA below is always this checkout's actual HEAD.
+      - id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -32,9 +44,9 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/fe:develop
+          tags: ghcr.io/need4deed-org/fe:develop
           build-args: |
             API_URL=http://be:8000
             NEXT_PUBLIC_CLOUDFRONT_URL=https://cdn.need4deed.org/images
             NEXT_PUBLIC_CLOUDFRONT_DATA_URL=https://cdn.need4deed.org/data
-            GIT_COMMIT_SHA=${{ github.sha }}
+            GIT_COMMIT_SHA=${{ steps.sha.outputs.sha }}


### PR DESCRIPTION
## Summary
The first live test of `infra`'s new `release-prod.yaml` orchestrator failed: calling this workflow cross-repo via `uses: need4deed-org/fe/.github/workflows/build-fe.yaml@develop` checked out **infra's** repository content by default (a documented `actions/checkout` gotcha for cross-repo `workflow_call`), not fe's — so the build had nothing to actually build.

- Pins `actions/checkout@v4` to `repository: need4deed-org/fe, ref: develop` explicitly.
- Also stops relying on `github.repository_owner`/`github.sha`, which reflect the **caller's** context in a cross-repo `workflow_call`, not this repo's. The image-tag owner happened to still resolve correctly today only because `infra` and `fe` share the same org — `GIT_COMMIT_SHA` would have silently baked in `infra`'s commit SHA instead of fe's real one. Resolves the real HEAD via `git rev-parse HEAD` right after checkout instead.

No behavior change for standalone `workflow_dispatch` runs (already defaulted to `develop`'s own content in that context).