### PR TITLE
add opportunities to the NGO dashboard sidebar

### DIFF
--- a/src/components/Layout/DashboardLayout/NavigationBar.tsx
+++ b/src/components/Layout/DashboardLayout/NavigationBar.tsx
@@ -134,12 +134,12 @@ export default function NavigationBar() {
             Icon: UserCheckIcon,
             route: DashboardRoutes.Volunteers,
           },
-          {
-            label: t("dashboard.home.sidebar.opportunities"),
-            Icon: ShootingStarIcon,
-            route: DashboardRoutes.Opportunities,
-          },
         ]),
+    {
+      label: t("dashboard.home.sidebar.opportunities"),
+      Icon: ShootingStarIcon,
+      route: DashboardRoutes.Opportunities,
+    },
     {
       label: t("dashboard.home.sidebar.agents"),
       Icon: BookOpenTextIcon,


### PR DESCRIPTION
## Description
Add opportunities to the NGO dashboard sidebar. NGO users had no way to reach the opportunities page from the dashboard. The sidebar entry was hidden from them, so the page was only reachable by typing the URL.


## Related Issues
Closes #935

## Changes
- Opportunities is now shown to NGO users; it was hidden from them

## Screenshots / Demos
<img width="1357" height="691" alt="Screenshot from 2026-08-23 13-58-19" src="https://github.com/user-attachments/assets/38e3aaab-c4d1-488e-a028-990ce13eb0c9" />


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

