### PR TITLE
give NGO users the full opportunity view

### DIFF
--- a/src/components/Dashboard/Opportunities/Filters/FiltersContent.tsx
+++ b/src/components/Dashboard/Opportunities/Filters/FiltersContent.tsx
@@ -13,7 +13,8 @@ type Props = {
 
 export default function FiltersContent({ setFilter, filter }: Props) {
   const { t } = useTranslation();
-  const { isAuthorized } = useAuth();
+  const { isAuthorized, isAgent } = useAuth();
+  const canSeeFullView = isAuthorized || isAgent;
 
   const { districtFilters, languageFilters, statusFilters, typeFilters, activityFilters, availabilityFilters } =
     createOpportunityFilterItems(filter, setFilter, t);
@@ -24,7 +25,7 @@ export default function FiltersContent({ setFilter, filter }: Props) {
       <AccordionFilter header={t("dashboard.volunteers.filters.district")} items={districtFilters} />
       <AccordionFilter header={t("dashboard.volunteers.filters.languages")} items={languageFilters} />
       <AccordionFilter header={t("dashboard.volunteers.filters.activities")} items={activityFilters} />
-      {isAuthorized && (
+      {canSeeFullView && (
         <AccordionFilter
           header={t("dashboard.opportunities.filters.schedule.header")}
           groupedItems={availabilityFilters}

--- a/src/components/Dashboard/Opportunities/Opportunities.tsx
+++ b/src/components/Dashboard/Opportunities/Opportunities.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { DashboardLayout } from "@/components/Layout";
 import { apiPathOption, questionMark } from "@/config/constants";
 import { useGetVolunteer, useGetQuery } from "@/hooks";
-import { ApiOptionLists, EntityTableName, UserRole } from "need4deed-sdk";
+import { ApiOptionLists, EntityTableName } from "need4deed-sdk";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import Filters from "../common/CardsFilter/Filters";
 import CardsHeader from "../common/CardsHeader/CardsHeader";
@@ -27,7 +27,6 @@ import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 export function Opportunities() {
   const user = useCurrentUser(true);
-  const isAgent = user?.role === UserRole.AGENT;
   const { t } = useTranslation();
   const [isFiltersOpen, setIsFiltersOpen] = useState(false);
   const [numOfOpps, setNumOfOpps] = useState(0);
@@ -39,16 +38,14 @@ export function Opportunities() {
   const sortOrder = parseSortParam(searchParams.get(SORT_PARAM));
   const tabs = !user
     ? []
-    : isAgent
-      ? [t("dashboard.opportunities.tabs.tab2"), t("dashboard.opportunities.tabs.tab3")]
-      : [
-          t("dashboard.opportunities.tabs.tab1"),
-          t("dashboard.opportunities.tabs.tab2"),
-          t("dashboard.opportunities.tabs.tab3"),
-        ];
+    : [
+        t("dashboard.opportunities.tabs.tab1"),
+        t("dashboard.opportunities.tabs.tab2"),
+        t("dashboard.opportunities.tabs.tab3"),
+      ];
 
   const urlViewParam = searchParams.get("view");
-  const VIEW_MODE_BY_TAB = isAgent ? [ViewMode.CARDS, ViewMode.MAP] : [ViewMode.LIST, ViewMode.CARDS, ViewMode.MAP];
+  const VIEW_MODE_BY_TAB = [ViewMode.LIST, ViewMode.CARDS, ViewMode.MAP];
   const foundIndex = VIEW_MODE_BY_TAB.findIndex((mode) => mode === urlViewParam);
   const selectedTabIndex = foundIndex === -1 ? 0 : foundIndex;
   const viewMode = VIEW_MODE_BY_TAB[selectedTabIndex];

--- a/src/components/Dashboard/Opportunities/OpportunityCardList.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityCardList.tsx
@@ -26,10 +26,11 @@ export function OpportunityCardList({
   activitiesList,
   districtsList,
 }: Props) {
-  const { isAuthorized } = useAuth();
+  const { isAuthorized, isAgent } = useAuth();
+  const canSeeFullView = isAuthorized || isAgent;
 
   const items = opportunities.map((opp) =>
-    isAuthorized ? (
+    canSeeFullView ? (
       <OpportunityCard
         key={opp.id}
         opportunity={opp}

--- a/src/components/Dashboard/Opportunities/OpportunityTableList.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityTableList.tsx
@@ -29,16 +29,17 @@ export function OpportunityTableList({
   volunteerId,
 }: TableListProps) {
   const { t } = useTranslation();
-  const { isAuthorized } = useAuth();
+  const { isAuthorized, isAgent } = useAuth();
+  const canSeeFullView = isAuthorized || isAgent;
 
   const columns = useMemo(() => createOpportunityTableColumns(t), [t]);
   const readOnlyColumns = useMemo(() => createReadOnlyAgentTableColumns(t), [t]);
   return (
     <EntityTableList
-      columns={isAuthorized ? columns : readOnlyColumns}
+      columns={canSeeFullView ? columns : readOnlyColumns}
       data={opportunities}
       renderRow={(opportunity, isLast) =>
-        isAuthorized ? (
+        canSeeFullView ? (
           <OpportunityTableRow
             key={opportunity.id}
             opportunity={opportunity}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -5,11 +5,11 @@ export const useAuth = (compareId?: Id) => {
   const user = useCurrentUser();
   const personId = user?.personId;
   const agentId = user?.agentId;
+  const isAgent = user?.role === UserRole.AGENT;
 
   const isAuthorized = user?.role === UserRole.ADMIN || user?.role === UserRole.COORDINATOR;
   const isOwnProfile =
-    (user?.role === UserRole.VOLUNTEER && personId === compareId) ||
-    (user?.role === UserRole.AGENT && agentId === compareId);
+    (user?.role === UserRole.VOLUNTEER && personId === compareId) || (isAgent && agentId === compareId);
 
-  return { isAuthorized, isOwnProfile };
+  return { isAuthorized, isOwnProfile, isAgent };
 };


### PR DESCRIPTION
 ## Update 2026-08-27

Nadav settled the scope question: anyone from the same NGO/agent sees that NGO/agent's opportunities. Backend half is be#916 and needs to land before this one; otherwise, NGO users get a clickable full view of every organisation's opportunities.


## Description
NGO users get the same opportunity view as coordinators: the list tab, full table columns, clickable rows and cards, and the schedule filter. Previously, they got a read-only version with fewer columns and nothing clickable.

Needs the backend scoping first, so the list only contains their own opportunities. I'll open the backend issue shortly. 

Quick clarification before I open the be issue.
The one thing I want to confirm: does "their own domain" mean every shelter under that domain, or just the shelter the user belongs to? The issue says "their own operator their email domain" but then "for their own shelter", and those give different lists if a domain has more than one shelter.


## Changes
- `useAuth` returns `isAgent`; `isOwnProfile` 
- Opportunity table, cards, and filters use `isAuthorized || isAgent` instead of `isAuthorized`
- All three tabs list, cards, and map are shown to agents; the list was hidden
- `isAuthorized` itself is unchanged, so the other places that use it keep their current meaning

 ## Related Issues
  Closes #934


## Screenshots / Demos
<img width="1357" height="691" alt="Screenshot from 2026-08-23 13-58-19" src="https://github.com/user-attachments/assets/5725fd86-3ede-4312-9d54-69ca44eea7f8" />


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

