### PR TITLE
fix: opportunities table Languages column reads wrong language purpose

### DIFF
--- a/src/components/Dashboard/Opportunities/OpportunityReadOnlyTableRow.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityReadOnlyTableRow.tsx
@@ -18,7 +18,7 @@ export function OpportunityReadOnlyTableRow({ opportunity, isLast, districtsList
   const { id, title, volunteerType, location, languages } = opportunity;
   // statusMatch is not yet in ApiVolunteerOpportunityGetList SDK type
   const statusMatch = (opportunity as ApiVolunteerOpportunityGetList & { statusMatch?: string }).statusMatch;
-  const mainCommunication = getLanguagesByPurpose(languages, LangPurpose.GENERAL);
+  const recipientLanguage = getLanguagesByPurpose(languages, LangPurpose.RECIPIENT);
   const districtTitle = location[0]?.id ? (districtsList?.find((d) => d.id === location[0].id)?.title ?? null) : null;
   const districtText = abbreviateDistrict(districtTitle) || "—";
   return (
@@ -36,7 +36,7 @@ export function OpportunityReadOnlyTableRow({ opportunity, isLast, districtsList
         {t(`dashboard.opportunities.matchStatus.${statusMatch}`)}
       </TableCell>
       <TableCell data-testid={`opportunity-languages-${id}`} $width={OPPORTUNITY_READ_ONLY_COL_WIDTHS.languages}>
-        {mainCommunication || "—"}
+        {recipientLanguage || "—"}
       </TableCell>
       <TableCell data-testid={`opportunity-district-${id}`} $width={OPPORTUNITY_READ_ONLY_COL_WIDTHS.district}>
         {districtText || "—"}

--- a/src/components/Dashboard/Opportunities/OpportunityTableRow.tsx
+++ b/src/components/Dashboard/Opportunities/OpportunityTableRow.tsx
@@ -45,7 +45,7 @@ export function OpportunityTableRow({ opportunity, isLast, districtsList, volunt
       ? formatSchedule(availability, t)
       : null;
 
-  const mainCommunication = getLanguagesByPurpose(languages, LangPurpose.GENERAL);
+  const recipientLanguage = getLanguagesByPurpose(languages, LangPurpose.RECIPIENT);
   const isMatched = statusMatch === OpportunityMatchStatusType.MATCHED;
   const statusLabel = statusMatch ? t(`dashboard.opportunities.matchStatus.${statusMatch}`) : "—";
   const firstNames = (volunteerNames ?? []).map((name) => name.split(" ")[0]).filter(Boolean);
@@ -68,7 +68,7 @@ export function OpportunityTableRow({ opportunity, isLast, districtsList, volunt
         {isMatched ? <MatchedBadge>{statusLabel}</MatchedBadge> : <TruncatedText>{statusLabel}</TruncatedText>}
       </TableCell>
       <TableCell $noWrap $width={OPPORTUNITY_COL_WIDTHS.languages} data-testid={`opportunity-languages-${id}`}>
-        <TruncatedText>{mainCommunication || "—"}</TruncatedText>
+        <TruncatedText>{recipientLanguage || "—"}</TruncatedText>
       </TableCell>
       <TableCell $noWrap $width={OPPORTUNITY_COL_WIDTHS.district} data-testid={`opportunity-district-${id}`}>
         <TruncatedText>{districtText}</TruncatedText>


### PR DESCRIPTION
## Description

The dashboard opportunities table's Languages column filtered `opportunity.languages` by `LangPurpose.GENERAL` ("main communication"), which is frequently empty, so the column showed "—" for most/all rows. `OpportunityCard.tsx` and `OpportunityDetailsDisplay.tsx` already surface `LangPurpose.RECIPIENT` (what the refugee/resident speaks) for the equivalent data. This swaps the table's filter to match.

Self-review caught a second spot with the identical bug: `OpportunityReadOnlyTableRow.tsx`, rendered by `OpportunityTableList.tsx` for non-authorized users on the same `/dashboard/opportunities` table, had the same `LangPurpose.GENERAL` read. Fixed the same way.

This only fixes the **Languages** half of the reported bug. The **District** column fix is blocked on need4deed-org/be#895 (agent/postcode-derived district isn't in the list endpoint response yet) and will follow in a separate PR once that lands.

## Related Issues

Part of #944

## Changes

- `OpportunityTableRow.tsx`: filter by `LangPurpose.RECIPIENT` instead of `LangPurpose.GENERAL` for the Languages column.
- `OpportunityReadOnlyTableRow.tsx`: same fix, for the read-only/non-authorized variant of the same table.

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes