### PR TITLE
956: feat volunteer profile completion after email confirmation

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "email-validator": "^2.0.4",
     "i18next": "^25.3.2",
-    "need4deed-sdk": "0.0.147",
+    "need4deed-sdk": "0.0.152",
     "next": "15.3.8",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.0",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -2211,6 +2211,10 @@
     "submit": "Absenden",
     "alreadyUser": "Bereits registriert?",
     "loginLink": "In Ihrem Konto anmelden",
+    "completion": {
+      "title": "Schließen Sie die Einrichtung Ihres Kontos ab",
+      "subtitle": "Erzählen Sie uns etwas über sich"
+    },
     "steps": {
       "account": {
         "title": "Ihr Konto",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -2207,12 +2207,30 @@
     "title": "Ehrenamtlich werden",
     "subtitle": "Erstellen Sie ein Konto, um sich ehrenamtlich für Geflüchtete in Berlin zu engagieren.",
     "next": "Weiter",
+    "back": "Zurück",
+    "submit": "Absenden",
     "alreadyUser": "Bereits registriert?",
     "loginLink": "In Ihrem Konto anmelden",
     "steps": {
       "account": {
         "title": "Ihr Konto",
         "description": "Geben Sie Ihre persönlichen Daten ein, um ein Login zu erstellen."
+      },
+      "availabilityInfo": {
+        "title": "Verfügbarkeit, Aktivitäten & Fähigkeiten",
+        "description": "Wann sind Sie verfügbar, an welchen Aktivitäten sind Sie interessiert und welche Fähigkeiten bringen Sie mit?"
+      },
+      "address": {
+        "title": "Standort & Sprachen",
+        "description": "Wo befinden Sie sich und welche Sprachen sprechen Sie?"
+      },
+      "certificates": {
+        "title": "Letzte Details",
+        "description": "Geben Sie an, ob Sie die folgenden Zertifikate besitzen und wie Sie von uns erfahren haben."
+      },
+      "review": {
+        "title": "Überprüfung",
+        "description": "Bitte überprüfen Sie Ihre Angaben vor dem Absenden."
       }
     },
     "fields": {
@@ -2230,7 +2248,12 @@
     "errors": {
       "passwordTooShort": "Das Passwort muss mindestens 8 Zeichen lang sein",
       "passwordMismatch": "Die Passwörter stimmen nicht überein",
-      "phoneTooShort": "Die Telefonnummer muss mindestens 7 Zeichen lang sein"
+      "phoneTooShort": "Die Telefonnummer muss mindestens 7 Zeichen lang sein",
+      "missingToken": "Dein Registrierungslink ist ungültig oder abgelaufen. Bitte verwende den Link aus deiner Bestätigungs-E-Mail."
+    },
+    "success": {
+      "title": "Registrierung erfolgreich!",
+      "description": "Ihr Konto wurde erstellt. Sie werden in Kürze zur Anmeldeseite weitergeleitet."
     },
     "checkEmail": {
       "title": "Prüfen Sie Ihre E-Mail",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -2247,7 +2247,77 @@
       "consent": {
         "header": "Hiermit stimme ich zu:",
         "and": "und"
-      }
+      },
+      "postcode": "PLZ (Berlin) Deines Wohnorts*",
+      "locations": {
+        "header": "Bevorzugte Bezirke* (Berlin)",
+        "para": "*Denke daran, dass die meisten Unterkünfte außerhalb des Rings liegen!",
+        "error": "",
+        "helpText": "Die möglichen ehrenamtlichen Tätigkeiten, die wir Dir schicken, basieren sowohl auf Deinen bevorzugten Bezirken als auch auf der Postleitzahl Deines Wohnorts.",
+        "helpTitle": ""
+      },
+      "availability": {
+        "header": "Verfügbarkeit*",
+        "para": "*Denke daran, dass die meisten Tätigkeiten innerhalb der regulären Arbeitszeit von 9-17 Uhr stattfinden, zumindest am Anfang!",
+        "error": "",
+        "helpText": "Die Verfügbarkeiten von Mo-So beziehen sich auf regelmäßige ehrenamtliche Tätigkeiten. Wenn Deine Verfügbarkeiten auf bestimmte Zeiträume begrenzt sind oder erklärt werden müssen, schreibe dies bitte im letzten Abschnitt in die Kommentare.",
+        "helpTitle": ""
+      },
+      "languages": {
+        "header": "Sprachen*",
+        "headerWithoutAsterick": "Sprachen",
+        "para": "*Wenn Du Deine Sprache nicht findest, wähle bitte \"Andere\" und gib Deine bevorzugte Sprache im Kommentarfeld unten an",
+        "addLanguage": "Sprache hinzufügen",
+        "chooseLanguage": "Sprache auswählen",
+        "chooseLevel": "Niveau auswählen",
+        "removeLanguage": "Entfernen",
+        "language": "Sprache",
+        "level": "Niveau",
+        "languagesNative": {
+          "header": "Muttersprache",
+          "error": ""
+        },
+        "languagesFluent": {
+          "header": "Fließend",
+          "error": "Bitte wähle mindestens eine Sprache aus"
+        },
+        "languagesIntermediate": {
+          "header": "Mittelstufe"
+        },
+        "singleLevelError": "Bitte gib nur ein Niveau pro Sprache an",
+        "helpText": "Fließend bedeutet, dass Du denkst, dass Du bei Bedarf in dieser Sprache übersetzen kannst. Die wählbaren Sprachen orientieren sich an den Bedarfen der Geflüchteten. Wenn die Sprache, die Du als Muttersprache oder fließend beherrschst, nicht hier aufgelistet ist, füge sie bitte im letzten Kommentarfeld hinzu!",
+        "helpTitle": ""
+      },
+      "activities": {
+        "header": "Bevorzugte Aktivitäten*",
+        "error": "Bitte wähle mindestens eine Aktivität aus",
+        "helpText": "Dies sind die häufigsten Bedarfe, die ehrenamtliche Unterstützung erfordern. Manchmal können sie sich ändern, sobald Du mit der ehrenamtlichen Arbeit beginnst.",
+        "helpTitle": ""
+      },
+      "skills": {
+        "header": "Zusätzliche Fähigkeiten oder Erfahrungen",
+        "helpText": "Alles, was Du an Erfahrungen, Fähigkeiten oder Fachwissen teilen kannst, kann nützlich sein. Aber keine Sorge, es ist keine Voraussetzung für ehrenamtliches Engagement!",
+        "helpTitle": ""
+      },
+      "certOfGoodConduct": {
+        "header": "Erweitertes Führungszeugnis*",
+        "error": "Bitte wähle mindestens eine Option aus",
+        "why": "Warum brauche ich ein Führungszeugnis?",
+        "true": "Ich habe ein erweitertes Führungszeugnis.",
+        "false": "Es muss beantragt werden.",
+        "helpText": "",
+        "helpTitle": ""
+      },
+      "certMeaslesVaccination": {
+        "header": "Masernimpfnachweis*",
+        "error": "Bitte wähle mindestens eine Option aus",
+        "true": "Ich habe einen Masernimpfnachweis.",
+        "false": "Ich habe noch keinen Nachweis und reiche ihn nach.",
+        "helpText": "",
+        "helpTitle": ""
+      },
+      "leadFrom": "Wie hast Du von uns erfahren?",
+      "comments": "Kommentare (andere Sprachen, Zeiten, Standorte, Aktivitäten usw.)"
     },
     "errors": {
       "passwordTooShort": "Das Passwort muss mindestens 8 Zeichen lang sein",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1863,12 +1863,34 @@
     "title": "Become a volunteer",
     "subtitle": "Create an account to start volunteering with refugees in Berlin.",
     "next": "Next",
+    "back": "Back",
+    "submit": "Submit",
     "alreadyUser": "Already registered?",
     "loginLink": "Login to your account",
+    "completion": {
+      "title": "Finish setting up your account",
+      "subtitle": "Tell us about your yourself"
+    },
     "steps": {
       "account": {
         "title": "Your account",
         "description": "Enter your personal details to create a login."
+      },
+      "availabilityInfo": {
+        "title": "Availability, activities & skills",
+        "description": "When are you available, what activities are you interested in and what skills do you have?"
+      },
+      "address": {
+        "title": "Location & languages",
+        "description": "Where is you located and what languages do you speak?"
+      },
+      "certificates": {
+        "title": "Final details",
+        "description": "Declare whether you have the following certificates along with how you heard of us"
+      },
+      "review": {
+        "title": "Review",
+        "description": "Please check your details before submitting."
       }
     },
     "fields": {
@@ -1883,10 +1905,15 @@
         "and": "and"
       }
     },
+    "success": {
+      "title": "Registration successful!",
+      "description": "Your account has been created. You will be redirected to the login page shortly."
+    },
     "errors": {
       "passwordTooShort": "Password must be at least 8 characters",
       "passwordMismatch": "Passwords do not match",
-      "phoneTooShort": "Phone number must be at least 7 characters"
+      "phoneTooShort": "Phone number must be at least 7 characters",
+      "missingToken": "Your registration link is invalid or has expired. Please use the link from your verification email."
     },
     "checkEmail": {
       "title": "Check your email",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1882,7 +1882,7 @@
       },
       "address": {
         "title": "Location & languages",
-        "description": "Where is you located and what languages do you speak?"
+        "description": "Where are you located and what languages do you speak?"
       },
       "certificates": {
         "title": "Final details",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1903,7 +1903,66 @@
       "consent": {
         "header": "I hereby agree to the:",
         "and": "and"
-      }
+      },
+      "postcode": "PLZ (Berlin) of your place of residence*",
+      "locations": {
+        "header": "Preferred districts* (Berlin)",
+        "para": "*keep in mind that most accommodation centers are outside the ring!",
+        "helpText": "The offers we send you will be based on your preferred districts and the zip code of your place of residence.",
+        "helpTitle": ""
+      },
+      "availability": {
+        "header": "Availability*",
+        "para": "*keep in mind that most opportunities are limited to the 9-17 working hours, at least for the beginning!",
+        "helpText": "The Mon-Sun availabilities refer to regularly repeating volunteering. If the time frames are limited to some periods or need explaining, please write in the comments at the last section",
+        "helpTitle": ""
+      },
+      "languages": {
+        "header": "Languages*",
+        "headerWithoutAsterick": "Languages",
+        "para": "*if you can't find your language, please select \"Other\" and indicate your preferable language in comments section bellow",
+        "addLanguage": "Add language",
+        "chooseLanguage": "Choose a language",
+        "chooseLevel": "Choose a level",
+        "removeLanguage": "Remove",
+        "language": "Language",
+        "level": "Level",
+        "languagesNative": {
+          "header": "Native"
+        },
+        "languagesFluent": {
+          "header": "Fluent",
+          "error": "Please pick at least one language"
+        },
+        "languagesIntermediate": {
+          "header": "Intermediate"
+        },
+        "singleLevelError": "Please pick a language at one level only",
+        "helpText": "Fluent means you think you can support it in case some translations between languages are needed\nThese languages are oriented by the needs of refugees, if the language you are native or fluent at is not here, please add it in the last comment section!",
+        "helpTitle": ""
+      },
+      "activities": {
+        "header": "Preferred Activities*",
+        "error": "Please pick at least one activity",
+        "helpText": "These are the most common needs that require voluntary support. Sometimes they can change once you started volunteering."
+      },
+      "skills": {
+        "header": "Additional skills or experience",
+        "helpText": "Anything you feel that you can share from your experience, abilities or expertise can  be useful to know, but don't worry, its not a must for volunteering!"
+      },
+      "certOfGoodConduct": {
+        "header": "Certificate of Good Conduct (Erweitertes Führungszeungnis)*",
+        "why": "Why do I need this?",
+        "true": "I have one",
+        "false": " Need to apply"
+      },
+      "certMeaslesVaccination": {
+        "header": "Certificate of Measles Vaccination*",
+        "true": "I have one",
+        "false": "Will turn in later"
+      },
+      "leadFrom": "Where did you hear about us?",
+      "comments": "Comments (other languages, times, locations, activities, etc.)"
     },
     "success": {
       "title": "Registration successful!",

--- a/src/app/[lang]/register/volunteer/complete/page.tsx
+++ b/src/app/[lang]/register/volunteer/complete/page.tsx
@@ -1,0 +1,5 @@
+import { ProfileCompletion } from "@/components/VolunteerRegistration/ProfileCompletion";
+
+export default function ProfileCompletionPage() {
+  return <ProfileCompletion />;
+}

--- a/src/components/Dashboard/Profile/sections/VolunteerProfile/mappingUtils.ts
+++ b/src/components/Dashboard/Profile/sections/VolunteerProfile/mappingUtils.ts
@@ -11,7 +11,7 @@ export function createMapping(items: ApiLanguageOption[]): Mapping {
   const titleToId: Record<string, number> = {};
   const titleToIdLower: Record<string, number> = {};
 
-  items.forEach((item) => {
+  items?.forEach((item) => {
     idToTitle[item.id] = item.title;
     titleToId[item.title] = item.id;
     titleToIdLower[item.title.toLowerCase()] = item.id;

--- a/src/components/EditableField/EditableField.tsx
+++ b/src/components/EditableField/EditableField.tsx
@@ -132,7 +132,7 @@ const Arrow = styled(IoIosArrowDown)`
 
 const DropdownList = styled.div<{ $direction?: "up" | "down" }>`
   position: var(--editableField-dropdownList-position);
-  ${(props) => (props.$direction === "down" ? "top: 100%;" : "bottom: 100%;")};
+  ${(props) => (props.$direction === "down" ? "var(--editableField-dropdownList-top);" : "bottom: 100%;")};
   left: var(--editableField-dropdownList-left);
   width: var(--editableField-dropdownList-width);
   background: var(--editableField-dropdownList-background);

--- a/src/components/EditableField/EditableField.tsx
+++ b/src/components/EditableField/EditableField.tsx
@@ -130,9 +130,9 @@ const Arrow = styled(IoIosArrowDown)`
   }
 `;
 
-const DropdownList = styled.div`
+const DropdownList = styled.div<{ $direction?: "up" | "down" }>`
   position: var(--editableField-dropdownList-position);
-  top: var(--editableField-dropdownList-top);
+  ${(props) => (props.$direction === "down" ? "top: 100%;" : "bottom: 100%;")};
   left: var(--editableField-dropdownList-left);
   width: var(--editableField-dropdownList-width);
   background: var(--editableField-dropdownList-background);
@@ -286,6 +286,7 @@ interface EditableFieldProps<T = string | number | string[]> {
   maxLength?: number;
   labels?: string[];
   displayValue?: string;
+  dropdownDirection?: "up" | "down";
 }
 
 export const EditableField = forwardRef(function EditableField<T extends string | number | string[]>(
@@ -304,6 +305,7 @@ export const EditableField = forwardRef(function EditableField<T extends string 
     maxLength,
     labels,
     displayValue,
+    dropdownDirection = "down",
   }: EditableFieldProps<T>,
   ref: React.Ref<EditableFieldRef<T>>,
 ) {
@@ -518,7 +520,7 @@ export const EditableField = forwardRef(function EditableField<T extends string 
             </DropdownButton>
 
             {open && (
-              <DropdownList>
+              <DropdownList $direction={dropdownDirection}>
                 {options.map((option, idx) => {
                   const isSelected =
                     type === "checkbox-list"

--- a/src/components/VolunteerRegistration/ProfileCompletion/ProfileCompletion.tsx
+++ b/src/components/VolunteerRegistration/ProfileCompletion/ProfileCompletion.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { Button } from "@/components/core/button";
+import { apiPathOption } from "@/config/constants";
+import { useRegisterVolunteer } from "@/hooks/useRegisterVolunteer";
+import { setAuthHint } from "@/utils/helpers";
+import { useForm } from "@tanstack/react-form";
+import i18next from "i18next";
+import { ApiOptionLists } from "need4deed-sdk";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ProgressBar } from "../ProgressBar";
+import { AddressStep } from "../steps/AddressStep";
+import { AvailabilityStep } from "../steps/AvailabilityStep";
+import { CertificateStep } from "../steps/CertificateStep";
+import { Actions, Card, ErrorBanner, PageSubtitle, PageTitle, StepDescription, StepTitle, Wrapper } from "../styled";
+import { defaultVolunteerRegistrationData, ProfileCompletionData, TOTAL_COMPLETION_STEPS } from "../types";
+import { useGetQuery } from "@/hooks";
+
+export function ProfileCompletion() {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const token = useSearchParams().get("token");
+
+  const [step, setStep] = useState(1);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const errorBannerRef = useRef<HTMLDivElement>(null);
+
+  const { data: optionLists } = useGetQuery<ApiOptionLists>({
+    queryKey: ["options"],
+    apiPath: apiPathOption,
+  });
+
+  const registerMutation = useRegisterVolunteer({
+    token,
+    onSuccess: () => {
+      setAuthHint();
+      router.push(`/${i18next.language}/dashboard`);
+    },
+  });
+
+  const formVolunteer = useForm<ProfileCompletionData>({
+    defaultValues: defaultVolunteerRegistrationData,
+    onSubmit: async ({ value }) => {
+      if (!token) {
+        showSubmitError(t("volunteerRegistration.errors.missingToken"));
+        return;
+      }
+      setSubmitError(null);
+      try {
+        await registerMutation.mutateAsync({ volunteer: value });
+      } catch (error) {
+        showSubmitError(t("message.errorGeneric"));
+        console.error(error);
+      }
+    },
+  });
+
+  const showSubmitError = useCallback((message: string) => {
+    setSubmitError(message);
+    requestAnimationFrame(() => {
+      errorBannerRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!token) showSubmitError(t("agentRegistration.errors.missingToken"));
+  }, [token, t, showSubmitError]);
+
+  const handleNext = async () => {
+    const errors = await formVolunteer.validateAllFields("submit");
+    const hasStepErrors = Object.keys(errors).length > 0;
+
+    if (!hasStepErrors) {
+      setStep((s) => s + 1);
+    }
+  };
+
+  const handleBack = () => {
+    Object.keys(formVolunteer.state.values).forEach((fieldName) => {
+      formVolunteer.setFieldMeta(fieldName as keyof ProfileCompletionData, (prev) => ({
+        ...prev,
+        errors: [],
+        errorMap: {},
+        isTouched: false,
+      }));
+    });
+
+    setStep((s) => s - 1);
+  };
+
+  const isLastStep = step === TOTAL_COMPLETION_STEPS;
+  const tokenMissing = !token;
+
+  return (
+    <Wrapper>
+      <Card>
+        <PageTitle>{t("volunteerRegistration.completion.title")}</PageTitle>
+        <PageSubtitle>{t("volunteerRegistration.completion.subtitle")}</PageSubtitle>
+
+        <ProgressBar currentStep={step} totalSteps={TOTAL_COMPLETION_STEPS} />
+
+        {submitError && <ErrorBanner ref={errorBannerRef}>{submitError}</ErrorBanner>}
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            formVolunteer.handleSubmit();
+          }}
+        >
+          {step === 1 && (
+            <div>
+              <StepTitle>{t("volunteerRegistration.steps.address.title")}</StepTitle>
+              <StepDescription>{t("volunteerRegistration.steps.address.description")}</StepDescription>
+              <AddressStep form={formVolunteer} optionLists={optionLists} />
+            </div>
+          )}
+
+          {step === 2 && (
+            <div>
+              <StepTitle>{t("volunteerRegistration.steps.availabilityInfo.title")}</StepTitle>
+              <StepDescription>{t("volunteerRegistration.steps.availabilityInfo.description")}</StepDescription>
+              <AvailabilityStep form={formVolunteer} optionLists={optionLists} />
+            </div>
+          )}
+
+          {step === 3 && (
+            <div>
+              <StepTitle>{t("volunteerRegistration.steps.certificates.title")}</StepTitle>
+              <StepDescription>{t("volunteerRegistration.steps.certificates.description")}</StepDescription>
+              <CertificateStep form={formVolunteer} optionLists={optionLists} />
+            </div>
+          )}
+
+          <Actions>
+            {step > 1 ? (
+              <formVolunteer.Subscribe selector={(state) => state.isSubmitting}>
+                {(isSubmitting) => (
+                  <Button
+                    text={t("volunteerRegistration.back")}
+                    backgroundcolor="var(--color-white)"
+                    textColor="var(--color-aubergine)"
+                    border="1px solid var(--color-aubergine)"
+                    onClick={handleBack}
+                    disabled={isSubmitting}
+                  />
+                )}
+              </formVolunteer.Subscribe>
+            ) : (
+              <div />
+            )}
+
+            {isLastStep ? (
+              <formVolunteer.Subscribe selector={(state) => state.isSubmitting}>
+                {(isSubmitting) => (
+                  <Button
+                    type="submit"
+                    text={t("volunteerRegistration.submit")}
+                    backgroundcolor="var(--color-aubergine)"
+                    textColor="var(--color-white)"
+                    disabled={isSubmitting || tokenMissing}
+                  />
+                )}
+              </formVolunteer.Subscribe>
+            ) : (
+              <Button
+                type="button"
+                text={t("volunteerRegistration.next")}
+                backgroundcolor="var(--color-aubergine)"
+                textColor="var(--color-white)"
+                onClick={handleNext}
+                disabled={tokenMissing}
+              />
+            )}
+          </Actions>
+        </form>
+      </Card>
+    </Wrapper>
+  );
+}

--- a/src/components/VolunteerRegistration/ProfileCompletion/ProfileCompletion.tsx
+++ b/src/components/VolunteerRegistration/ProfileCompletion/ProfileCompletion.tsx
@@ -65,7 +65,7 @@ export function ProfileCompletion() {
   }, []);
 
   useEffect(() => {
-    if (!token) showSubmitError(t("agentRegistration.errors.missingToken"));
+    if (!token) showSubmitError(t("volunteerRegistration.errors.missingToken"));
   }, [token, t, showSubmitError]);
 
   const handleNext = async () => {

--- a/src/components/VolunteerRegistration/ProfileCompletion/ProfileCompletion.tsx
+++ b/src/components/VolunteerRegistration/ProfileCompletion/ProfileCompletion.tsx
@@ -6,17 +6,24 @@ import { useRegisterVolunteer } from "@/hooks/useRegisterVolunteer";
 import { setAuthHint } from "@/utils/helpers";
 import { useForm } from "@tanstack/react-form";
 import i18next from "i18next";
-import { ApiOptionLists } from "need4deed-sdk";
+import { ApiOptionLists, ApiVolunteerRegisterNew, DocumentStatusType } from "need4deed-sdk";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ProgressBar } from "../ProgressBar";
 import { AddressStep } from "../steps/AddressStep";
 import { AvailabilityStep } from "../steps/AvailabilityStep";
 import { CertificateStep } from "../steps/CertificateStep";
 import { Actions, Card, ErrorBanner, PageSubtitle, PageTitle, StepDescription, StepTitle, Wrapper } from "../styled";
-import { defaultVolunteerRegistrationData, ProfileCompletionData, TOTAL_COMPLETION_STEPS } from "../types";
+import { DefaultVolunteerRegistrationData, defaultVolunteerRegistrationData, TOTAL_COMPLETION_STEPS } from "../types";
 import { useGetQuery } from "@/hooks";
+import { formToApiAvailability } from "@/components/Dashboard/Profile/sections/VolunteerProfile/availabilityUtils";
+import { createMapping } from "@/components/Dashboard/Profile/sections/VolunteerProfile/mappingUtils";
+import {
+  mapToApiItems,
+  transformLanguagesToApi,
+} from "@/components/Dashboard/Profile/sections/VolunteerProfile/transformers";
+import { ApiLanguageOption } from "@/components/Dashboard/Profile/sections/VolunteerProfile/hooks";
 
 export function ProfileCompletion() {
   const { t } = useTranslation();
@@ -32,6 +39,42 @@ export function ProfileCompletion() {
     apiPath: apiPathOption,
   });
 
+  const languageMapping = useMemo(
+    () => createMapping(optionLists?.language as ApiLanguageOption[]),
+    [optionLists?.language],
+  );
+  const activityMapping = useMemo(
+    () => createMapping(optionLists?.activity as ApiLanguageOption[]),
+    [optionLists?.activity],
+  );
+  const skillMapping = useMemo(() => createMapping(optionLists?.skill as ApiLanguageOption[]), [optionLists?.language]);
+
+  const leadMapping = useMemo(
+    () => createMapping(optionLists?.lead_from as ApiLanguageOption[]),
+    [optionLists?.lead_from],
+  );
+  const processCertOfGoodConduct = (value: boolean | undefined) => {
+    if (value) return DocumentStatusType.YES;
+    else return DocumentStatusType.NO;
+  };
+  const processCertOfMeaslesCert = (value: boolean | undefined) => {
+    if (value) return DocumentStatusType.YES;
+    else return DocumentStatusType.NO;
+  };
+
+  const formToApiVolunteer = (value: DefaultVolunteerRegistrationData): ApiVolunteerRegisterNew => ({
+    addressPostcode: value.addressPostcode,
+    locations: value.locations.map((id) => ({ id })),
+    languages: transformLanguagesToApi(value.languages, languageMapping),
+    availability: formToApiAvailability(value.availability),
+    activities: mapToApiItems(value.activities.map(String), activityMapping),
+    skills: mapToApiItems(value.skills.map(String), skillMapping),
+    leadFrom: mapToApiItems(value.leadFrom.map(String), leadMapping),
+    goodConductCertificate: processCertOfGoodConduct(value.goodConductCertificate),
+    measlesVaccination: processCertOfMeaslesCert(value.measlesVaccination),
+    comments: value.comments,
+  });
+
   const registerMutation = useRegisterVolunteer({
     token,
     onSuccess: () => {
@@ -40,7 +83,7 @@ export function ProfileCompletion() {
     },
   });
 
-  const formVolunteer = useForm<ProfileCompletionData>({
+  const formVolunteer = useForm<DefaultVolunteerRegistrationData>({
     defaultValues: defaultVolunteerRegistrationData,
     onSubmit: async ({ value }) => {
       if (!token) {
@@ -49,7 +92,7 @@ export function ProfileCompletion() {
       }
       setSubmitError(null);
       try {
-        await registerMutation.mutateAsync({ volunteer: value });
+        await registerMutation.mutateAsync(formToApiVolunteer(value));
       } catch (error) {
         showSubmitError(t("message.errorGeneric"));
         console.error(error);
@@ -79,7 +122,7 @@ export function ProfileCompletion() {
 
   const handleBack = () => {
     Object.keys(formVolunteer.state.values).forEach((fieldName) => {
-      formVolunteer.setFieldMeta(fieldName as keyof ProfileCompletionData, (prev) => ({
+      formVolunteer.setFieldMeta(fieldName as keyof DefaultVolunteerRegistrationData, (prev) => ({
         ...prev,
         errors: [],
         errorMap: {},

--- a/src/components/VolunteerRegistration/ProfileCompletion/index.ts
+++ b/src/components/VolunteerRegistration/ProfileCompletion/index.ts
@@ -1,0 +1,1 @@
+export { ProfileCompletion } from "./ProfileCompletion";

--- a/src/components/VolunteerRegistration/ProfileCompletion/styled.ts
+++ b/src/components/VolunteerRegistration/ProfileCompletion/styled.ts
@@ -1,0 +1,79 @@
+import styled from "styled-components";
+
+interface MatchBannerProps {
+  $matched: boolean;
+}
+
+export const MatchBanner = styled.div<MatchBannerProps>`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  margin-top: 8px;
+  font-size: 0.9375rem;
+  background: ${({ $matched }) =>
+    $matched ? "var(--color-success-light, #f0fdf4)" : "var(--color-orchid-light, #faf5ff)"};
+  border: 1px solid ${({ $matched }) => ($matched ? "var(--color-success-border, #bbf7d0)" : "var(--color-grey-200)")};
+  color: var(--color-midnight);
+`;
+
+// Plain descriptive copy above the match list — must not read as a CTA the
+// way MatchBanner's colored/bordered box does; the row below is the CTA.
+export const MatchListCopy = styled.p`
+  font-size: 0.9375rem;
+  color: var(--color-grey-500);
+  margin: 8px 0 4px;
+`;
+
+export const CheckMark = styled.span`
+  font-size: 1.25rem;
+  color: var(--color-success, #16a34a);
+  flex-shrink: 0;
+`;
+
+// A single candidate in the address-match picker: the whole row is the
+// call-to-action (click to select), not a row + separate button.
+export const MatchRow = styled.button`
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 12px 16px;
+  border-radius: 8px;
+  margin-top: 6px;
+  font-size: 0.9375rem;
+  cursor: pointer;
+  background: var(--color-white);
+  border: 1px solid var(--color-grey-200);
+  color: var(--color-midnight);
+
+  &:hover {
+    background: var(--color-orchid-light, #faf5ff);
+    border-color: var(--color-aubergine);
+  }
+`;
+
+export const MatchActions = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+`;
+
+interface SmallButtonProps {
+  $primary?: boolean;
+}
+
+export const SmallButton = styled.button<SmallButtonProps>`
+  padding: 6px 14px;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid ${({ $primary }) => ($primary ? "var(--color-aubergine)" : "var(--color-grey-300)")};
+  background: ${({ $primary }) => ($primary ? "var(--color-aubergine)" : "var(--color-white)")};
+  color: ${({ $primary }) => ($primary ? "var(--color-white)" : "var(--color-midnight)")};
+
+  &:hover {
+    opacity: 0.85;
+  }
+`;

--- a/src/components/VolunteerRegistration/ProgressBar.tsx
+++ b/src/components/VolunteerRegistration/ProgressBar.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 32px;
+`;
+
+const StepLabel = styled.span`
+  font-size: 0.875rem;
+  color: var(--color-grey-500);
+`;
+
+const Track = styled.div`
+  display: flex;
+  gap: 6px;
+`;
+
+interface SegmentProps {
+  $active: boolean;
+}
+
+const Segment = styled.div<SegmentProps>`
+  flex: 1;
+  height: 4px;
+  border-radius: 2px;
+  background: ${({ $active }) => ($active ? "var(--color-aubergine)" : "var(--color-grey-200)")};
+  transition: background 0.2s ease;
+`;
+
+interface Props {
+  currentStep: number;
+  totalSteps: number;
+}
+
+export function ProgressBar({ currentStep, totalSteps }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <Container>
+      <StepLabel>
+        {t("agentRegistration.step")} {currentStep} / {totalSteps}
+      </StepLabel>
+      <Track>
+        {Array.from({ length: totalSteps }, (_, i) => (
+          <Segment key={i} $active={i < currentStep} />
+        ))}
+      </Track>
+    </Container>
+  );
+}

--- a/src/components/VolunteerRegistration/steps/AddressStep.tsx
+++ b/src/components/VolunteerRegistration/steps/AddressStep.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { createMapping } from "@/components/Dashboard/Profile/sections/VolunteerProfile/mappingUtils";
+import { ApiLanguageOption } from "@/components/Dashboard/Profile/sections/VolunteerProfile/hooks";
+import { LanguageFields } from "@/components/forms/LanguageFields";
+import { EditableField } from "@/components/EditableField/EditableField";
+import { ErrorMessage, FormInput } from "@/components/core/common";
+import { ApiOptionLists } from "need4deed-sdk";
+import { useTranslation } from "react-i18next";
+import { FieldLabel, FieldWrapper } from "../styled";
+import { ProfileCompletionData } from "../types";
+import { useForm } from "@tanstack/react-form";
+
+type Props = {
+  form: ReturnType<typeof useForm<ProfileCompletionData>>;
+  optionLists?: ApiOptionLists;
+};
+
+export function AddressStep({ form, optionLists }: Props) {
+  const { t } = useTranslation();
+
+  const locations = optionLists?.district;
+  const locationMapping = createMapping(optionLists?.district as ApiLanguageOption[]);
+
+  return (
+    <div>
+      <form.Field
+        name="addressPostcode"
+        validators={{
+          onChange: ({ value }) => (!value ? t("form.error.required") : undefined),
+        }}
+      >
+        {(field) => (
+          <FieldWrapper>
+            <FieldLabel>{t("form.becomeVolunteer.fields.postcode.label")}</FieldLabel>
+            <FormInput
+              value={field.state.value || ""}
+              onInputChange={(v) => field.handleChange(v)}
+              placeHolder="12345"
+            />
+            {field.state.meta.errors.length > 0 && <ErrorMessage message={field.state.meta.errors.join(", ")} />}
+          </FieldWrapper>
+        )}
+      </form.Field>
+
+      <form.Field
+        name="locations"
+        validators={{
+          onChange: ({ value }) => (value.length === 0 ? t("form.error.required") : undefined),
+        }}
+      >
+        {(field) => (
+          <FieldWrapper>
+            <FieldLabel>{t("form.becomeVolunteer.fields.locations.header")}</FieldLabel>
+            <EditableField
+              mode="edit"
+              type="checkbox-list"
+              value={(field.state.value || []).map((location) => locationMapping.idToTitle[location])}
+              setValue={(value) => {
+                const labels = Array.isArray(value) ? value : [value];
+                const mappedIds = labels.map((val) => locationMapping.titleToId[val]);
+                field.handleChange(mappedIds);
+              }}
+              options={locations?.map((a) => a.title)}
+            />
+            {field.state.meta.errors.length > 0 && <ErrorMessage message={field.state.meta.errors.join(", ")} />}
+          </FieldWrapper>
+        )}
+      </form.Field>
+
+      <form.Field
+        name="languages"
+        validators={{
+          onBlur: ({ value }) => (!value[0].language || !value[0].level ? t("form.error.required") : undefined),
+        }}
+      >
+        {(field) => (
+          <FieldWrapper>
+            <FieldLabel>{t("form.becomeVolunteer.fields.languages.headerWithoutAsterick")}</FieldLabel>
+            <LanguageFields languages={field.state.value || []} t={t} onChange={(e) => field.handleChange(e)} />
+            {field.state.meta.errors.length > 0 && (
+              <ErrorMessage
+                message={field.state.meta.errors.join(", ")}
+                paddingLeft="calc(var(--editableField-fieldWrapper-label-width) + var(--editableField-fieldWrapper-gap))"
+              />
+            )}
+          </FieldWrapper>
+        )}
+      </form.Field>
+    </div>
+  );
+}

--- a/src/components/VolunteerRegistration/steps/AddressStep.tsx
+++ b/src/components/VolunteerRegistration/steps/AddressStep.tsx
@@ -45,7 +45,7 @@ export function AddressStep({ form, optionLists }: Props) {
 
       <form.Field
         name="locations"
-        validators={{ onChange: ({ value }) => (value.length === 0 ? t("form.error.required") : undefined) }}
+        // validators={{ onChange: ({ value }) => (value.length === 0 ? t("form.error.required") : undefined) }}
       >
         {(field) => (
           <FieldWrapper>

--- a/src/components/VolunteerRegistration/steps/AddressStep.tsx
+++ b/src/components/VolunteerRegistration/steps/AddressStep.tsx
@@ -32,7 +32,7 @@ export function AddressStep({ form, optionLists }: Props) {
       >
         {(field) => (
           <FieldWrapper>
-            <FieldLabel>{t("form.becomeVolunteer.fields.postcode.label")}</FieldLabel>
+            <FieldLabel>{t("volunteerRegistration.fields.postcode")}</FieldLabel>
             <FormInput
               value={field.state.value || ""}
               onInputChange={(v) => field.handleChange(v)}
@@ -45,13 +45,11 @@ export function AddressStep({ form, optionLists }: Props) {
 
       <form.Field
         name="locations"
-        validators={{
-          onChange: ({ value }) => (value.length === 0 ? t("form.error.required") : undefined),
-        }}
+        validators={{ onChange: ({ value }) => (value.length === 0 ? t("form.error.required") : undefined) }}
       >
         {(field) => (
           <FieldWrapper>
-            <FieldLabel>{t("form.becomeVolunteer.fields.locations.header")}</FieldLabel>
+            <FieldLabel>{t("volunteerRegistration.fields.locations.header")}</FieldLabel>
             <EditableField
               mode="edit"
               type="checkbox-list"
@@ -76,7 +74,7 @@ export function AddressStep({ form, optionLists }: Props) {
       >
         {(field) => (
           <FieldWrapper>
-            <FieldLabel>{t("form.becomeVolunteer.fields.languages.headerWithoutAsterick")}</FieldLabel>
+            <FieldLabel>{t("volunteerRegistration.fields.languages.header")}</FieldLabel>
             <LanguageFields languages={field.state.value || []} t={t} onChange={(e) => field.handleChange(e)} />
             {field.state.meta.errors.length > 0 && (
               <ErrorMessage

--- a/src/components/VolunteerRegistration/steps/AddressStep.tsx
+++ b/src/components/VolunteerRegistration/steps/AddressStep.tsx
@@ -5,23 +5,31 @@ import { ApiLanguageOption } from "@/components/Dashboard/Profile/sections/Volun
 import { LanguageFields } from "@/components/forms/LanguageFields";
 import { EditableField } from "@/components/EditableField/EditableField";
 import { ErrorMessage, FormInput } from "@/components/core/common";
-import { ApiOptionLists } from "need4deed-sdk";
+import { ApiOptionLists, Lang } from "need4deed-sdk";
 import { useTranslation } from "react-i18next";
 import { FieldLabel, FieldWrapper } from "../styled";
-import { ProfileCompletionData } from "../types";
+import { DefaultVolunteerRegistrationData } from "../types";
 import { useForm } from "@tanstack/react-form";
+import { useMemo } from "react";
 
 type Props = {
-  form: ReturnType<typeof useForm<ProfileCompletionData>>;
+  form: ReturnType<typeof useForm<DefaultVolunteerRegistrationData>>;
   optionLists?: ApiOptionLists;
 };
 
 export function AddressStep({ form, optionLists }: Props) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const locations = optionLists?.district;
   const locationMapping = createMapping(optionLists?.district as ApiLanguageOption[]);
-
+  const languagesForForm = useMemo(
+    () =>
+      optionLists?.language?.map((lang) => ({
+        id: lang.id,
+        title: { [i18n.language as Lang]: lang.title } as Record<Lang, string>,
+      })),
+    [optionLists?.language, i18n.language],
+  );
   return (
     <div>
       <form.Field
@@ -45,7 +53,7 @@ export function AddressStep({ form, optionLists }: Props) {
 
       <form.Field
         name="locations"
-        // validators={{ onChange: ({ value }) => (value.length === 0 ? t("form.error.required") : undefined) }}
+        validators={{ onChange: ({ value }) => (value.length === 0 ? t("form.error.required") : undefined) }}
       >
         {(field) => (
           <FieldWrapper>
@@ -75,7 +83,19 @@ export function AddressStep({ form, optionLists }: Props) {
         {(field) => (
           <FieldWrapper>
             <FieldLabel>{t("volunteerRegistration.fields.languages.header")}</FieldLabel>
-            <LanguageFields languages={field.state.value || []} t={t} onChange={(e) => field.handleChange(e)} />
+            <LanguageFields
+              languages={field.state.value}
+              t={t}
+              onChange={(languages) =>
+                field.handleChange(
+                  languages.map((language) => ({
+                    ...language,
+                    id: language.language ? Number(language.language) : language.id,
+                  })),
+                )
+              }
+              availableLanguages={languagesForForm}
+            />
             {field.state.meta.errors.length > 0 && (
               <ErrorMessage
                 message={field.state.meta.errors.join(", ")}

--- a/src/components/VolunteerRegistration/steps/AvailabilityStep.tsx
+++ b/src/components/VolunteerRegistration/steps/AvailabilityStep.tsx
@@ -37,7 +37,7 @@ export function AvailabilityStep({ form, optionLists }: Props) {
       >
         {(field) => (
           <FieldWrapper>
-            <FieldLabel>{t("form.becomeVolunteer.fields.availability.header")}</FieldLabel>
+            <FieldLabel>{t("volunteerRegistration.fields.availability.header")}</FieldLabel>
             <AvailabilityGrid
               availability={field.state.value}
               onChange={(e) => field.handleChange(e)}
@@ -62,7 +62,7 @@ export function AvailabilityStep({ form, optionLists }: Props) {
       >
         {(field) => (
           <FieldWrapper>
-            <FieldLabel>{t("form.becomeVolunteer.fields.activities.header")}</FieldLabel>
+            <FieldLabel>{t("volunteerRegistration.fields.activities.header")}</FieldLabel>
             <EditableField
               mode="edit"
               type="checkbox-list"
@@ -82,7 +82,7 @@ export function AvailabilityStep({ form, optionLists }: Props) {
       <form.Field name="skills">
         {(field) => (
           <FieldWrapper>
-            <FieldLabel>{t("form.becomeVolunteer.fields.skills.header")}</FieldLabel>
+            <FieldLabel>{t("volunteerRegistration.fields.skills.header")}</FieldLabel>
             <EditableField
               mode="edit"
               type="checkbox-list"

--- a/src/components/VolunteerRegistration/steps/AvailabilityStep.tsx
+++ b/src/components/VolunteerRegistration/steps/AvailabilityStep.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { createMapping } from "@/components/Dashboard/Profile/sections/VolunteerProfile/mappingUtils";
+import { ApiLanguageOption } from "@/components/Dashboard/Profile/sections/VolunteerProfile/hooks";
+import { EditableField } from "@/components/EditableField/EditableField";
+import { ErrorMessage } from "@/components/core/common";
+import { AvailabilityGrid } from "@/components/forms/AvailabilityGrid";
+import { useForm } from "@tanstack/react-form";
+import { ApiOptionLists, Lang } from "need4deed-sdk";
+import { useTranslation } from "react-i18next";
+import { FieldLabel, FieldWrapper } from "../styled";
+import { ProfileCompletionData } from "../types";
+
+type Props = {
+  form: ReturnType<typeof useForm<ProfileCompletionData>>;
+  optionLists?: ApiOptionLists;
+};
+
+export function AvailabilityStep({ form, optionLists }: Props) {
+  const { t, i18n } = useTranslation();
+  const activities = optionLists?.activity;
+  const skills = optionLists?.skill;
+  const activityMapping = createMapping(optionLists?.activity as ApiLanguageOption[]);
+  const skillMapping = createMapping(optionLists?.skill as ApiLanguageOption[]);
+
+  return (
+    <div>
+      <form.Field
+        name="availability"
+        validators={{
+          onChange: ({ value }) =>
+            Array.isArray(value) &&
+            !value.some((day) => day.timeSlots.some((slot: { selected: boolean }) => slot.selected))
+              ? t("form.error.required")
+              : undefined,
+        }}
+      >
+        {(field) => (
+          <FieldWrapper>
+            <FieldLabel>{t("form.becomeVolunteer.fields.availability.header")}</FieldLabel>
+            <AvailabilityGrid
+              availability={field.state.value}
+              onChange={(e) => field.handleChange(e)}
+              t={t}
+              currentLanguage={i18n.language as Lang}
+            />
+            {field.state.meta.errors.length > 0 && (
+              <ErrorMessage
+                message={field.state.meta.errors.join(", ")}
+                paddingLeft="calc(var(--editableField-fieldWrapper-label-width) + var(--editableField-fieldWrapper-gap))"
+              />
+            )}
+          </FieldWrapper>
+        )}
+      </form.Field>
+
+      <form.Field
+        name="activities"
+        validators={{
+          onChange: ({ value }) => (value.length === 0 ? t("form.error.required") : undefined),
+        }}
+      >
+        {(field) => (
+          <FieldWrapper>
+            <FieldLabel>{t("form.becomeVolunteer.fields.activities.header")}</FieldLabel>
+            <EditableField
+              mode="edit"
+              type="checkbox-list"
+              value={(field.state.value || []).map((activity) => activityMapping.idToTitle[activity as number])}
+              setValue={(value) => {
+                const labels = Array.isArray(value) ? value : [value];
+                const mappedIds = labels.map((val) => activityMapping.titleToId[val]);
+                field.handleChange(mappedIds);
+              }}
+              options={activities?.map((a) => a.title)}
+              errorMessage={field.state.meta.errors.join(", ")}
+            />
+          </FieldWrapper>
+        )}
+      </form.Field>
+
+      <form.Field name="skills">
+        {(field) => (
+          <FieldWrapper>
+            <FieldLabel>{t("form.becomeVolunteer.fields.skills.header")}</FieldLabel>
+            <EditableField
+              mode="edit"
+              type="checkbox-list"
+              dropdownDirection="up"
+              value={(field.state.value || []).map((skill) => skillMapping.idToTitle[skill as number])}
+              setValue={(value) => {
+                const labels = Array.isArray(value) ? value : [value];
+                const mappedIds = labels.map((val) => skillMapping.titleToId[val]);
+                field.handleChange(mappedIds);
+              }}
+              options={skills?.map((a) => a.title)}
+              errorMessage={field.state.meta.errors.join(", ")}
+            />
+          </FieldWrapper>
+        )}
+      </form.Field>
+    </div>
+  );
+}

--- a/src/components/VolunteerRegistration/steps/AvailabilityStep.tsx
+++ b/src/components/VolunteerRegistration/steps/AvailabilityStep.tsx
@@ -9,10 +9,10 @@ import { useForm } from "@tanstack/react-form";
 import { ApiOptionLists, Lang } from "need4deed-sdk";
 import { useTranslation } from "react-i18next";
 import { FieldLabel, FieldWrapper } from "../styled";
-import { ProfileCompletionData } from "../types";
+import { DefaultVolunteerRegistrationData } from "../types";
 
 type Props = {
-  form: ReturnType<typeof useForm<ProfileCompletionData>>;
+  form: ReturnType<typeof useForm<DefaultVolunteerRegistrationData>>;
   optionLists?: ApiOptionLists;
 };
 

--- a/src/components/VolunteerRegistration/steps/CertificateStep.tsx
+++ b/src/components/VolunteerRegistration/steps/CertificateStep.tsx
@@ -30,7 +30,7 @@ export function CertificateStep({ form, optionLists }: Props) {
       >
         {(field) => (
           <FieldWrapper>
-            <FieldLabel>{t("form.becomeVolunteer.fields.certOfGoodConduct.header")}</FieldLabel>
+            <FieldLabel>{t("volunteerRegistration.fields.certOfGoodConduct.header")}</FieldLabel>
             <EditableField
               mode="edit"
               type="radio-list"
@@ -59,15 +59,15 @@ export function CertificateStep({ form, optionLists }: Props) {
       >
         {(field) => (
           <FieldWrapper>
-            <FieldLabel>{t("form.becomeVolunteer.fields.certMeaslesVaccination.header")}</FieldLabel>
+            <FieldLabel>{t("volunteerRegistration.fields.certMeaslesVaccination.header")}</FieldLabel>
             <EditableField
               mode="edit"
               type="radio-list"
               value={field.state.value || ""}
               setValue={(value) => field.handleChange(value as string)}
               options={[
-                t("form.becomeVolunteer.fields.certMeaslesVaccination.true"),
-                t("form.becomeVolunteer.fields.certMeaslesVaccination.false"),
+                t("volunteerRegistration.fields.certMeaslesVaccination.true"),
+                t("volunteerRegistration.fields.certMeaslesVaccination.false"),
               ]}
               errorMessage={field.state.meta.errors.join(", ")}
             />
@@ -78,7 +78,7 @@ export function CertificateStep({ form, optionLists }: Props) {
       <form.Field name="leadFrom">
         {(field) => (
           <FieldWrapper>
-            <FieldLabel>{t("form.becomeVolunteer.fields.leadFrom.header")}</FieldLabel>
+            <FieldLabel>{t("volunteerRegistration.fields.leadFrom")}</FieldLabel>
             <EditableField
               mode="edit"
               type="checkbox-list"
@@ -98,7 +98,7 @@ export function CertificateStep({ form, optionLists }: Props) {
       <form.Field name="comments">
         {(field) => (
           <FieldWrapper>
-            <FieldLabel>{t("form.becomeVolunteer.fields.comments.label")}</FieldLabel>
+            <FieldLabel>{t("volunteerRegistration.fields.comments")}</FieldLabel>
             <FormInput value={field.state.value || ""} onInputChange={(v) => field.handleChange(v)} placeHolder="" />
             {field.state.meta.errors.length > 0 && <ErrorMessage message={field.state.meta.errors.join(", ")} />}
           </FieldWrapper>

--- a/src/components/VolunteerRegistration/steps/CertificateStep.tsx
+++ b/src/components/VolunteerRegistration/steps/CertificateStep.tsx
@@ -19,13 +19,14 @@ export function CertificateStep({ form, optionLists }: Props) {
   const { t } = useTranslation();
   const leadFrom = optionLists?.lead_from ?? [];
   const leadFromMapping = createMapping(optionLists?.lead_from as ApiLanguageOption[]);
-
+  const certOfGoodConductCopyPath = "volunteerRegistration.fields.certOfGoodConduct.";
+  const certMeaslesVaccinationCopyPath = "volunteerRegistration.fields.certMeaslesVaccination.";
   return (
     <div>
       <form.Field
-        name="goodConductCertificate"
+        name="certOfGoodConduct"
         validators={{
-          onChange: ({ value }) => (!value ? t("form.error.required") : undefined),
+          onChange: ({ value }) => (value === undefined ? t("form.error.required") : undefined),
         }}
       >
         {(field) => (
@@ -34,17 +35,20 @@ export function CertificateStep({ form, optionLists }: Props) {
             <EditableField
               mode="edit"
               type="radio-list"
-              value={field.state.value || ""}
-              setValue={(value) => field.handleChange(value as string)}
-              options={[
-                t("form.becomeVolunteer.fields.certOfGoodConduct.true"),
-                t("form.becomeVolunteer.fields.certOfGoodConduct.false"),
-              ]}
+              value={field.state.value === undefined ? "" : String(field.state.value)}
+              setValue={(value) => field.handleChange(value === "true")}
+              options={["true", "false"]}
+              labels={[t(`${certOfGoodConductCopyPath}true`), t(`${certOfGoodConductCopyPath}false`)]}
+              displayValue={
+                field.state.value === undefined
+                  ? undefined
+                  : t(`${certOfGoodConductCopyPath}${String(field.state.value)}`)
+              }
               errorMessage={field.state.meta.errors.join(", ")}
             />
             <h6>
               <a href="https://www.berlin.de/laf/engagement/fuehrungszeugnis/" target="_blank" rel="noreferrer">
-                {t("form.becomeVolunteer.fields.certOfGoodConduct.why")}
+                {t("volunteerRegistration.fields.certOfGoodConduct.why")}
               </a>
             </h6>
           </FieldWrapper>
@@ -52,9 +56,9 @@ export function CertificateStep({ form, optionLists }: Props) {
       </form.Field>
 
       <form.Field
-        name="measlesVaccination"
+        name="certMeaslesVaccination"
         validators={{
-          onChange: ({ value }) => (!value ? t("form.error.required") : undefined),
+          onChange: ({ value }) => (value === undefined ? t("form.error.required") : undefined),
         }}
       >
         {(field) => (
@@ -63,12 +67,15 @@ export function CertificateStep({ form, optionLists }: Props) {
             <EditableField
               mode="edit"
               type="radio-list"
-              value={field.state.value || ""}
-              setValue={(value) => field.handleChange(value as string)}
-              options={[
-                t("volunteerRegistration.fields.certMeaslesVaccination.true"),
-                t("volunteerRegistration.fields.certMeaslesVaccination.false"),
-              ]}
+              value={field.state.value === undefined ? "" : String(field.state.value)}
+              setValue={(value) => field.handleChange(value === "true")}
+              options={["true", "false"]}
+              labels={[t(`${certMeaslesVaccinationCopyPath}true`), t(`${certMeaslesVaccinationCopyPath}false`)]}
+              displayValue={
+                field.state.value === undefined
+                  ? undefined
+                  : t(`${certMeaslesVaccinationCopyPath}${String(field.state.value)}`)
+              }
               errorMessage={field.state.meta.errors.join(", ")}
             />
           </FieldWrapper>

--- a/src/components/VolunteerRegistration/steps/CertificateStep.tsx
+++ b/src/components/VolunteerRegistration/steps/CertificateStep.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { ErrorMessage, FormInput } from "@/components/core/common";
+import { ApiLanguageOption } from "@/components/Dashboard/Profile/sections/VolunteerProfile/hooks";
+import { createMapping } from "@/components/Dashboard/Profile/sections/VolunteerProfile/mappingUtils";
+import { EditableField } from "@/components/EditableField/EditableField";
+import { useForm } from "@tanstack/react-form";
+import { ApiOptionLists } from "need4deed-sdk";
+import { useTranslation } from "react-i18next";
+import { FieldLabel, FieldWrapper } from "../styled";
+import { ProfileCompletionData } from "../types";
+
+type Props = {
+  form: ReturnType<typeof useForm<ProfileCompletionData>>;
+  optionLists?: ApiOptionLists;
+};
+
+export function CertificateStep({ form, optionLists }: Props) {
+  const { t } = useTranslation();
+  const leadFrom = optionLists?.lead_from ?? [];
+  const leadFromMapping = createMapping(optionLists?.lead_from as ApiLanguageOption[]);
+
+  return (
+    <div>
+      <form.Field
+        name="goodConductCertificate"
+        validators={{
+          onChange: ({ value }) => (!value ? t("form.error.required") : undefined),
+        }}
+      >
+        {(field) => (
+          <FieldWrapper>
+            <FieldLabel>{t("form.becomeVolunteer.fields.certOfGoodConduct.header")}</FieldLabel>
+            <EditableField
+              mode="edit"
+              type="radio-list"
+              value={field.state.value || ""}
+              setValue={(value) => field.handleChange(value as string)}
+              options={[
+                t("form.becomeVolunteer.fields.certOfGoodConduct.true"),
+                t("form.becomeVolunteer.fields.certOfGoodConduct.false"),
+              ]}
+              errorMessage={field.state.meta.errors.join(", ")}
+            />
+            <h6>
+              <a href="https://www.berlin.de/laf/engagement/fuehrungszeugnis/" target="_blank" rel="noreferrer">
+                {t("form.becomeVolunteer.fields.certOfGoodConduct.why")}
+              </a>
+            </h6>
+          </FieldWrapper>
+        )}
+      </form.Field>
+
+      <form.Field
+        name="measlesVaccination"
+        validators={{
+          onChange: ({ value }) => (!value ? t("form.error.required") : undefined),
+        }}
+      >
+        {(field) => (
+          <FieldWrapper>
+            <FieldLabel>{t("form.becomeVolunteer.fields.certMeaslesVaccination.header")}</FieldLabel>
+            <EditableField
+              mode="edit"
+              type="radio-list"
+              value={field.state.value || ""}
+              setValue={(value) => field.handleChange(value as string)}
+              options={[
+                t("form.becomeVolunteer.fields.certMeaslesVaccination.true"),
+                t("form.becomeVolunteer.fields.certMeaslesVaccination.false"),
+              ]}
+              errorMessage={field.state.meta.errors.join(", ")}
+            />
+          </FieldWrapper>
+        )}
+      </form.Field>
+
+      <form.Field name="leadFrom">
+        {(field) => (
+          <FieldWrapper>
+            <FieldLabel>{t("form.becomeVolunteer.fields.leadFrom.header")}</FieldLabel>
+            <EditableField
+              mode="edit"
+              type="checkbox-list"
+              value={(field.state.value || []).map((lead) => leadFromMapping.idToTitle[lead])}
+              setValue={(value) => {
+                const labels = Array.isArray(value) ? value : [value];
+                const mappedIds = labels.map((val) => leadFromMapping.titleToId[val]);
+                field.handleChange(mappedIds);
+              }}
+              options={leadFrom?.map((a) => a.title)}
+              errorMessage={field.state.meta.errors.join(", ")}
+            />
+          </FieldWrapper>
+        )}
+      </form.Field>
+
+      <form.Field name="comments">
+        {(field) => (
+          <FieldWrapper>
+            <FieldLabel>{t("form.becomeVolunteer.fields.comments.label")}</FieldLabel>
+            <FormInput value={field.state.value || ""} onInputChange={(v) => field.handleChange(v)} placeHolder="" />
+            {field.state.meta.errors.length > 0 && <ErrorMessage message={field.state.meta.errors.join(", ")} />}
+          </FieldWrapper>
+        )}
+      </form.Field>
+    </div>
+  );
+}

--- a/src/components/VolunteerRegistration/steps/CertificateStep.tsx
+++ b/src/components/VolunteerRegistration/steps/CertificateStep.tsx
@@ -8,10 +8,10 @@ import { useForm } from "@tanstack/react-form";
 import { ApiOptionLists } from "need4deed-sdk";
 import { useTranslation } from "react-i18next";
 import { FieldLabel, FieldWrapper } from "../styled";
-import { ProfileCompletionData } from "../types";
+import { DefaultVolunteerRegistrationData } from "../types";
 
 type Props = {
-  form: ReturnType<typeof useForm<ProfileCompletionData>>;
+  form: ReturnType<typeof useForm<DefaultVolunteerRegistrationData>>;
   optionLists?: ApiOptionLists;
 };
 
@@ -24,7 +24,7 @@ export function CertificateStep({ form, optionLists }: Props) {
   return (
     <div>
       <form.Field
-        name="certOfGoodConduct"
+        name="goodConductCertificate"
         validators={{
           onChange: ({ value }) => (value === undefined ? t("form.error.required") : undefined),
         }}
@@ -56,7 +56,7 @@ export function CertificateStep({ form, optionLists }: Props) {
       </form.Field>
 
       <form.Field
-        name="certMeaslesVaccination"
+        name="measlesVaccination"
         validators={{
           onChange: ({ value }) => (value === undefined ? t("form.error.required") : undefined),
         }}

--- a/src/components/VolunteerRegistration/styled.ts
+++ b/src/components/VolunteerRegistration/styled.ts
@@ -1,0 +1,194 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 48px 16px;
+  background: var(--layout-static-page-background-default, #f8f6f8);
+`;
+
+export const Card = styled.div`
+  background: var(--color-white);
+  border-radius: 16px;
+  padding: 40px;
+  width: 100%;
+  max-width: 850px;
+  box-shadow: 0 2px 16px rgba(0, 0, 0, 0.08);
+`;
+
+export const PageTitle = styled.h1`
+  font-size: 1.625rem;
+  font-weight: 700;
+  color: var(--color-midnight);
+  margin: 0 0 4px;
+`;
+
+export const PageSubtitle = styled.p`
+  font-size: 0.9375rem;
+  color: var(--color-grey-500);
+  margin: 0 0 32px;
+`;
+
+export const Actions = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 32px;
+  gap: 12px;
+`;
+
+export const ErrorBanner = styled.div`
+  background: var(--color-error-light, #fef2f2);
+  border: 1px solid var(--color-error-border, #fecaca);
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin-bottom: 20px;
+  font-size: 0.9375rem;
+  color: var(--color-error, #dc2626);
+`;
+
+export const SuccessWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 24px 0;
+  text-align: center;
+`;
+
+export const ExistingUserWrapper = styled.div`
+  display: flex;
+  gap: var(--agent-form-existing-user-gap);
+  margin-bottom: var(--agent-form-existing-user-margin-bottom);
+`;
+
+export const ExistingUserText = styled.span`
+  font-size: var(--agent-form-existing-user-font-size);
+  color: var(--color-grey-800);
+`;
+
+export const SuccessTitle = styled.h2`
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: var(--color-midnight);
+`;
+
+export const SuccessText = styled.p`
+  font-size: 0.9375rem;
+  color: var(--color-grey-500);
+`;
+
+export const StepTitle = styled.h2`
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: var(--color-midnight);
+  margin: 0 0 8px;
+`;
+
+export const StepDescription = styled.p`
+  font-size: 0.9375rem;
+  color: var(--color-grey-500);
+  margin: 0 0 28px;
+`;
+
+export const FieldWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 20px;
+`;
+
+export const FieldLabel = styled.label`
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-midnight);
+`;
+
+type SelectProps = {
+  $hasError: boolean;
+};
+
+export const StyledSelect = styled.select<SelectProps>`
+  color: var(--color-midnight);
+  font-size: var(--form-input-fontSize, 1rem);
+  height: var(--form-input-container-height, 48px);
+  width: -webkit-fill-available;
+  background-color: var(--color-white);
+  border-radius: var(--form-input-container-border-radius, 8px);
+  padding: var(--form-input-container-padding, 0 12px);
+  border: ${({ $hasError }) =>
+    $hasError ? "var(--form-input-container-border-error)" : "var(--form-input-container-border)"};
+  cursor: pointer;
+
+  &:focus {
+    outline: none;
+    border: var(--form-input-container-border-focus);
+  }
+`;
+
+export const StyledTextarea = styled.textarea`
+  color: var(--color-midnight);
+  font-size: var(--form-input-fontSize, 1rem);
+  width: -webkit-fill-available;
+  background-color: var(--color-white);
+  border-radius: var(--form-input-container-border-radius, 8px);
+  padding: 12px;
+  border: var(--form-input-container-border);
+  resize: vertical;
+  font-family: inherit;
+
+  &:focus {
+    outline: none;
+    border: var(--form-input-container-border-focus);
+  }
+`;
+
+export const FieldConsent = styled.label`
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+
+  input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    margin-top: 4px;
+    accent-color: var(--color-aubergine);
+    cursor: pointer;
+  }
+`;
+
+export const StyledErrorMessage = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--form-input-error-message-container-gap);
+  padding: var(--form-input-error-message-container-padding);
+  color: var(--form-input-error-message-color);
+  font-size: var(--form-input-error-message-fontSize);
+  font-weight: var(--form-input-error-message-fontWeight);
+  line-height: var(--form-input-error-message-lineHeight);
+`;
+
+export const CheckboxGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 10px;
+`;
+
+export const CheckboxLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 0.9375rem;
+  color: var(--color-midnight);
+
+  input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--color-aubergine);
+    cursor: pointer;
+  }
+`;

--- a/src/components/VolunteerRegistration/types.ts
+++ b/src/components/VolunteerRegistration/types.ts
@@ -13,8 +13,8 @@ export interface ProfileCompletionData {
   activities: number[];
   skills: number[];
   leadFrom: number[];
-  goodConductCertificate: string;
-  measlesVaccination: string;
+  certOfGoodConduct: boolean | undefined;
+  certMeaslesVaccination: boolean | undefined;
   comments: string;
 }
 
@@ -26,8 +26,8 @@ export const defaultVolunteerRegistrationData: ProfileCompletionData = {
   activities: [],
   skills: [],
   leadFrom: [],
-  goodConductCertificate: "",
-  measlesVaccination: "",
+  certOfGoodConduct: undefined,
+  certMeaslesVaccination: undefined,
   comments: "",
 };
 

--- a/src/components/VolunteerRegistration/types.ts
+++ b/src/components/VolunteerRegistration/types.ts
@@ -1,0 +1,35 @@
+import { LanguageObject } from "@/types";
+import { VolunteerFormData } from "need4deed-sdk";
+import { Availability } from "@/components/forms/types/availabilityTypes";
+import { getScheduleState } from "../forms/utils";
+
+export type ApiVolunteerRegister = { volunteer: VolunteerFormData };
+
+export interface ProfileCompletionData {
+  addressPostcode: string;
+  locations: number[];
+  languages: LanguageObject[];
+  availability: Availability;
+  activities: number[];
+  skills: number[];
+  leadFrom: number[];
+  goodConductCertificate: string;
+  measlesVaccination: string;
+  comments: string;
+}
+
+export const defaultVolunteerRegistrationData: ProfileCompletionData = {
+  addressPostcode: "",
+  locations: [],
+  languages: [{ id: 1, language: "", level: "" }],
+  availability: getScheduleState(),
+  activities: [],
+  skills: [],
+  leadFrom: [],
+  goodConductCertificate: "",
+  measlesVaccination: "",
+  comments: "",
+};
+
+export const TOTAL_STEPS = 1;
+export const TOTAL_COMPLETION_STEPS = 3;

--- a/src/components/VolunteerRegistration/types.ts
+++ b/src/components/VolunteerRegistration/types.ts
@@ -1,11 +1,9 @@
-import { LanguageObject } from "@/types";
-import { VolunteerFormData } from "need4deed-sdk";
 import { Availability } from "@/components/forms/types/availabilityTypes";
 import { getScheduleState } from "../forms/utils";
+import { LanguageObject } from "@/types";
+import { OptionById, OptionId } from "need4deed-sdk";
 
-export type ApiVolunteerRegister = { volunteer: VolunteerFormData };
-
-export interface ProfileCompletionData {
+export interface DefaultVolunteerRegistrationData {
   addressPostcode: string;
   locations: number[];
   languages: LanguageObject[];
@@ -13,21 +11,21 @@ export interface ProfileCompletionData {
   activities: number[];
   skills: number[];
   leadFrom: number[];
-  certOfGoodConduct: boolean | undefined;
-  certMeaslesVaccination: boolean | undefined;
+  goodConductCertificate: boolean | undefined;
+  measlesVaccination: boolean | undefined;
   comments: string;
 }
 
-export const defaultVolunteerRegistrationData: ProfileCompletionData = {
+export const defaultVolunteerRegistrationData: DefaultVolunteerRegistrationData = {
   addressPostcode: "",
   locations: [],
-  languages: [{ id: 1, language: "", level: "" }],
+  languages: [{ id: 0, language: "", level: "" }],
   availability: getScheduleState(),
   activities: [],
   skills: [],
   leadFrom: [],
-  certOfGoodConduct: undefined,
-  certMeaslesVaccination: undefined,
+  goodConductCertificate: undefined,
+  measlesVaccination: undefined,
   comments: "",
 };
 

--- a/src/components/VolunteerRegistration/types.ts
+++ b/src/components/VolunteerRegistration/types.ts
@@ -1,7 +1,6 @@
 import { Availability } from "@/components/forms/types/availabilityTypes";
 import { getScheduleState } from "../forms/utils";
 import { LanguageObject } from "@/types";
-import { OptionById, OptionId } from "need4deed-sdk";
 
 export interface DefaultVolunteerRegistrationData {
   addressPostcode: string;

--- a/src/components/forms/LanguageFields/LanguageFields.tsx
+++ b/src/components/forms/LanguageFields/LanguageFields.tsx
@@ -17,6 +17,7 @@ type Props = {
 };
 
 export function LanguageFields({ languages, onChange, onFocus, t, availableLanguages, showLevel = true }: Props) {
+  console.log("aval", availableLanguages);
   const updateLanguage = (id: number, newLang: string) => {
     onChange(languages.map((item) => (item.id === id ? { ...item, language: newLang } : item)));
   };
@@ -46,12 +47,12 @@ export function LanguageFields({ languages, onChange, onFocus, t, availableLangu
 
   return (
     <div className={style["form-languages-wrapper"]} data-testid="language-fields-container" onFocus={onFocus}>
-      {languages.map((lang) => (
+      {languages.map((lang, index) => (
         <LanguageFieldRow
           key={`${lang.id}-${lang.language}-${lang.level}`}
           language={lang}
           disabledLanguages={disabledLanguages}
-          showRemove={lang.id !== 1}
+          showRemove={index !== 0}
           showLevel={showLevel}
           onUpdateLanguage={updateLanguage}
           onUpdateLevel={updateLevel}

--- a/src/components/forms/LanguageFields/LanguageFields.tsx
+++ b/src/components/forms/LanguageFields/LanguageFields.tsx
@@ -17,7 +17,6 @@ type Props = {
 };
 
 export function LanguageFields({ languages, onChange, onFocus, t, availableLanguages, showLevel = true }: Props) {
-  console.log("aval", availableLanguages);
   const updateLanguage = (id: number, newLang: string) => {
     onChange(languages.map((item) => (item.id === id ? { ...item, language: newLang } : item)));
   };

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -18,6 +18,7 @@ export const apiPathOpportunity = `/${apiPrefix}/opportunity`;
 export const apiPathAgent = `/${apiPrefix}/agent`;
 export const apiPathAgentMe = `/${apiPrefix}/agent/me`;
 export const apiPathAgentRegister = `/${apiPrefix}/agent/register`;
+export const apiPathVolunteerRegister = `/${apiPrefix}/volunteer/register`;
 export const apiPathAgentMembership = `/${apiPrefix}/agent/membership`;
 export const apiPathOption = `/${apiPrefix}/option`;
 export const apiPathOpportunityVolunteer = `/${apiPrefix}/opportunity-volunteer`;

--- a/src/hooks/useRegisterVolunteer.ts
+++ b/src/hooks/useRegisterVolunteer.ts
@@ -1,0 +1,32 @@
+import axios from "axios";
+import { apiPathVolunteerRegister } from "@/config/constants";
+import { useMutationQuery } from "@/hooks";
+import { ProfileCompletionData } from "@/components/VolunteerRegistration/types";
+import { ApiVolunteerGet } from "need4deed-sdk";
+
+type VolunteerRegistrationPayload = {
+  volunteer: ProfileCompletionData;
+};
+
+type Props = {
+  token: string | null;
+  onSuccess?: () => void;
+};
+
+export const useRegisterVolunteer = ({ token, onSuccess }: Props) => {
+  return useMutationQuery<VolunteerRegistrationPayload, { message: string; data: ApiVolunteerGet }>({
+    mutationFn: async (payload: VolunteerRegistrationPayload) => {
+      if (!token) {
+        throw new Error("Token is required for volunteer registration");
+      }
+      const response = await axios.post<{ message: string; data: ApiVolunteerGet }>(
+        `${apiPathVolunteerRegister}?token=${encodeURIComponent(token)}`,
+        payload,
+      );
+      return response.data;
+    },
+    onSuccessCallback: onSuccess,
+    successMessage: "volunteerRegistration.success.title",
+    queryKeyToInvalidate: ["volunteer"],
+  });
+};

--- a/src/hooks/useRegisterVolunteer.ts
+++ b/src/hooks/useRegisterVolunteer.ts
@@ -1,12 +1,7 @@
 import axios from "axios";
 import { apiPathVolunteerRegister } from "@/config/constants";
 import { useMutationQuery } from "@/hooks";
-import { ProfileCompletionData } from "@/components/VolunteerRegistration/types";
-import { ApiVolunteerGet } from "need4deed-sdk";
-
-type VolunteerRegistrationPayload = {
-  volunteer: ProfileCompletionData;
-};
+import { ApiVolunteerGet, ApiVolunteerRegisterNew } from "need4deed-sdk";
 
 type Props = {
   token: string | null;
@@ -14,8 +9,8 @@ type Props = {
 };
 
 export const useRegisterVolunteer = ({ token, onSuccess }: Props) => {
-  return useMutationQuery<VolunteerRegistrationPayload, { message: string; data: ApiVolunteerGet }>({
-    mutationFn: async (payload: VolunteerRegistrationPayload) => {
+  return useMutationQuery<ApiVolunteerRegisterNew, { message: string; data: ApiVolunteerGet }>({
+    mutationFn: async (payload: ApiVolunteerRegisterNew) => {
       if (!token) {
         throw new Error("Token is required for volunteer registration");
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,10 +2412,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.147:
-  version "0.0.147"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.147.tgz#b5d54178585dc519be975f7a0be4d29b6daf5713"
-  integrity sha512-SDZHVyVWrmMzESvjmEb87TV4299gLL3oyEZ4VgiiuLxwhqprdnzUDe5TaZT72FbYll/kQoV0fspMKjNq6+mKmw==
+need4deed-sdk@0.0.152:
+  version "0.0.152"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.152.tgz#bde13645bfffc9e61f3969102bef7fff70212769"
+  integrity sha512-NNCB92cvX/uJGphWv86XrsOpArVKTBJQ50jc7/jViell68ZKS9IlZAS99G7Mh7LPMJjpewsHqTepaWhEZG3Qkw==
 
 next@15.3.8:
   version "15.3.8"


### PR DESCRIPTION
## Description
Completes new volunteer registration process.

Dependant on `be` endpoint which needs to be created

This branch is based on `nadavosa/954-volunteer-registration` which is used on PR #955 

## Related Issues
Closes #956 

## Changes
- Replicated `AgentRegistration` somewhat but I refactored it so that we use `tanstack-form` along with `tanstack` useMutation for consistency and better robustness
- The previous `BecomeVolunteer` form used a pilllike checkboxes for fields such as `activities` and `skills` . I felt it was better UX to use our existing checkbox Dropdown menu on the `EditableField` component

## Screenshots / Demos

### step1
<img width="885" height="755" alt="image" src="https://github.com/user-attachments/assets/821862b3-8e98-4f34-a7c1-4925236d4e62" />

### step2
<img width="962" height="846" alt="image" src="https://github.com/user-attachments/assets/7c8d0d93-3e31-4637-8919-cba450311b49" />

### step3
<img width="868" height="846" alt="image" src="https://github.com/user-attachments/assets/5fc336e4-926c-486a-9e1f-dea9d95e7f35" />


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

