### PR TITLE
fix: scope volunteer dashboard to Home, Opportunities, Profile

### DIFF
--- a/src/components/Layout/DashboardLayout/NavigationBar.tsx
+++ b/src/components/Layout/DashboardLayout/NavigationBar.tsx
@@ -112,7 +112,9 @@ export default function NavigationBar() {
   const currentPathname = usePathname();
   const user = useCurrentUser();
   const isAgent = user?.role === UserRole.AGENT;
-  const canSeeCalendar = !isAgent;
+  const isVolunteer = user?.role === UserRole.VOLUNTEER;
+  const canSeeStaffNav = !isAgent && !isVolunteer;
+  const canSeeCalendar = !isAgent && !isVolunteer;
 
   const userInitials = user?.fullName
     ? user.fullName
@@ -126,34 +128,38 @@ export default function NavigationBar() {
 
   const options: BarOptions[] = [
     { label: t("dashboard.home.sidebar.home"), Icon: HouseIcon, route: DashboardRoutes.Home },
-    ...(isAgent
-      ? []
-      : [
+    ...(canSeeStaffNav
+      ? [
           {
             label: t("dashboard.home.sidebar.volunteers"),
             Icon: UserCheckIcon,
             route: DashboardRoutes.Volunteers,
           },
-        ]),
+        ]
+      : []),
     {
       label: t("dashboard.home.sidebar.opportunities"),
       Icon: ShootingStarIcon,
       route: DashboardRoutes.Opportunities,
     },
-    {
-      label: t("dashboard.home.sidebar.agents"),
-      Icon: BookOpenTextIcon,
-      route: DashboardRoutes.Agents,
-    },
-    ...(isAgent
-      ? []
-      : [
+    ...(canSeeStaffNav
+      ? [
+          {
+            label: t("dashboard.home.sidebar.agents"),
+            Icon: BookOpenTextIcon,
+            route: DashboardRoutes.Agents,
+          },
+        ]
+      : []),
+    ...(canSeeStaffNav
+      ? [
           {
             label: t("dashboard.home.sidebar.posts"),
             Icon: NotepadIcon,
             route: DashboardRoutes.Posts,
           },
-        ]),
+        ]
+      : []),
     ...(canSeeCalendar
       ? [
           {

--- a/src/components/Layout/DashboardLayout/NavigationBar.tsx
+++ b/src/components/Layout/DashboardLayout/NavigationBar.tsx
@@ -114,7 +114,6 @@ export default function NavigationBar() {
   const isAgent = user?.role === UserRole.AGENT;
   const isVolunteer = user?.role === UserRole.VOLUNTEER;
   const canSeeStaffNav = !isAgent && !isVolunteer;
-  const canSeeCalendar = !isAgent && !isVolunteer;
 
   const userInitials = user?.fullName
     ? user.fullName
@@ -142,15 +141,15 @@ export default function NavigationBar() {
       Icon: ShootingStarIcon,
       route: DashboardRoutes.Opportunities,
     },
-    ...(canSeeStaffNav
-      ? [
+    ...(isVolunteer
+      ? []
+      : [
           {
             label: t("dashboard.home.sidebar.agents"),
             Icon: BookOpenTextIcon,
             route: DashboardRoutes.Agents,
           },
-        ]
-      : []),
+        ]),
     ...(canSeeStaffNav
       ? [
           {
@@ -160,7 +159,7 @@ export default function NavigationBar() {
           },
         ]
       : []),
-    ...(canSeeCalendar
+    ...(canSeeStaffNav
       ? [
           {
             label: t("dashboard.home.sidebar.calendar"),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -41,6 +41,14 @@ export function middleware(request: NextRequest) {
     const userObject = decodeJwtPayload(token);
     const isAuthorized =
       (userObject && userObject.role === UserRole.ADMIN) || (userObject && userObject.role === UserRole.COORDINATOR);
+
+    const volunteerRestrictedRegex = /^(?:\/[a-z]{2})?\/dashboard\/(volunteers|agents|posts|calendar)(?:\/|$)/;
+    if (userObject?.role === UserRole.VOLUNTEER && volunteerRestrictedRegex.test(pathname)) {
+      const url = request.nextUrl.clone();
+      url.pathname = "/dashboard";
+      return NextResponse.redirect(url);
+    }
+
     const match = pathname.match(authorizedRoutes.AGENT.regex);
     if (match) {
       if (isAuthorized || userObject.role === UserRole.AGENT) {
@@ -54,13 +62,6 @@ export function middleware(request: NextRequest) {
 
     const calendarRegex = /^(?:\/[a-z]{2})?\/dashboard\/calendar(?:\/|$)/;
     if (userObject?.role === UserRole.AGENT && calendarRegex.test(pathname)) {
-      const url = request.nextUrl.clone();
-      url.pathname = "/dashboard";
-      return NextResponse.redirect(url);
-    }
-
-    const volunteerRestrictedRegex = /^(?:\/[a-z]{2})?\/dashboard\/(volunteers|agents|posts|calendar)(?:\/|$)/;
-    if (userObject?.role === UserRole.VOLUNTEER && volunteerRestrictedRegex.test(pathname)) {
       const url = request.nextUrl.clone();
       url.pathname = "/dashboard";
       return NextResponse.redirect(url);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -58,6 +58,13 @@ export function middleware(request: NextRequest) {
       url.pathname = "/dashboard";
       return NextResponse.redirect(url);
     }
+
+    const volunteerRestrictedRegex = /^(?:\/[a-z]{2})?\/dashboard\/(volunteers|agents|posts|calendar)(?:\/|$)/;
+    if (userObject?.role === UserRole.VOLUNTEER && volunteerRestrictedRegex.test(pathname)) {
+      const url = request.nextUrl.clone();
+      url.pathname = "/dashboard";
+      return NextResponse.redirect(url);
+    }
   }
 
   const localePrefixRegex = /^\/([a-z]{2})(?:\/|$)/i;


### PR DESCRIPTION
## Description
Volunteers currently see the full staff sidebar (Volunteers, NGOs, Posts, Calendar) since nav gating only ever branched on the AGENT role, not VOLUNTEER. This became reachable by real users once https://github.com/need4deed-org/fe/pull/955 shipped self-registration for volunteers.

## Related Issues
Closes https://github.com/need4deed-org/fe/issues/974

## Changes
- `NavigationBar.tsx`: added an `isVolunteer` check and a `canSeeStaffNav` gate applied to Volunteers, NGOs/Agents, and Posts (Agents was previously always shown regardless of role). `canSeeCalendar` now also excludes volunteers. Volunteers now see only Home, Opportunities, Profile.
- `middleware.ts`: added a redirect so a `VOLUNTEER` hitting `/dashboard/volunteers`, `/dashboard/agents`, `/dashboard/posts`, or `/dashboard/calendar` directly (bookmark, typed URL) is bounced back to `/dashboard`, since hiding the icon alone doesn't block direct navigation.

## Out of scope
- Backend API authorization for these resources (separate `be` repo concern).
- Hiding agent/organization contact info on the Opportunities view for volunteers (not part of #974 as filed; can be a follow-up issue).

## Verification
- `yarn typecheck` and `yarn lint` pass.
- Manually confirmed sidebar options list for `VOLUNTEER` renders only Home/Opportunities/Profile.

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes