### PR TITLE
feat: add post cards and management controls (#963)

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -534,7 +534,19 @@
     "posts": {
       "inputPlaceholder": "Nachricht eingeben...",
       "send": "Senden",
-      "empty": "Noch keine Beiträge. Sei der Erste, der eine Nachricht postet."
+      "empty": "Noch keine Beiträge. Sei der Erste, der eine Nachricht postet.",
+      "options": "Beitragsoptionen",
+      "edit": "Beitrag bearbeiten",
+      "delete": "Beitrag löschen",
+      "save": "Speichern",
+      "cancel": "Abbrechen",
+      "updated": "Beitrag erfolgreich aktualisiert",
+      "deleted": "Beitrag erfolgreich gelöscht",
+      "unknownUser": "Benutzer",
+      "deleteDialog": {
+        "title": "Beitrag löschen?",
+        "message": "Dieser Beitrag wird unwiderruflich gelöscht."
+      }
     },
     "found": "gefunden",
     "searchPlaceHolder": "Ehrenamtliche suchen",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -528,7 +528,19 @@
     "posts": {
       "inputPlaceholder": "Type a message...",
       "send": "Send",
-      "empty": "No posts yet. Be the first to post a message."
+      "empty": "No posts yet. Be the first to post a message.",
+      "options": "Post options",
+      "edit": "Edit post",
+      "delete": "Delete post",
+      "save": "Save",
+      "cancel": "Cancel",
+      "updated": "Post updated successfully",
+      "deleted": "Post deleted successfully",
+      "unknownUser": "user",
+      "deleteDialog": {
+        "title": "Delete post?",
+        "message": "This post will be permanently deleted."
+      }
     },
     "found": "found",
     "searchPlaceHolder": "Search volunteers",

--- a/src/components/Dashboard/Posts/PostActionMenu.tsx
+++ b/src/components/Dashboard/Posts/PostActionMenu.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+
+import { ActionMenu, ActionMenuItem } from "./styles";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+};
+
+export function PostActionMenu({ isOpen, onClose, onEdit, onDelete }: Props) {
+  const { t } = useTranslation();
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const closeOnOutsideClick = (event: MouseEvent) => {
+      if (!menuRef.current?.contains(event.target as Node)) onClose();
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+
+    document.addEventListener("mousedown", closeOnOutsideClick);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("mousedown", closeOnOutsideClick);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <ActionMenu ref={menuRef} role="menu">
+      <ActionMenuItem role="menuitem" onClick={onEdit}>
+        {t("dashboard.posts.edit")}
+      </ActionMenuItem>
+      <ActionMenuItem role="menuitem" $danger onClick={onDelete}>
+        {t("dashboard.posts.delete")}
+      </ActionMenuItem>
+    </ActionMenu>
+  );
+}
+
+export default PostActionMenu;

--- a/src/components/Dashboard/Posts/PostActionMenu.tsx
+++ b/src/components/Dashboard/Posts/PostActionMenu.tsx
@@ -1,3 +1,4 @@
+import { useClickOutside } from "@/hooks";
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -13,21 +14,17 @@ type Props = {
 export function PostActionMenu({ isOpen, onClose, onEdit, onDelete }: Props) {
   const { t } = useTranslation();
   const menuRef = useRef<HTMLDivElement>(null);
+  useClickOutside(menuRef, onClose);
 
   useEffect(() => {
     if (!isOpen) return;
 
-    const closeOnOutsideClick = (event: MouseEvent) => {
-      if (!menuRef.current?.contains(event.target as Node)) onClose();
-    };
     const closeOnEscape = (event: KeyboardEvent) => {
       if (event.key === "Escape") onClose();
     };
 
-    document.addEventListener("mousedown", closeOnOutsideClick);
     document.addEventListener("keydown", closeOnEscape);
     return () => {
-      document.removeEventListener("mousedown", closeOnOutsideClick);
       document.removeEventListener("keydown", closeOnEscape);
     };
   }, [isOpen, onClose]);

--- a/src/components/Dashboard/Posts/PostCard.tsx
+++ b/src/components/Dashboard/Posts/PostCard.tsx
@@ -24,6 +24,7 @@ import {
   PostHeader,
   PostHeaderText,
   PostMenuButton,
+  PostMenuWrapper,
   PostText,
   PostTimestamp,
 } from "./styles";
@@ -38,13 +39,14 @@ export function PostCard({ post }: Props) {
   const [isEditing, setIsEditing] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [editText, setEditText] = useState(post.text);
-
-  const closeEdit = useCallback(() => {
-    setIsEditing(false);
-    setEditText(post.text);
-  }, [post.text]);
   const updatePost = useUpdatePost(post.id, () => setIsEditing(false));
   const deletePost = useDeletePost(post.id, () => setIsDeleteOpen(false));
+
+  const closeEdit = useCallback(() => {
+    if (updatePost.isPending) return;
+    setIsEditing(false);
+    setEditText(post.text);
+  }, [post.text, updatePost.isPending]);
 
   const canManage =
     currentUser?.personId === post.author.id ||
@@ -84,10 +86,22 @@ export function PostCard({ post }: Props) {
 
   const saveEdit = () => {
     let formattedText = editText.trim();
-    post.taggedPersons.forEach((person) => {
-      formattedText = formattedText.replaceAll(`@${person.fullName}`, `<@${person.id}>`);
+    const taggedPersonIds: number[] = [];
+    [...post.taggedPersons]
+      .sort((first, second) => second.fullName.length - first.fullName.length)
+      .forEach((person) => {
+        const escapedName = person.fullName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const mentionPattern = new RegExp(`@${escapedName}(?![\\p{L}\\p{N}_])`, "gu");
+        formattedText = formattedText.replace(mentionPattern, () => {
+          taggedPersonIds.push(person.id);
+          return `<@${person.id}>`;
+        });
+      });
+    updatePost.mutate({
+      text: formattedText,
+      taggedPersonIds: [...new Set(taggedPersonIds)],
+      linkedOpportunityIds: post.linkedOpportunities.map(({ id }) => id),
     });
-    updatePost.mutate({ text: formattedText });
   };
 
   return (
@@ -103,7 +117,7 @@ export function PostCard({ post }: Props) {
           <PostTimestamp dateTime={createdAt.toISOString()}>{createdAt.toLocaleString(i18n.language)}</PostTimestamp>
         </PostHeaderText>
         {canManage && (
-          <div style={{ position: "relative", marginLeft: "auto" }}>
+          <PostMenuWrapper>
             <PostMenuButton
               type="button"
               aria-label={t("dashboard.posts.options")}
@@ -125,7 +139,7 @@ export function PostCard({ post }: Props) {
                 setIsDeleteOpen(true);
               }}
             />
-          </div>
+          </PostMenuWrapper>
         )}
       </PostHeader>
 
@@ -134,7 +148,7 @@ export function PostCard({ post }: Props) {
           <>
             <EditTextArea value={editText} onChange={(event) => setEditText(event.target.value)} autoFocus />
             <EditActions>
-              <EditButton type="button" onClick={closeEdit}>
+              <EditButton type="button" disabled={updatePost.isPending} onClick={closeEdit}>
                 {t("dashboard.posts.cancel")}
               </EditButton>
               <EditButton type="button" $primary disabled={!editText.trim() || updatePost.isPending} onClick={saveEdit}>
@@ -168,7 +182,11 @@ export function PostCard({ post }: Props) {
           confirmText={t("dashboard.posts.delete")}
           cancelText={t("dashboard.posts.cancel")}
           onCancel={() => setIsDeleteOpen(false)}
-          onConfirm={() => deletePost.mutate()}
+          onConfirm={() => {
+            if (!deletePost.isPending) deletePost.mutate();
+          }}
+          cancelDisabled={deletePost.isPending}
+          confirmDisabled={deletePost.isPending}
           compact
         />
       )}

--- a/src/components/Dashboard/Posts/PostCard.tsx
+++ b/src/components/Dashboard/Posts/PostCard.tsx
@@ -1,0 +1,179 @@
+import { ConfirmationDialog } from "@/components/Dashboard/Profile/sections/shared/ConfirmationDialog";
+import { useDeletePost, useUpdatePost } from "@/hooks";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { getImageUrl } from "@/utils";
+import { DotsThreeOutline } from "@phosphor-icons/react";
+import { ApiPostGet, UserRole } from "need4deed-sdk";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { Fragment, useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import PostActionMenu from "./PostActionMenu";
+import {
+  Avatar,
+  AvatarInitials,
+  EditActions,
+  EditButton,
+  EditTextArea,
+  FeedPost,
+  OpportunityChip,
+  OpportunityList,
+  PostAuthor,
+  PostBody,
+  PostHeader,
+  PostHeaderText,
+  PostMenuButton,
+  PostText,
+  PostTimestamp,
+} from "./styles";
+
+type Props = { post: ApiPostGet };
+
+export function PostCard({ post }: Props) {
+  const { t, i18n } = useTranslation();
+  const { lang } = useParams<{ lang: string }>();
+  const currentUser = useCurrentUser(true);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [editText, setEditText] = useState(post.text);
+
+  const closeEdit = useCallback(() => {
+    setIsEditing(false);
+    setEditText(post.text);
+  }, [post.text]);
+  const updatePost = useUpdatePost(post.id, () => setIsEditing(false));
+  const deletePost = useDeletePost(post.id, () => setIsDeleteOpen(false));
+
+  const canManage =
+    currentUser?.personId === post.author.id ||
+    currentUser?.role === UserRole.ADMIN ||
+    currentUser?.role === UserRole.COORDINATOR;
+  const createdAt = new Date(post.createdAt);
+  const authorInitials = post.author.fullName
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((name) => name[0]?.toUpperCase())
+    .join("");
+
+  const displayText = useMemo(() => {
+    const parts = post.text.split(/(<@\d+>)/g);
+    return parts.map((part, index) => {
+      const match = part.match(/^<@(\d+)>$/);
+      if (!match) return <Fragment key={`${post.id}-text-${index}`}>{part}</Fragment>;
+      const person = post.taggedPersons.find(({ id }) => id === Number(match[1]));
+      return (
+        <strong className="tag" key={`${post.id}-tag-${index}`}>
+          @{person?.fullName ?? t("dashboard.posts.unknownUser")}
+        </strong>
+      );
+    });
+  }, [post.id, post.taggedPersons, post.text, t]);
+
+  const startEdit = () => {
+    const editableText = post.text.replace(/<@(\d+)>/g, (token, id) => {
+      const person = post.taggedPersons.find((taggedPerson) => taggedPerson.id === Number(id));
+      return person ? `@${person.fullName}` : token;
+    });
+    setEditText(editableText);
+    setIsEditing(true);
+    setIsMenuOpen(false);
+  };
+
+  const saveEdit = () => {
+    let formattedText = editText.trim();
+    post.taggedPersons.forEach((person) => {
+      formattedText = formattedText.replaceAll(`@${person.fullName}`, `<@${person.id}>`);
+    });
+    updatePost.mutate({ text: formattedText });
+  };
+
+  return (
+    <FeedPost>
+      <PostHeader>
+        {post.author.avatarUrl ? (
+          <Avatar src={getImageUrl(post.author.avatarUrl)} alt="" />
+        ) : (
+          <AvatarInitials aria-hidden="true">{authorInitials}</AvatarInitials>
+        )}
+        <PostHeaderText>
+          <PostAuthor>{post.author.fullName}</PostAuthor>
+          <PostTimestamp dateTime={createdAt.toISOString()}>{createdAt.toLocaleString(i18n.language)}</PostTimestamp>
+        </PostHeaderText>
+        {canManage && (
+          <div style={{ position: "relative", marginLeft: "auto" }}>
+            <PostMenuButton
+              type="button"
+              aria-label={t("dashboard.posts.options")}
+              aria-expanded={isMenuOpen}
+              onMouseDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+                setIsMenuOpen((isOpen) => !isOpen);
+              }}
+            >
+              <DotsThreeOutline size={24} weight="fill" />
+            </PostMenuButton>
+            <PostActionMenu
+              isOpen={isMenuOpen}
+              onClose={() => setIsMenuOpen(false)}
+              onEdit={startEdit}
+              onDelete={() => {
+                setIsMenuOpen(false);
+                setIsDeleteOpen(true);
+              }}
+            />
+          </div>
+        )}
+      </PostHeader>
+
+      <PostBody>
+        {isEditing ? (
+          <>
+            <EditTextArea value={editText} onChange={(event) => setEditText(event.target.value)} autoFocus />
+            <EditActions>
+              <EditButton type="button" onClick={closeEdit}>
+                {t("dashboard.posts.cancel")}
+              </EditButton>
+              <EditButton type="button" $primary disabled={!editText.trim() || updatePost.isPending} onClick={saveEdit}>
+                {t("dashboard.posts.save")}
+              </EditButton>
+            </EditActions>
+          </>
+        ) : (
+          <PostText>{displayText}</PostText>
+        )}
+
+        {post.linkedOpportunities.length > 0 && (
+          <OpportunityList>
+            {post.linkedOpportunities.map((opportunity) => (
+              <OpportunityChip
+                as={Link}
+                key={opportunity.id}
+                href={`/${lang}/dashboard/opportunities/${opportunity.id}`}
+              >
+                {opportunity.title}
+              </OpportunityChip>
+            ))}
+          </OpportunityList>
+        )}
+      </PostBody>
+
+      {isDeleteOpen && (
+        <ConfirmationDialog
+          title={t("dashboard.posts.deleteDialog.title")}
+          message={t("dashboard.posts.deleteDialog.message")}
+          confirmText={t("dashboard.posts.delete")}
+          cancelText={t("dashboard.posts.cancel")}
+          onCancel={() => setIsDeleteOpen(false)}
+          onConfirm={() => deletePost.mutate()}
+          compact
+        />
+      )}
+    </FeedPost>
+  );
+}
+
+export default PostCard;

--- a/src/components/Dashboard/Posts/PostFeed.tsx
+++ b/src/components/Dashboard/Posts/PostFeed.tsx
@@ -1,19 +1,11 @@
 import { Paragraph } from "@/components/styled/text";
 import { usePostsFeed } from "@/hooks";
-import type { ApiPostGet } from "need4deed-sdk";
 import { useParams } from "next/navigation";
 import { useCallback, useLayoutEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
-import {
-  EmptyState,
-  FeedPost,
-  FeedScrollContainer,
-  LoadOlderIndicator,
-  PostAuthor,
-  PostHeader,
-  PostTimestamp,
-} from "./styles";
+import { EmptyState, FeedScrollContainer, LoadOlderIndicator } from "./styles";
+import PostCard from "./PostCard";
 
 const LOAD_OLDER_THRESHOLD = 80;
 
@@ -22,22 +14,8 @@ interface ScrollMetrics {
   top: number;
 }
 
-function renderPost(post: ApiPostGet, locale: string) {
-  const createdAt = new Date(post.createdAt);
-
-  return (
-    <FeedPost key={post.id}>
-      <PostHeader>
-        <PostAuthor>{post.author.fullName}</PostAuthor>
-        <PostTimestamp dateTime={createdAt.toISOString()}>{createdAt.toLocaleString(locale)}</PostTimestamp>
-      </PostHeader>
-      <Paragraph $textWrap="pretty">{post.text}</Paragraph>
-    </FeedPost>
-  );
-}
-
 export function PostFeed() {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const { lang } = useParams<{ lang: string }>();
   const feedRef = useRef<HTMLDivElement>(null);
   const didScrollToNewest = useRef(false);
@@ -138,7 +116,9 @@ export function PostFeed() {
           {isError ? t("message.errorGeneric") : isFetchingNextPage ? "…" : null}
         </LoadOlderIndicator>
       )}
-      {posts.map((post) => renderPost(post, i18n.language))}
+      {posts.map((post) => (
+        <PostCard key={post.id} post={post} />
+      ))}
     </FeedScrollContainer>
   );
 }

--- a/src/components/Dashboard/Posts/Posts.tsx
+++ b/src/components/Dashboard/Posts/Posts.tsx
@@ -1,31 +1,15 @@
 "use client";
 
-import { useTranslation } from "react-i18next";
-
-import { Button } from "@/components/core/button";
-import { EditableField } from "@/components/EditableField/EditableField";
 import { DashboardLayout } from "@/components/Layout";
 
 import PostFeed from "./PostFeed";
-import { NewPostSection, PostsContainer } from "./styles";
+import { PostsContainer } from "./styles";
 
 export function Posts() {
-  const { t } = useTranslation();
-
   return (
     <DashboardLayout>
       <PostsContainer>
         <PostFeed />
-        <NewPostSection>
-          <EditableField
-            placeholder={t("dashboard.posts.inputPlaceholder")}
-            mode="edit"
-            type="textarea"
-            value=""
-            setValue={() => {}}
-          />
-          <Button text={t("dashboard.posts.send")} onClick={() => {}} height="" disabled />
-        </NewPostSection>
       </PostsContainer>
     </DashboardLayout>
   );

--- a/src/components/Dashboard/Posts/styles.ts
+++ b/src/components/Dashboard/Posts/styles.ts
@@ -1,12 +1,5 @@
 import styled from "styled-components";
 
-export const NewPostSection = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-4);
-  flex-shrink: 0;
-`;
-
 export const PostsContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -66,23 +59,23 @@ export const LoadOlderIndicator = styled.div`
 export const FeedPost = styled.article`
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-8);
-  padding: var(--spacing-16);
+  gap: var(--spacing-16);
+  padding: var(--spacing-20);
   border: 1px solid var(--color-grey-200);
   border-radius: var(--card-border-radius);
   background-color: var(--color-white);
+  box-shadow: 0 4px 16px rgba(38, 23, 44, 0.06);
 `;
 
 export const PostHeader = styled.header`
   display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--spacing-8);
+  align-items: center;
+  gap: var(--spacing-12);
 `;
 
 export const PostAuthor = styled.strong`
   color: var(--color-midnight);
+  font-size: var(--font-size-lg);
 `;
 
 export const PostTimestamp = styled.time`
@@ -90,9 +83,163 @@ export const PostTimestamp = styled.time`
   font-size: var(--font-size-sm);
 `;
 
-export const InputRow = styled.div`
+export const Avatar = styled.img`
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
+  border-radius: 50%;
+  object-fit: cover;
+`;
+
+export const AvatarInitials = styled.div`
+  display: grid;
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--color-pink-50);
+  color: var(--color-aubergine);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+`;
+
+export const PostHeaderText = styled.div`
   display: flex;
-  flex-direction: row;
-  align-items: flex-end;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--spacing-4);
+`;
+
+export const PostBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-12);
+  padding-left: 56px;
+
+  @media (max-width: 767px) {
+    padding-left: 0;
+  }
+`;
+
+export const PostText = styled.p`
+  margin: 0;
+  color: var(--color-midnight);
+  font-size: var(--text-p-font-size);
+  line-height: var(--text-p-line-height);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+
+  .tag {
+    color: var(--color-aubergine);
+  }
+`;
+
+export const PostMenuButton = styled.button`
+  display: grid;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--color-midnight);
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    background: var(--color-pink-50);
+  }
+`;
+
+export const ActionMenu = styled.div`
+  position: absolute;
+  z-index: 10;
+  top: calc(100% + var(--spacing-4));
+  right: 0;
+  display: flex;
+  width: 180px;
+  flex-direction: column;
+  padding: var(--spacing-8) 0;
+  border: 1px solid var(--color-grey-200);
+  border-radius: var(--border-radius-small);
+  background: var(--color-white);
+  box-shadow: 0 10px 30px -12px rgba(143, 81, 138, 0.35);
+`;
+
+export const ActionMenuItem = styled.button<{ $danger?: boolean }>`
+  padding: var(--spacing-12) var(--spacing-16);
+  border: 0;
+  background: transparent;
+  color: ${({ $danger }) => ($danger ? "var(--color-red-600)" : "var(--color-midnight)")};
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    background: var(--color-pink-50);
+  }
+`;
+
+export const OpportunityList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
   gap: var(--spacing-8);
+`;
+
+export const OpportunityChip = styled.a`
+  display: inline-flex;
+  max-width: 100%;
+  padding: var(--spacing-8) var(--spacing-12);
+  border-radius: 999px;
+  background: var(--color-pink-50);
+  color: var(--color-aubergine);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  text-decoration: none;
+
+  &:hover,
+  &:focus-visible {
+    text-decoration: underline;
+  }
+`;
+
+export const EditTextArea = styled.textarea`
+  width: 100%;
+  min-height: 120px;
+  padding: var(--spacing-12);
+  border: 1px solid var(--color-grey-200);
+  border-radius: var(--border-radius-small);
+  color: var(--color-midnight);
+  font: inherit;
+  line-height: var(--text-p-line-height);
+  resize: vertical;
+
+  &:focus {
+    border-color: var(--color-aubergine);
+    outline: none;
+  }
+`;
+
+export const EditActions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-8);
+`;
+
+export const EditButton = styled.button<{ $primary?: boolean }>`
+  padding: var(--spacing-8) var(--spacing-16);
+  border: 1px solid var(--color-aubergine);
+  border-radius: var(--button-border-radius);
+  background: ${({ $primary }) => ($primary ? "var(--color-aubergine)" : "transparent")};
+  color: ${({ $primary }) => ($primary ? "var(--color-white)" : "var(--color-aubergine)")};
+  font: inherit;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
 `;

--- a/src/components/Dashboard/Posts/styles.ts
+++ b/src/components/Dashboard/Posts/styles.ts
@@ -153,6 +153,11 @@ export const PostMenuButton = styled.button`
   }
 `;
 
+export const PostMenuWrapper = styled.div`
+  position: relative;
+  margin-left: auto;
+`;
+
 export const ActionMenu = styled.div`
   position: absolute;
   z-index: 10;

--- a/src/components/Dashboard/Profile/sections/shared/ConfirmationDialog.tsx
+++ b/src/components/Dashboard/Profile/sections/shared/ConfirmationDialog.tsx
@@ -12,6 +12,8 @@ type Props = {
   onCancel: () => void;
   onConfirm: () => void;
   compact?: boolean;
+  cancelDisabled?: boolean;
+  confirmDisabled?: boolean;
 };
 
 const Title = styled.h3`
@@ -47,11 +49,13 @@ export function ConfirmationDialog({
   onCancel,
   onConfirm,
   compact = false,
+  cancelDisabled = false,
+  confirmDisabled = false,
 }: Props) {
   const { t } = useTranslation();
 
   return (
-    <Modal isOpen onClose={onCancel}>
+    <Modal isOpen onClose={cancelDisabled ? () => undefined : onCancel}>
       <div
         data-testid="confirmation-dialog"
         style={{ display: "flex", flexDirection: "column", gap: "var(--spacing-24)" }}
@@ -62,6 +66,7 @@ export function ConfirmationDialog({
           <Button
             text={cancelText || t("dashboard.communicationSection.cancel", "Cancel")}
             onClick={onCancel}
+            disabled={cancelDisabled}
             backgroundcolor="transparent"
             textColor="var(--color-aubergine)"
             border="var(--border-width-medium) solid var(--color-aubergine)"
@@ -72,6 +77,7 @@ export function ConfirmationDialog({
           <Button
             text={confirmText || t("dashboard.communicationSection.delete", "Delete")}
             onClick={onConfirm}
+            disabled={confirmDisabled}
             backgroundcolor="var(--color-aubergine)"
             textColor="var(--color-white)"
             height={compact ? "40px" : undefined}

--- a/src/hooks/usePosts.ts
+++ b/src/hooks/usePosts.ts
@@ -1,7 +1,8 @@
 import { apiPathPost } from "@/config/constants";
 import { fetchData } from "@/hooks/useGetQuery";
+import { useMutationQuery } from "@/hooks/useMutationQuery";
 import { useInfiniteQuery } from "@tanstack/react-query";
-import type { ApiPostGet, Lang } from "need4deed-sdk";
+import type { ApiPostGet, ApiPostPatch, Lang } from "need4deed-sdk";
 import { useParams } from "next/navigation";
 
 export const POSTS_QUERY_KEY = ["posts"];
@@ -23,5 +24,25 @@ export function usePostsFeed() {
       const loadedPostCount = pages.reduce((count, page) => count + page.data.length, 0);
       return loadedPostCount < lastPage.count ? pages.length + 1 : undefined;
     },
+  });
+}
+
+export function useUpdatePost(postId: number, onSuccess: () => void) {
+  return useMutationQuery<ApiPostPatch, unknown>({
+    apiPath: `${apiPathPost}/${postId}`,
+    method: "patch",
+    queryKeyToInvalidate: POSTS_QUERY_KEY,
+    successMessage: "dashboard.posts.updated",
+    onSuccessCallback: onSuccess,
+  });
+}
+
+export function useDeletePost(postId: number, onSuccess: () => void) {
+  return useMutationQuery<void, unknown>({
+    apiPath: `${apiPathPost}/${postId}`,
+    method: "delete",
+    queryKeyToInvalidate: POSTS_QUERY_KEY,
+    successMessage: "dashboard.posts.deleted",
+    onSuccessCallback: onSuccess,
   });
 }


### PR DESCRIPTION
## Description

Adds the complete post-card presentation and management controls for the Posts page. Posts now match the dashboard styling and clearly show their author, timestamp, mentions, and linked opportunities, while permitted users can edit or delete posts safely.

## Related Issues

Closes #963

## Changes

- Add styled post cards with author name, avatar or branded initials, and timestamp
- Render tagged people clearly inside post text
- Render linked opportunities as clickable chips leading to their profiles
- Add an author/admin/coordinator three-dot menu with Edit and Delete actions
- Add inline post editing using the existing PATCH endpoint
- Add a confirmation dialog before permanent deletion
- Remove the old disabled composer placeholder in preparation for #961
- Add English and German labels for the new controls

## Screenshots / Demos

<img width="640" alt="963-post-card-with-menu png" src="https://github.com/user-attachments/assets/6ef4fecd-12c8-4957-9149-29c4e2d213e2" />

<img width="640" alt="963-post-delete-confirmation png" src="https://github.com/user-attachments/assets/d094daca-9e10-4499-9598-f1197e89a9b8" />


## Checklist

- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes