### PR TITLE
feat: add public event details page (#941)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -26,16 +26,6 @@ const nextConfig: NextConfig = {
   compiler: {
     styledComponents: true,
   },
-  async redirects() {
-    const eventPageDestination =
-      "https://docs.google.com/forms/d/e/1FAIpQLSft1xi4NrQB_O6-OyOvVm_HcDSzQtog_3MMj2XAIVNaLKEJxA/viewform?usp=dialog";
-    return [
-      { source: "/event-page", destination: eventPageDestination, permanent: false },
-      { source: "/event-page/", destination: eventPageDestination, permanent: false },
-      { source: "/:lang/event-page", destination: eventPageDestination, permanent: false },
-      { source: "/:lang/event-page/", destination: eventPageDestination, permanent: false },
-    ];
-  },
   async rewrites() {
     return [{ source: `/${apiPrefix}/:path*`, destination: `${apiURL}/:path*` }];
   },

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -103,6 +103,15 @@
       }
     }
   },
+  "eventPage": {
+    "about": "Über diese Veranstaltung",
+    "details": "Veranstaltungsdetails",
+    "register": "Jetzt anmelden",
+    "registrationUnavailable": "Die Anmeldung ist noch nicht verfügbar.",
+    "loading": "Veranstaltung wird geladen…",
+    "empty": "Keine kommende Veranstaltung",
+    "emptyDescription": "Schau bald wieder vorbei, um unsere nächste Veranstaltung zu sehen."
+  },
   "form": {
     "error": {
       "required": "Dieses Feld ist erforderlich",

--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -109,6 +109,7 @@
     "register": "Jetzt anmelden",
     "registrationUnavailable": "Die Anmeldung ist noch nicht verfügbar.",
     "loading": "Veranstaltung wird geladen…",
+    "loadError": "Die Veranstaltung konnte nicht geladen werden. Bitte versuche es erneut.",
     "empty": "Keine kommende Veranstaltung",
     "emptyDescription": "Schau bald wieder vorbei, um unsere nächste Veranstaltung zu sehen."
   },

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -111,6 +111,7 @@
     "register": "Register now",
     "registrationUnavailable": "Registration is not available yet.",
     "loading": "Loading event…",
+    "loadError": "The event could not be loaded. Please try again.",
     "empty": "No upcoming event",
     "emptyDescription": "Please check back soon for our next event."
   },

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -105,6 +105,15 @@
       }
     }
   },
+  "eventPage": {
+    "about": "About this event",
+    "details": "Event details",
+    "register": "Register now",
+    "registrationUnavailable": "Registration is not available yet.",
+    "loading": "Loading event…",
+    "empty": "No upcoming event",
+    "emptyDescription": "Please check back soon for our next event."
+  },
   "form": {
     "error": {
       "required": "This field is required",

--- a/src/app/[lang]/event-page/page.tsx
+++ b/src/app/[lang]/event-page/page.tsx
@@ -1,0 +1,5 @@
+import EventPage from "@/components/EventPage";
+
+export default function PublicEventPage() {
+  return <EventPage />;
+}

--- a/src/components/Dashboard/Calendar/Calendar/EventCard.tsx
+++ b/src/components/Dashboard/Calendar/Calendar/EventCard.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 
 import { eventDateRange } from "@/utils/calendar";
+import { getHttpUrl } from "@/utils/events";
 
 interface Props {
   event: ApiEventN4DGetList;
@@ -88,16 +89,6 @@ export function EventCard({ event, variant = "card", onEdit, onDelete }: Props) 
       </Actions>
     </Card>
   );
-}
-
-function getHttpUrl(value?: string) {
-  if (!value) return null;
-  try {
-    const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : null;
-  } catch {
-    return null;
-  }
 }
 
 const Card = styled.article`

--- a/src/components/EventPage/EventPage.tsx
+++ b/src/components/EventPage/EventPage.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { Button } from "@/components/core/button";
+import { PageLayout } from "@/components/Layout";
+import { Heading1, Heading2, Paragraph } from "@/components/styled/text";
+import { useEvents } from "@/hooks/useEvents";
+import { formatEventDate, getHttpUrl, getUpcomingEvent } from "@/utils/events";
+import { CalendarBlankIcon, MapPinIcon } from "@phosphor-icons/react";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+
+const PageContent = styled.main`
+  width: min(100% - 32px, 960px);
+  margin: 0 auto;
+  padding: clamp(40px, 7vw, 88px) 0;
+`;
+
+const EventCard = styled.article`
+  overflow: hidden;
+  border: 1px solid var(--color-orchid-light, var(--color-orchid));
+  border-radius: 24px;
+  background: var(--color-white);
+  box-shadow: 0 16px 40px rgb(40 25 47 / 10%);
+`;
+
+const Hero = styled.header`
+  padding: clamp(28px, 6vw, 64px);
+  background: linear-gradient(135deg, var(--color-orchid-subtle), var(--color-orchid));
+`;
+
+const EventType = styled.span`
+  display: inline-flex;
+  margin-bottom: var(--spacing-20);
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: var(--color-midnight);
+  color: var(--color-white);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  text-transform: capitalize;
+`;
+
+const Subtitle = styled(Paragraph)`
+  margin-top: var(--spacing-12);
+`;
+
+const Body = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 300px);
+  gap: clamp(32px, 6vw, 72px);
+  padding: clamp(28px, 6vw, 64px);
+
+  @media (max-width: 767px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const Description = styled(Paragraph)`
+  margin-top: var(--spacing-20);
+  white-space: pre-line;
+`;
+
+const AdditionalInfo = styled.ul`
+  margin: var(--spacing-20) 0 0;
+  padding-left: 20px;
+  color: var(--color-midnight);
+`;
+
+const Details = styled.aside`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-20);
+`;
+
+const Detail = styled.div`
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  gap: var(--spacing-12);
+  align-items: start;
+  color: var(--color-midnight);
+`;
+
+const EmptyState = styled.div`
+  padding: clamp(40px, 8vw, 96px) 24px;
+  text-align: center;
+`;
+
+export function EventPage() {
+  const { t, i18n } = useTranslation();
+  const { data: events, isLoading } = useEvents();
+  const event = useMemo(() => getUpcomingEvent(events), [events]);
+  const registrationUrl = getHttpUrl(event?.linkRSVP);
+
+  return (
+    <PageLayout>
+      <PageContent>
+        {isLoading ? (
+          <EmptyState aria-live="polite">
+            <Heading2>{t("eventPage.loading")}</Heading2>
+          </EmptyState>
+        ) : event ? (
+          <EventCard>
+            <Hero>
+              <EventType>{event.type}</EventType>
+              <Heading1 margin={0}>{event.title}</Heading1>
+              {event.subTitle && <Subtitle fontSize="var(--font-size-lg)">{event.subTitle}</Subtitle>}
+            </Hero>
+
+            <Body>
+              <section>
+                <Heading2>{t("eventPage.about")}</Heading2>
+                <Description>{event.description}</Description>
+                {event.additionalInfo?.length ? (
+                  <>
+                    {event.additionalTitle && (
+                      <Heading2 margin="var(--spacing-32) 0 0">{event.additionalTitle}</Heading2>
+                    )}
+                    <AdditionalInfo>
+                      {event.additionalInfo.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </AdditionalInfo>
+                  </>
+                ) : null}
+              </section>
+
+              <Details aria-label={t("eventPage.details")}>
+                <Detail>
+                  <CalendarBlankIcon size={22} aria-hidden />
+                  <span>{formatEventDate(event, i18n.language)}</span>
+                </Detail>
+                <Detail>
+                  <MapPinIcon size={22} aria-hidden />
+                  <span>
+                    {event.address}
+                    {event.locationComment && (
+                      <>
+                        <br />
+                        {event.locationComment}
+                      </>
+                    )}
+                  </span>
+                </Detail>
+                {registrationUrl ? (
+                  <Button
+                    text={t("eventPage.register")}
+                    width="100%"
+                    onClick={() => window.open(registrationUrl, "_blank", "noopener,noreferrer")}
+                  />
+                ) : (
+                  <Paragraph>{t("eventPage.registrationUnavailable")}</Paragraph>
+                )}
+              </Details>
+            </Body>
+          </EventCard>
+        ) : (
+          <EmptyState aria-live="polite">
+            <Heading2>{t("eventPage.empty")}</Heading2>
+            <Paragraph margin="var(--spacing-12) 0 0">{t("eventPage.emptyDescription")}</Paragraph>
+          </EmptyState>
+        )}
+      </PageContent>
+    </PageLayout>
+  );
+}
+
+export default EventPage;

--- a/src/components/EventPage/EventPage.tsx
+++ b/src/components/EventPage/EventPage.tsx
@@ -6,6 +6,7 @@ import { Heading1, Heading2, Paragraph } from "@/components/styled/text";
 import { useEvents } from "@/hooks/useEvents";
 import { formatEventDate, getHttpUrl, getUpcomingEvent } from "@/utils/events";
 import { CalendarBlankIcon, MapPinIcon } from "@phosphor-icons/react";
+import { EventN4DType } from "need4deed-sdk";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
@@ -88,9 +89,13 @@ const EmptyState = styled.div`
 
 export function EventPage() {
   const { t, i18n } = useTranslation();
-  const { data: events, isLoading } = useEvents();
+  const { data: events, isError, isLoading } = useEvents();
   const event = useMemo(() => getUpcomingEvent(events), [events]);
   const registrationUrl = getHttpUrl(event?.linkRSVP);
+  const eventTypeLabel =
+    event?.type === EventN4DType.PARTY
+      ? t("dashboard.calendar.createForm.typeParty")
+      : t("dashboard.calendar.createForm.typeWorkshop");
 
   return (
     <PageLayout>
@@ -99,10 +104,14 @@ export function EventPage() {
           <EmptyState aria-live="polite">
             <Heading2>{t("eventPage.loading")}</Heading2>
           </EmptyState>
+        ) : isError ? (
+          <EmptyState role="alert">
+            <Heading2>{t("eventPage.loadError")}</Heading2>
+          </EmptyState>
         ) : event ? (
           <EventCard>
             <Hero>
-              <EventType>{event.type}</EventType>
+              <EventType>{eventTypeLabel}</EventType>
               <Heading1 margin={0}>{event.title}</Heading1>
               {event.subTitle && <Subtitle fontSize="var(--font-size-lg)">{event.subTitle}</Subtitle>}
             </Hero>
@@ -117,8 +126,8 @@ export function EventPage() {
                       <Heading2 margin="var(--spacing-32) 0 0">{event.additionalTitle}</Heading2>
                     )}
                     <AdditionalInfo>
-                      {event.additionalInfo.map((item) => (
-                        <li key={item}>{item}</li>
+                      {event.additionalInfo.map((item, index) => (
+                        <li key={index}>{item}</li>
                       ))}
                     </AdditionalInfo>
                   </>

--- a/src/components/EventPage/index.ts
+++ b/src/components/EventPage/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./EventPage";
+export * from "./EventPage";

--- a/src/components/EventsSection/EventsSection.tsx
+++ b/src/components/EventsSection/EventsSection.tsx
@@ -8,11 +8,11 @@ import { eventsPublicLandingUrl, ScreenTypes } from "@/config/constants";
 import { useScreenType } from "@/context/DeviceContext";
 import { useEvents } from "@/hooks/useEvents";
 import { getImageUrl } from "@/utils/helpers";
-import type { ApiEventN4DGetList } from "need4deed-sdk";
 import { EventN4DType } from "need4deed-sdk";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
+import { formatEventDate, getUpcomingEvent } from "@/utils/events";
 
 const EventsSectionContainer = styled(OverlayingSectionContainer)`
   height: var(--homepage-events-section-container-height);
@@ -77,24 +77,6 @@ const imageNamesMap: Record<EventN4DType, Record<ScreenTypes, string>> = {
   },
 };
 
-function getUpcomingEvent(events?: ApiEventN4DGetList[]) {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-
-  return events
-    ?.filter((event) => event.active && new Date(event.dateEnd ?? event.date) >= today)
-    .sort((first, second) => new Date(first.date).getTime() - new Date(second.date).getTime())[0];
-}
-
-function formatEventDate(event: ApiEventN4DGetList, locale: string) {
-  const format = new Intl.DateTimeFormat(locale, { day: "numeric", month: "long", year: "numeric" });
-  const start = format.format(new Date(event.date));
-  if (!event.dateEnd) return start;
-
-  const end = format.format(new Date(event.dateEnd));
-  return start === end ? start : `${start} – ${end}`;
-}
-
 export function EventsSection() {
   const { t, i18n } = useTranslation();
   const screenType = useScreenType();
@@ -157,7 +139,7 @@ export function EventsSection() {
               <ButtonContainer>
                 <Button
                   text={t("homepage.events.button")}
-                  onClick={() => window.location.assign(eventsPublicLandingUrl)}
+                  onClick={() => window.location.assign(`/${i18n.language}${eventsPublicLandingUrl}`)}
                 />
               </ButtonContainer>
             )}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -64,7 +64,7 @@ export function Header({
       t("homepage.heroSection.menuItems.volunteeringOpportunities"),
       isAgent ? opportunityCardsPublicUrl : `${DashboardRoutes.Opportunities}?view=cards`,
     ],
-    [t("homepage.heroSection.menuItems.events"), eventsPublicLandingUrl],
+    [t("homepage.heroSection.menuItems.events"), `/${i18n.language}${eventsPublicLandingUrl}`],
   ];
 
   return (

--- a/src/components/Header/MenuitemList.tsx
+++ b/src/components/Header/MenuitemList.tsx
@@ -2,7 +2,6 @@ import Link from "next/link";
 
 import MenuItem from "./MenuItem";
 import { MenuItemType } from "@/types";
-import { eventsPublicLandingUrl } from "@/config/constants";
 
 interface Props {
   items: MenuItemType[];
@@ -13,12 +12,7 @@ export default function MenuitemList({ items, menuItemColor }: Props) {
   return (
     <>
       {items.map(([label, linkUrl]) => (
-        <Link
-          href={linkUrl}
-          key={label}
-          target={linkUrl === eventsPublicLandingUrl ? "_blank" : "_self"}
-          rel={linkUrl === eventsPublicLandingUrl ? "noopener noreferrer" : undefined}
-        >
+        <Link href={linkUrl} key={label}>
           <MenuItem text={label} color={menuItemColor} />
         </Link>
       ))}

--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -71,13 +71,14 @@ axios.interceptors.response.use(
       clearAuthHint();
 
       // Only redirect if we aren't already on a public auth-flow/form entry page
-      // (login, or a standalone form like forms/volunteer or register/agent) —
+      // (login, a standalone form, or the public event page) —
       // those pages shouldn't be hijacked by a stale/expired session.
       if (
         !(
           window.location.pathname.includes("login") ||
           window.location.pathname.includes("forms") ||
-          window.location.pathname.includes("register")
+          window.location.pathname.includes("register") ||
+          window.location.pathname.includes("event-page")
         )
       ) {
         toast.error("Session expired. Please log in again.");

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -52,7 +52,7 @@ export const phoneRegEx = /^([+]?[\s0-9]+)?(\d{3}|[(]?[0-9]+[)])?([-]?[\s]?[0-9]
 export const n4dLanguageLocalStorageKey = "n4d-language";
 
 export const eventsSectionContainerId = "events-section-container";
-export const eventsPublicLandingUrl = "https://www.need4deed.org/event-page";
+export const eventsPublicLandingUrl = "/event-page";
 export const opportunityCardsPublicUrl = "https://www.need4deed.org/opportunity-cards";
 
 export const cloudfrontURL = process.env.NEXT_PUBLIC_CLOUDFRONT_URL ?? "https://d2nwrdddg8skub.cloudfront.net/images";

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,0 +1,34 @@
+import type { ApiEventN4DGetList } from "need4deed-sdk";
+
+export function getUpcomingEvent(events?: ApiEventN4DGetList[]) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  return events
+    ?.filter((event) => event.active && new Date(event.dateEnd ?? event.date) >= today)
+    .sort((first, second) => new Date(first.date).getTime() - new Date(second.date).getTime())[0];
+}
+
+export function formatEventDate(event: ApiEventN4DGetList, locale: string) {
+  const format = new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+  const start = format.format(new Date(event.date));
+  if (!event.dateEnd) return start;
+
+  const end = format.format(new Date(event.dateEnd));
+  return start === end ? start : `${start} – ${end}`;
+}
+
+export function getHttpUrl(value?: string) {
+  if (!value) return undefined;
+
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Description

Adds a localized public event-details page inside the FE application. It reuses the same live event API and upcoming-event selection as the landing-page Events section, so event content created by coordinators is shown consistently without another hardcoded source.

## Related Issues

Closes #941

## Changes

- Add the public `/[lang]/event-page` route with title, description, date, address, additional information, and registration action
- Reuse shared upcoming-event selection and localized date formatting with the #917 landing banner
- Update header and landing-page Events links to navigate internally
- Remove the legacy redirect that sent `/event-page` directly to Google Forms
- Use each event's API-provided registration URL while keeping in-app registration outside this issue (#647)
- Add localized loading, empty, and event-page labels in English and German
- Keep the public route accessible when a stale authentication cookie is present

## Screenshots / Demos

<img width="640" alt="941-event-details-page" src="https://github.com/user-attachments/assets/797480a4-5dbe-4e1b-88a9-2f27506ca79e" />

<img width="640" alt="941-landing-events-banner" src="https://github.com/user-attachments/assets/7ce250ec-7032-4957-9c39-6d3ed0d8b64b" />


## Checklist

- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated — no automated test runner is configured; typecheck, lint, production build, and manual end-to-end event creation/navigation/deletion were verified
- [ ] Documentation updated — not required for this UI change
- [ ] CI passes — pending
