### PR TITLE
960: fixes filters that didn't deserialize

### DIFF
--- a/src/components/Dashboard/Volunteers/helpers.ts
+++ b/src/components/Dashboard/Volunteers/helpers.ts
@@ -188,15 +188,15 @@ export function deserializeVolunteerFilters(filter: VolunteerCardsFilter, search
 
   const queryEngagement = searchParams.getAll(QueryParamsKeys.ENGAGEMENT);
   queryEngagement.forEach((e) => {
-    if (newFilter.engagement[e] !== undefined) {
-      newFilter.engagement[e] = true;
+    if (newFilter.engagement[`vol-${e}`] !== undefined) {
+      newFilter.engagement[`vol-${e}`] = true;
     }
   });
 
   const queryStatusMatch = searchParams.getAll(VolunteerStatusMatch.MATCH);
   queryStatusMatch.forEach((e) => {
-    if (newFilter.match[e] !== undefined) {
-      newFilter.match[e] = true;
+    if (newFilter.match[`vol-${e}`] !== undefined) {
+      newFilter.match[`vol-${e}`] = true;
     }
   });
 


### PR DESCRIPTION
## Description
Original issue expresses error with all filters not deserializing but only present on `Volunteer` with `engagement` and `match` filters .

This is because both have unique enum values, such as `vol-matched` which was causing a condition check within the `deserializeVolunteerFilters` to return `false`.

Have added additional `"vol-"` to match its enum values, pass the condition and correctly deserialize.

Not generated with AI ;) 

## Related Issues
Closes #960 

## Changes
- Bullet list of meaningful changes (optional)

## Screenshots / Demos

https://github.com/user-attachments/assets/719225a0-2cb0-40ab-a126-461266f0d66f



## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

